### PR TITLE
[JIRA: CDSADAPTERS-1928] Use cds.root to resolve package.json path

### DIFF
--- a/lib/ORD.js
+++ b/lib/ORD.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const { exists } = cds.utils;
 const defaults = require("./defaults");
 const {
     fCreateGroupsTemplate,
@@ -15,8 +16,13 @@ const {
  * @returns {Object} An object containing global vaiables.
  */
 const fInitializeGlobal = (csn) => {
-    const packageJsonPath = path.resolve(process.cwd(), "package.json");
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    let packagejsonPath = path.join(cds.root,'package.json')
+    let packageJson;
+    if (exists(packagejsonPath)) {
+        packageJson = require(packagejsonPath);
+    } else {
+        throw new Error(`package.json not found in the project root directory`);
+    }
 
     const appName = packageJson.name.replace(/\s/g, "-");
 


### PR DESCRIPTION
JIRA: https://jira.tools.sap/browse/CDSADAPTERS-1928

This PR includes minor changes to reuse the in-built functionality of cds to resolve package.json path.