### PR TITLE
feat: Use package name for product ORD IDs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -4,8 +4,9 @@ const regexWithRemoval = (name) => {
     return name.replace(/[^a-zA-Z0-9]/g,'');
   }
 }
-const regexWithUnderScore = (name) => {
-  return regexWithRemoval(name.charAt(0)) + name.slice(1, name.length).replace(/[^a-zA-Z0-9]/g,'_');
+
+const nameWithDot = (name) => {
+  return regexWithRemoval(name.charAt(0)) + name.slice(1, name.length).replace(/[^a-zA-Z0-9]/g,'.');
 }
 
 /**
@@ -18,7 +19,7 @@ module.exports = {
   description: "this is an application description",
   products: (name) => [
     { 
-      ordId: `customer:product:${regexWithUnderScore(name)}:`,
+      ordId: `customer:product:${nameWithDot(name)}:`,
       title: `ORD App Title for ${regexWithRemoval(name)}`,
       shortDescription: " shortDescription for products",
       vendor: "customer:vendor:SAPCustomer:",
@@ -33,7 +34,7 @@ module.exports = {
         shortDescription: "Here is the shortDescription for packages",
         description: "Here is the description for packages",
         version: "1.0.0",
-        partOfProducts: [`customer:product:${regexWithUnderScore(name)}:`],
+        partOfProducts: [`customer:product:${nameWithDot(name)}:`],
         vendor: "customer:vendor:SAP:"
       };
     }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -22,7 +22,7 @@ module.exports = {
       ordId: `customer:product:${nameWithDot(name)}:`,
       title: `ORD App Title for ${regexWithRemoval(name)}`,
       shortDescription: " shortDescription for products",
-      vendor: "customer:vendor:SAPCustomer:",
+      vendor: "customer:vendor:customer:",
     },
   ],
   groupTypeId: "sap.cds:service", 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -9,6 +9,10 @@ const nameWithDot = (name) => {
   return regexWithRemoval(name.charAt(0)) + name.slice(1, name.length).replace(/[^a-zA-Z0-9]/g,'.');
 }
 
+const nameWithSpaces = (name) => {
+  return regexWithRemoval(name.charAt(0)) + name.slice(1, name.length).replace(/[^a-zA-Z0-9]/g,' ');
+}
+
 /**
  * Module containing default configuration for ORD Document.
  * @module defaults
@@ -20,8 +24,8 @@ module.exports = {
   products: (name) => [
     { 
       ordId: `customer:product:${nameWithDot(name)}:`,
-      title: `ORD App Title for ${regexWithRemoval(name)}`,
-      shortDescription: " shortDescription for products",
+      title: nameWithSpaces(name),
+      shortDescription: nameWithSpaces(name),
       vendor: "customer:vendor:customer:",
     },
   ],

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -23,6 +23,7 @@ const fInitializeGlobal = (csn) => {
     } else {
         throw new Error(`package.json not found in the project root directory`);
     }
+    const packageName = packageJson.name;
     const appName = packageJson.name.replace(/^[@]/, "").replace(/[@/]/g, "-");
     const aModelKeys = Object.keys(csn.definitions);
     const aEvents = [];
@@ -32,7 +33,7 @@ const fInitializeGlobal = (csn) => {
     const capNamespace = csn.namespace;
      // namespace variable value if present in cdsrc.json take it there or else from package.json
     //if cdsrc.json does not have applicationNamespace, then use just the namespace
-    const namespace = cds.env["ord"]?.namespace || `customer.${appName}`;
+    const namespace = cds.env["ord"]?.namespace || packageJson.name.replace(/@/,'').replace(/\//g,'');
     const applicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
     
     if (applicationNamespace && fGetNamespaceComponents(namespace) !== fGetNamespaceComponents(applicationNamespace)) {
@@ -68,7 +69,8 @@ const fInitializeGlobal = (csn) => {
         aServices,
         aODMEntity,
         namespace,
-        applicationNamespace
+        applicationNamespace,
+        packageName
     }
 }
 
@@ -99,7 +101,7 @@ const fGetDescription = (global) => global.env?.description || defaults.descript
  * @returns {Array<object>} The products array.
  * if global.namespace is defined in cdsrc.json, then use it, else use the appName from package.json
  */
-const fGetProducts = (global) => global.env?.products || defaults.products(global.namespace);
+const fGetProducts = (global) => global.env?.products || defaults.products(global.packageName);
 
 /**
  * Retrieves the groups that services belongs to.

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -33,7 +33,7 @@ const fInitializeGlobal = (csn) => {
     const capNamespace = csn.namespace;
      // namespace variable value if present in cdsrc.json take it there or else from package.json
     //if cdsrc.json does not have applicationNamespace, then use just the namespace
-    const namespace = cds.env["ord"]?.namespace || packageJson.name.replace(/@/,'').replace(/\//g,'');
+    const namespace = cds.env["ord"]?.namespace || packageName.replace(/@/,'').replace(/\//g,'');
     const applicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
     
     if (applicationNamespace && fGetNamespaceComponents(namespace) !== fGetNamespaceComponents(applicationNamespace)) {


### PR DESCRIPTION
Addressing 

- ORD namespace (used as prefix in several ORD IDs) = `package.name.replace(/@/,'').replace(/\//g,’')`, unless explicitly configured in cds.env.ord.namespace
- **Products:** 
    - "ordId": "customer:product:capire.bookstore:”→ i.e. `package.name.replace(/@/,'').replace(/\//g,'.')`
    - `"vendor": "customer:vendor:customer:”`
    - "title": “capire bookstore”→ i.e. `package.name.replace(/@/,'').replace(///g,'.')`
    - "shortDescription": “capire bookstore" → i.e. `package.name.replace(/@/,'').replace(///g,' ')`


from https://github.com/cap-js/ord/issues/38