### PR TITLE
dynamicMetadata preset

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -15,3 +15,5 @@ const registerORDCompileTarget = () => {
 };
 
 registerORDCompileTarget();
+
+cds.build?.register?.('ord', require('./lib/build'));  

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,0 +1,42 @@
+const cds = require("@sap/cds");
+const path = require("path");
+const { compile: openapi } = require("@cap-js/openapi");
+const { compile: asyncapi } = require("@cap-js/asyncapi");
+
+module.exports = class ORDBuildPlugin extends cds.build.BuildPlugin {
+
+  static taskDefaults = {
+    src: ".", dest: "srv/srv/ordResources",
+  };
+
+  async init() {
+    const model = await cds.load(this.task.src + "/srv");
+    const serviceNames = cds.reflect(model).services.map((service) => service.name);
+
+    if (serviceNames.length > 0) {
+      for (const serviceName of serviceNames) {
+        const srvDefinition = model.definitions[serviceName];
+        const options = { service: serviceName, as: "str", messages: [] };
+
+        // Generate OpenAPI if the service has entities or actions
+        if (Object.keys(srvDefinition.entities).length > 0 ||
+          Object.keys(srvDefinition.actions).length > 0) {
+          const result = openapi(model, options);
+          this._writeResult(result, serviceName, ".openapi.json");
+        }
+
+        // Generate AsyncAPI if the service has events
+        if (Object.keys(srvDefinition.events).length > 0) {
+          const result = asyncapi(model, options);
+          this._writeResult(result, serviceName, ".json");
+        }
+      }
+    }
+  }
+
+  _writeResult(content, serviceName, type) {
+    const fileName = serviceName + type;
+    const destPath = type === ".json" ? 'asyncapi' : 'openapi';
+    this.write(content).to(path.join(this.task.dest, destPath, fileName));
+  }
+};

--- a/lib/build.js
+++ b/lib/build.js
@@ -9,7 +9,7 @@ module.exports = class ORDBuildPlugin extends cds.build.BuildPlugin {
     src: ".", nodeDest: "srv/srv", javaDest: "srv/src/main/resources"
   };
 
-  async init() {
+  async build() {
     const model = await cds.load(this.task.src + "/srv");
     const serviceNames = cds.reflect(model).services.map((service) => service.name);
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -6,7 +6,7 @@ const { compile: asyncapi } = require("@cap-js/asyncapi");
 module.exports = class ORDBuildPlugin extends cds.build.BuildPlugin {
 
   static taskDefaults = {
-    src: ".", nodeDest: "srv/srv/resources", javaDest: "srv/src/main/resources"
+    src: ".", nodeDest: "srv/srv", javaDest: "srv/src/main/resources"
   };
 
   async init() {
@@ -22,22 +22,22 @@ module.exports = class ORDBuildPlugin extends cds.build.BuildPlugin {
         if (Object.keys(srvDefinition.entities).length > 0 ||
           Object.keys(srvDefinition.actions).length > 0) {
           const result = openapi(model, options);
-          this._writeResult(result, serviceName, ".openapi.json");
+          await this._writeResult(result, serviceName, ".openapi.json");
         }
 
         // Generate AsyncAPI if the service has events
         if (Object.keys(srvDefinition.events).length > 0) {
           const result = asyncapi(model, options);
-          this._writeResult(result, serviceName, ".json");
+          await this._writeResult(result, serviceName, ".json");
         }
       }
     }
   }
 
-  _writeResult(content, serviceName, type) {
+  async _writeResult(content, serviceName, type) {
     const fileName = serviceName + type;
     const destPath = cds.env["project-nature"] === "nodejs" ? this.task.nodeDest : this.task.javaDest;
     const folderPath = type === ".json" ? "asyncapi" : "openapi";
-    this.write(content).to(path.join(destPath, folderPath, fileName));
+    await this.write(content).to(path.join(destPath, folderPath, fileName));
   }
 };

--- a/lib/build.js
+++ b/lib/build.js
@@ -6,7 +6,7 @@ const { compile: asyncapi } = require("@cap-js/asyncapi");
 module.exports = class ORDBuildPlugin extends cds.build.BuildPlugin {
 
   static taskDefaults = {
-    src: ".", dest: "srv/srv/ordResources",
+    src: ".", nodeDest: "srv/srv/resources", javaDest: "srv/src/main/resources"
   };
 
   async init() {
@@ -36,7 +36,8 @@ module.exports = class ORDBuildPlugin extends cds.build.BuildPlugin {
 
   _writeResult(content, serviceName, type) {
     const fileName = serviceName + type;
-    const destPath = type === ".json" ? 'asyncapi' : 'openapi';
-    this.write(content).to(path.join(this.task.dest, destPath, fileName));
+    const destPath = cds.env["project-nature"] === "nodejs" ? this.task.nodeDest : this.task.javaDest;
+    const folderPath = type === ".json" ? "asyncapi" : "openapi";
+    this.write(content).to(path.join(destPath, folderPath, fileName));
   }
 };

--- a/lib/metaData.js
+++ b/lib/metaData.js
@@ -18,9 +18,9 @@ module.exports = async (data) => {
 
     const csn = cds.services[serviceName].model;
     const nodejsFilePathMap = {
-        "oas3": path.join(cds.root, 'gen/srv/srv/openapi', `${serviceName}.openapi.json`),
-        "asyncapi2": path.join(cds.root, 'gen/srv/srv/asyncapi', `${serviceName}.json`),
-        "edmx": path.join(cds.root, 'gen/srv/srv/odata/v4', `${serviceName}.xml`)
+        "oas3": path.join('/srv/openapi', `${serviceName}.openapi.json`),
+        "asyncapi2": path.join('/srv/asyncapi', `${serviceName}.json`),
+        "edmx": path.join('/srv/odata/v4', `${serviceName}.xml`)
     };
     const javaFilePathMap = {
         "oas3": path.join(cds.root, 'srv/src/main/resources/openapi', `${serviceName}.openapi.json`),

--- a/lib/metaData.js
+++ b/lib/metaData.js
@@ -1,4 +1,6 @@
 const cds = require('@sap/cds/lib');
+const fs = require('fs');
+const path = require('path');
 const { compile : openapi } = require('@cap-js/openapi')
 const { compile : asyncapi } = require('@cap-js/asyncapi');
 
@@ -8,38 +10,45 @@ const { compile : asyncapi } = require('@cap-js/asyncapi');
  * @returns {string, JSON|XML} contentType, response 
  */
 module.exports = async (data) => {
+    const dynamicMetadata = !cds.env.ord?.dynamicMetadata && !cds.env.profiles.includes('production');
     const parts = data?.split("/").pop().replace(/\.json$/, '').split(".");
     const compilerType = parts.pop();
     const serviceName = parts.join(".");
+
     const csn = cds.services[serviceName].model;
-
-    let responseFile; 
-    const options = { service: serviceName, as: 'str', messages: [] }
-    if (compilerType === "oas3") {
-        try {
-            responseFile = openapi(csn, options);
-        } catch (error) {
-            console.error("OpenApi error:", error.message);
-            throw error;
-        }
-    } else if (compilerType === "asyncapi2") {
-        try {
-            responseFile = asyncapi(csn, options);
-        } catch (error) {
-            console.error("AsyncApi error:", error.message);
-            throw error;
-        }
-    } else if (compilerType === "edmx") {
-        try {
-            responseFile = await cds.compile(csn).to["edmx"](options);
-        } catch (error) {
-            console.error("Edmx error:", error.message);
-            throw error;
-        }
-    }
-
-    return {
-        contentType: `application/${compilerType === "edmx" ? "xml" : "json"}`,
-        response: responseFile
+    const filePathMap = {
+        "oas3": path.join(cds.root, 'gen/srv/srv/ordResources/openapi', `${serviceName}.openapi.json`),
+        "asyncapi2": path.join(cds.root, 'gen/srv/srv/ordResources/asyncapi', `${serviceName}.json`),
+        "edmx": path.join(cds.root, 'gen/srv/srv/odata/v4', `${serviceName}.xml`)
     };
-}
+
+    try {
+        if (dynamicMetadata) {
+            return {
+                contentType: `application/${compilerType === "edmx" ? "xml" : "json"}`,
+                response: fs.readFileSync(filePathMap[compilerType])
+            };
+        } else {
+            const options = { service: serviceName, as: 'str', messages: [] };
+            let responseFile;
+            switch (compilerType) {
+                case "oas3":
+                    responseFile = await openapi(csn, options);
+                    break;
+                case "asyncapi2":
+                    responseFile = await asyncapi(csn, options);
+                    break;
+                case "edmx":
+                    responseFile = await cds.compile(csn).to["edmx"](options);
+                    break;
+            }
+            return {
+                contentType: `application/${compilerType === "edmx" ? "xml" : "json"}`,
+                response: responseFile
+            };
+        }
+    } catch (error) {
+        console.error(`${compilerType} error:`, error.message);
+        throw error;
+    }
+};

--- a/lib/metaData.js
+++ b/lib/metaData.js
@@ -10,15 +10,16 @@ const { compile : asyncapi } = require('@cap-js/asyncapi');
  * @returns {string, JSON|XML} contentType, response 
  */
 module.exports = async (data) => {
-    const dynamicMetadata = (cds.env.ord?.dynamicMetadata && cds.env.profiles.includes('production')) || false;
+    const production = cds.env.profiles.includes('production');
+    const dynamicMetadata = production ? cds.env.ord?.dynamicMetadata : true;
     const parts = data?.split("/").pop().replace(/\.json$/, '').split(".");
     const compilerType = parts.pop();
     const serviceName = parts.join(".");
 
     const csn = cds.services[serviceName].model;
     const nodejsFilePathMap = {
-        "oas3": path.join(cds.root, 'gen/srv/srv/resources/openapi', `${serviceName}.openapi.json`),
-        "asyncapi2": path.join(cds.root, 'gen/srv/srv/resources/asyncapi', `${serviceName}.json`),
+        "oas3": path.join(cds.root, 'gen/srv/srv/openapi', `${serviceName}.openapi.json`),
+        "asyncapi2": path.join(cds.root, 'gen/srv/srv/asyncapi', `${serviceName}.json`),
         "edmx": path.join(cds.root, 'gen/srv/srv/odata/v4', `${serviceName}.xml`)
     };
     const javaFilePathMap = {

--- a/lib/metaData.js
+++ b/lib/metaData.js
@@ -10,25 +10,25 @@ const { compile : asyncapi } = require('@cap-js/asyncapi');
  * @returns {string, JSON|XML} contentType, response 
  */
 module.exports = async (data) => {
-    const dynamicMetadata = !cds.env.ord?.dynamicMetadata && !cds.env.profiles.includes('production');
+    const dynamicMetadata = (cds.env.ord?.dynamicMetadata && cds.env.profiles.includes('production')) || false;
     const parts = data?.split("/").pop().replace(/\.json$/, '').split(".");
     const compilerType = parts.pop();
     const serviceName = parts.join(".");
 
     const csn = cds.services[serviceName].model;
-    const filePathMap = {
-        "oas3": path.join(cds.root, 'gen/srv/srv/ordResources/openapi', `${serviceName}.openapi.json`),
-        "asyncapi2": path.join(cds.root, 'gen/srv/srv/ordResources/asyncapi', `${serviceName}.json`),
+    const nodejsFilePathMap = {
+        "oas3": path.join(cds.root, 'gen/srv/srv/resources/openapi', `${serviceName}.openapi.json`),
+        "asyncapi2": path.join(cds.root, 'gen/srv/srv/resources/asyncapi', `${serviceName}.json`),
         "edmx": path.join(cds.root, 'gen/srv/srv/odata/v4', `${serviceName}.xml`)
+    };
+    const javaFilePathMap = {
+        "oas3": path.join(cds.root, 'srv/src/main/resources/openapi', `${serviceName}.openapi.json`),
+        "asyncapi2": path.join(cds.root, 'srv/src/main/resources/asyncapi', `${serviceName}.json`),
+        "edmx": path.join(cds.root, 'srv/src/main/resources/edmx/odata/v4', `${serviceName}.xml`)
     };
 
     try {
         if (dynamicMetadata) {
-            return {
-                contentType: `application/${compilerType === "edmx" ? "xml" : "json"}`,
-                response: fs.readFileSync(filePathMap[compilerType])
-            };
-        } else {
             const options = { service: serviceName, as: 'str', messages: [] };
             let responseFile;
             switch (compilerType) {
@@ -46,6 +46,13 @@ module.exports = async (data) => {
                 contentType: `application/${compilerType === "edmx" ? "xml" : "json"}`,
                 response: responseFile
             };
+        } else {
+            return {
+                contentType: `application/${compilerType === "edmx" ? "xml" : "json"}`,
+                response: fs.readFileSync(cds.env["project-nature"] === "nodejs"
+                    ? nodejsFilePathMap[compilerType] : javaFilePathMap[compilerType]),
+            };
+
         }
     } catch (error) {
         console.error(`${compilerType} error:`, error.message);

--- a/lib/metaData.js
+++ b/lib/metaData.js
@@ -18,9 +18,9 @@ module.exports = async (data) => {
 
     const csn = cds.services[serviceName].model;
     const nodejsFilePathMap = {
-        "oas3": path.join('/srv/openapi', `${serviceName}.openapi.json`),
-        "asyncapi2": path.join('/srv/asyncapi', `${serviceName}.json`),
-        "edmx": path.join('/srv/odata/v4', `${serviceName}.xml`)
+        "oas3": path.join(cds.root, '/srv/openapi', `${serviceName}.openapi.json`),
+        "asyncapi2": path.join(cds.root, '/srv/asyncapi', `${serviceName}.json`),
+        "edmx": path.join(cds.root, '/srv/odata/v4', `${serviceName}.xml`)
     };
     const javaFilePathMap = {
         "oas3": path.join(cds.root, 'srv/src/main/resources/openapi', `${serviceName}.openapi.json`),

--- a/package.json
+++ b/package.json
@@ -19,5 +19,10 @@
     "@sap/cds": ">=7.6",
     "@cap-js/asyncapi": "^1.0.0",
     "@cap-js/openapi": "^1.0.2"
+  },
+  "cds": {
+    "[production]": {
+      "ord": { "dynamicMetadata": false }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "files": [
     "lib",
     "data",
-    "LICENSES"
+    "LICENSES",
+    "cds-plugin.js"
   ],
   "scripts": {
     "lint": "npx eslint ."

--- a/xmpl/.cdsrc.json
+++ b/xmpl/.cdsrc.json
@@ -13,7 +13,6 @@
     "ord": {
         "namespace": "sap.sample",
         "description": "this is my custom description",
-        "policyLevel": "sap:core:v1",
-        "dynamicMetadata": false
+        "policyLevel": "sap:core:v1"
     }
 }

--- a/xmpl/.cdsrc.json
+++ b/xmpl/.cdsrc.json
@@ -13,6 +13,7 @@
     "ord": {
         "namespace": "sap.sample",
         "description": "this is my custom description",
-        "policyLevel": "sap:core:v1"
+        "policyLevel": "sap:core:v1",
+        "dynamicMetadata": false
     }
 }


### PR DESCRIPTION
- `dynamicMetadata: true` can be set only for production.
- By default it is false.
- Supported for Node.js and Java.

To test:
- Run `cds build --production`
- gen/srv contains metadata files
- With `dynamicMetadata` set by default or to false, deploy application
- Static files are read when metadata endpoints are hit