### PR TITLE
fix: Set proper values for titles and descriptions

### DIFF
--- a/__tests__/__snapshots__/ord.test.js.snap
+++ b/__tests__/__snapshots__/ord.test.js.snap
@@ -6,7 +6,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   "apiResources": [
     {
       "apiProtocol": "odata-v4",
-      "description": "Here we have the description for AdminService",
+      "description": "AdminService",
       "entityTypeMappings": [
         {
           "entityTypeTargets": [],
@@ -46,14 +46,14 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
           "url": "/.well-known/open-resource-discovery/v1/api-metadata/AdminService.edmx",
         },
       ],
-      "shortDescription": "Here we have the shortDescription for AdminService",
-      "title": "The service is for AdminService",
+      "shortDescription": "AdminService",
+      "title": "AdminService",
       "version": "1.0.0",
       "visibility": "public",
     },
     {
       "apiProtocol": "odata-v4",
-      "description": "Here we have the description for CatalogService",
+      "description": "CatalogService",
       "entityTypeMappings": [
         {
           "entityTypeTargets": [],
@@ -93,8 +93,8 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
           "url": "/.well-known/open-resource-discovery/v1/api-metadata/CatalogService.edmx",
         },
       ],
-      "shortDescription": "Here we have the shortDescription for CatalogService",
-      "title": "The service is for CatalogService",
+      "shortDescription": "CatalogService",
+      "title": "CatalogService",
       "version": "1.0.0",
       "visibility": "public",
     },
@@ -104,12 +104,12 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
     {
       "groupId": "sap.cds:service:capjs.ord:undefined.AdminService",
       "groupTypeId": "sap.cds:service",
-      "title": "Admin Service Title",
+      "title": "Admin Service",
     },
     {
       "groupId": "sap.cds:service:capjs.ord:undefined.CatalogService",
       "groupTypeId": "sap.cds:service",
-      "title": "Catalog Service Title",
+      "title": "Catalog Service",
     },
   ],
   "openResourceDiscovery": "1.9",

--- a/__tests__/unittest/__snapshots__/templates.test.js.snap
+++ b/__tests__/unittest/__snapshots__/templates.test.js.snap
@@ -80,7 +80,7 @@ exports[`templates fCreateAPIResourceTemplate should create API resource templat
 
 exports[`templates fCreateEventResourceTemplate should create API resource template correctly 1`] = `
 {
-  "description": "This is an example event catalog that contains only a partial ODM testAppName V1 event",
+  "description": "CAP Event resource describing events / messages.",
   "extensible": {
     "supported": "no",
   },

--- a/__tests__/unittest/__snapshots__/templates.test.js.snap
+++ b/__tests__/unittest/__snapshots__/templates.test.js.snap
@@ -30,7 +30,7 @@ exports[`templates fCreateAPIResourceTemplate should create API resource templat
 [
   {
     "apiProtocol": "odata-v4",
-    "description": "Here we have the description for MyService",
+    "description": "MyService",
     "entityTypeMappings": [
       {
         "entityTypeTargets": undefined,
@@ -70,8 +70,8 @@ exports[`templates fCreateAPIResourceTemplate should create API resource templat
         "url": "/.well-known/open-resource-discovery/v1/api-metadata/MyService.edmx",
       },
     ],
-    "shortDescription": "Here we have the shortDescription for MyService",
-    "title": "The service is for MyService",
+    "shortDescription": "MyService",
+    "title": "MyService",
     "version": "1.0.0",
     "visibility": "public",
   },

--- a/__tests__/unittest/templates.test.js
+++ b/__tests__/unittest/templates.test.js
@@ -57,7 +57,7 @@ describe('templates', () => {
             const testResult = {
                 groupId: 'sap.cds:service:customer:undefined.testServiceName',
                 groupTypeId: 'sap.cds:service',
-                title: 'test Service Title'
+                title: 'test Service'
             };
             expect(templates.fCreateGroupsTemplateForService(testSrv, linkedModel, testGroupIds)).toEqual(testResult);
         });
@@ -80,7 +80,7 @@ describe('templates', () => {
                 groupId: 'sap.cds:service:customer:undefined.testEventName',
                 groupTypeId: 'sap.cds:service',
                 // TODO: space because of service name missing
-                title: ' Service Title'
+                title: ' Service'
             };
             expect(templates.fCreateGroupsTemplateForEvent(tesEvent, linkedModel, testGroupIds)).toEqual(testResult);
         });

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -35,7 +35,7 @@ module.exports = {
     function createPackage(name, tag) {
       return {
         ordId: `${regexWithRemoval(name)}:package:${capNamespace}${tag}`,
-        title: `sample title for ${regexWithRemoval(name)}`,
+        title: regexWithRemoval(name),
         shortDescription: "Here is the shortDescription for packages",
         description: "Here is the description for packages",
         version: "1.0.0",

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -281,7 +281,7 @@ const fCreateEventResourceTemplate = (srv, srvDefinition, global,packageIds) => 
     shortDescription: ordExtensions.shortDescription ?? "Example ODM Event",
     description:  ordExtensions.description ??
                   srvDefinition['@description'] ?? srvDefinition['@Core.Description'] ??
-                  `This is an example event catalog that contains only a partial ODM ${global.appName} V1 event`,
+                  "CAP Event resource describing events / messages.",
     version:  ordExtensions.version ?? "1.0.0",
     releaseStatus:  ordExtensions.releaseStatus ?? "beta",
     partOfPackage: _getPackageID(global.capNamespace,packageIds,'event'),

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -1,8 +1,11 @@
 const defaults = require("./defaults");
 const cds = require("@sap/cds");
 const fReplaceSpecialCharacters = (namespace) => {
-  return namespace.replace(/customer\.(.+)/, (match, group1) => 'customer.' + group1.replace(/[^a-zA-Z0-9]/g, ''))
-}
+  return namespace.replace(
+    /customer\.(.+)/,
+    (match, group1) => "customer." + group1.replace(/[^a-zA-Z0-9]/g, "")
+  );
+};
 
 /**
  * Reads the ORD (Open Resource Discovery) annotation from a given service definition object and returns them as an object.
@@ -65,107 +68,118 @@ const fCreateEntityTypeTemplate = (entity) => ({
 
 /**
  * This is a template function to form the group id.
- * 
+ *
  * @param {string} fullyQualifiedName The fully qualified name of the service or event.
  * @param {string} groupTypeId The group type id.
  * @returns {string} a group id.
  */
-function _getGroupID(fullyQualifiedName, groupTypeId = defaults.groupTypeId, isService = true) {
-    if (isService) {
-        return `${groupTypeId}:${fReplaceSpecialCharacters(global.namespace)}:${fullyQualifiedName}`;
-    } else {
-        return `${groupTypeId}:${fReplaceSpecialCharacters(global.namespace)}:` +
-                `${fullyQualifiedName.slice(0, fullyQualifiedName.lastIndexOf("."))}`;
-    }
+function _getGroupID(
+  fullyQualifiedName,
+  groupTypeId = defaults.groupTypeId,
+  isService = true
+) {
+  if (isService) {
+    return `${groupTypeId}:${fReplaceSpecialCharacters(
+      global.namespace
+    )}:${fullyQualifiedName}`;
+  } else {
+    return (
+      `${groupTypeId}:${fReplaceSpecialCharacters(global.namespace)}:` +
+      `${fullyQualifiedName.slice(0, fullyQualifiedName.lastIndexOf("."))}`
+    );
+  }
 }
-
 
 /**
  * This is a function to resolve the title of the service group.
- * 
+ *
  * @param {string} srv The name of the service.
  * @returns {string} The title of the service group.
  */
 function _getTitleFromServiceName(srv) {
-    let serviceName = srv.substring(srv.lastIndexOf(".") + 1);
-    let index = serviceName.indexOf("Service");
-    if (index >= 0) {
-        return `${serviceName.substring(0, index)} Service Title`;
-    } else {
-        return `${serviceName} Service Title`;
-    }
+  let serviceName = srv.substring(srv.lastIndexOf(".") + 1);
+  let index = serviceName.indexOf("Service");
+  if (index >= 0) {
+    return `${serviceName.substring(0, index)} Service`;
+  } else {
+    return `${serviceName} Service`;
+  }
 }
-
 
 /**
  * This is a template function to create group object of a service for groups array in ORD doc.
- * 
+ *
  * @param {string} srv The name of the service.
  * @param {object} srvDefinition The definition of the service
  * @param {Set} groupIds A set of group ids.
  * @returns {Object} A group object.
  */
 const fCreateGroupsTemplateForService = (srv, srvDefinition, groupIds) => {
-    const ordExtensions = fReadORDExtensions(srvDefinition);
+  const ordExtensions = fReadORDExtensions(srvDefinition);
 
-    let fullyQualifiedServiceName = srv;
-    if(!srv.includes(global.capNamespace)){
-      fullyQualifiedServiceName = global.capNamespace + "." + srv;
-    }
+  let fullyQualifiedServiceName = srv;
+  if (!srv.includes(global.capNamespace)) {
+    fullyQualifiedServiceName = global.capNamespace + "." + srv;
+  }
 
-    if (checkEntityFunctionAction(srvDefinition, global).length > 0) {
-      let groupId = _getGroupID(fullyQualifiedServiceName, defaults.groupTypeId);
-      if (groupIds.has(groupId)) {
-          return null;
-      } else {
-          groupIds.add(groupId);
-          return {
-              groupId: groupId,
-              groupTypeId: `${defaults.groupTypeId}`,
-              title: ordExtensions.title ?? _getTitleFromServiceName(srv)
-          };
-      }
+  if (checkEntityFunctionAction(srvDefinition, global).length > 0) {
+    let groupId = _getGroupID(fullyQualifiedServiceName, defaults.groupTypeId);
+    if (groupIds.has(groupId)) {
+      return null;
+    } else {
+      groupIds.add(groupId);
+      return {
+        groupId: groupId,
+        groupTypeId: `${defaults.groupTypeId}`,
+        title: ordExtensions.title ?? _getTitleFromServiceName(srv),
+      };
     }
-}
+  }
+};
 
 /**
- * 
- * @param {string} event The name of the event. 
+ *
+ * @param {string} event The name of the event.
  * @returns {string} The title of the event group.
  */
 function _getEventTitle(event) {
-    let serviceName = event.substring(0, event.lastIndexOf("."));
-    return _getTitleFromServiceName(serviceName);
+  let serviceName = event.substring(0, event.lastIndexOf("."));
+  return _getTitleFromServiceName(serviceName);
 }
 
 /**
  * This is a template function to create group object of an event for groups array in ORD doc.
- * 
+ *
  * @param {string} event The name of the event.
  * @param {object} eventDefinition The definition of the event.
  * @param {Set} groupIds A set of group ids.
  * @returns {Object} A group object.
  */
 const fCreateGroupsTemplateForEvent = (event, eventDefinition, groupIds) => {
-    const ordExtensions = fReadORDExtensions(eventDefinition);
+  const ordExtensions = fReadORDExtensions(eventDefinition);
 
-    let fullyQualifiedEventName = event;
-    if(!event.includes(global.capNamespace)){
-      fullyQualifiedEventName = global.capNamespace + "." + event;
-    }
+  let fullyQualifiedEventName = event;
+  if (!event.includes(global.capNamespace)) {
+    fullyQualifiedEventName = global.capNamespace + "." + event;
+  }
 
-    let groupId = _getGroupID(fullyQualifiedEventName, defaults.groupTypeId, global, false);
-    if (groupIds.has(groupId)) {
-        return null;
-    } else {
-        groupIds.add(groupId);
-        return {
-            groupId: groupId,
-            groupTypeId: `${defaults.groupTypeId}`,
-            title: ordExtensions.title ?? _getEventTitle(event)
-        };
-    }
-}
+  let groupId = _getGroupID(
+    fullyQualifiedEventName,
+    defaults.groupTypeId,
+    global,
+    false
+  );
+  if (groupIds.has(groupId)) {
+    return null;
+  } else {
+    groupIds.add(groupId);
+    return {
+      groupId: groupId,
+      groupTypeId: `${defaults.groupTypeId}`,
+      title: ordExtensions.title ?? _getEventTitle(event),
+    };
+  }
+};
 
 /**
  * This is a template function to create API Resource object for API Resource Array.
@@ -174,7 +188,7 @@ const fCreateGroupsTemplateForEvent = (event, eventDefinition, groupIds) => {
  * @param {object} srvDefinition The definition of the service
  * @returns {Array} An array of objects for the API Resources.
  */
-const fCreateAPIResourceTemplate = (srv, srvDefinition, global,packageIds) => {
+const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
   const ordExtensions = fReadORDExtensions(srvDefinition);
   const paths = fGeneratePaths(srv, srvDefinition);
   const apiResources = [];
@@ -206,27 +220,29 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global,packageIds) => {
       }
 
       let obj = {
-        ordId: `${fReplaceSpecialCharacters(global.namespace)}:apiResource:${srvName}:v1`,
+        ordId: `${fReplaceSpecialCharacters(
+          global.namespace
+        )}:apiResource:${srvName}:v1`,
         title:
           ordExtensions.title ??
           srvDefinition["@title"] ??
           srvDefinition["@Common.Label"] ??
-          `The service is for ${srv}`,
-        shortDescription:
-          ordExtensions.shortDescription ??
-          `Here we have the shortDescription for ${srv}`,
+          srv,
+        shortDescription: ordExtensions.shortDescription ?? srv,
         description:
           ordExtensions.description ??
           srvDefinition["@Core.Description"] ??
-          `Here we have the description for ${srv}`,
+          srv,
         version: ordExtensions.version ?? "1.0.0",
         visibility: ordExtensions.visibility ?? "public",
-        partOfPackage: _getPackageID(global.capNamespace,packageIds,'api'),
+        partOfPackage: _getPackageID(global.capNamespace, packageIds, "api"),
         partOfGroups: [_getGroupID(srvName, defaults.groupTypeId, global)],
         releaseStatus: ordExtensions.active ?? "active",
         partOfConsumptionBundles: [
           {
-            ordId: `${fReplaceSpecialCharacters(global.namespace)}:consumptionBundle:noAuth:v1`,
+            ordId: `${fReplaceSpecialCharacters(
+              global.namespace
+            )}:consumptionBundle:noAuth:v1`,
           },
         ],
         apiProtocol:
@@ -252,22 +268,35 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global,packageIds) => {
  * @param {object} srvDefinition The definition of the event.
  * @returns {Object} An object for the Event Resource.
  */
-const fCreateEventResourceTemplate = (srv, srvDefinition, global,packageIds) => {
+const fCreateEventResourceTemplate = (
+  srv,
+  srvDefinition,
+  global,
+  packageIds
+) => {
   const ordExtensions = fReadORDExtensions(srvDefinition);
   let srvName = srv;
-  if(!srvName.includes(global.capNamespace)){
+  if (!srvName.includes(global.capNamespace)) {
     srvName = global.capNamespace + "." + srv;
   }
   return {
-    ordId: `${fReplaceSpecialCharacters(global.namespace)}:eventResource:${srvName}:v1`,
-    title:  ordExtensions.title ?? srvDefinition['@title'] ?? srvDefinition['@Common.Label'] ?? `ODM ${global.appName.replace(/[^a-zA-Z0-9]/g, '')} Events`,
+    ordId: `${fReplaceSpecialCharacters(
+      global.namespace
+    )}:eventResource:${srvName}:v1`,
+    title:
+      ordExtensions.title ??
+      srvDefinition["@title"] ??
+      srvDefinition["@Common.Label"] ??
+      `ODM ${global.appName.replace(/[^a-zA-Z0-9]/g, "")} Events`,
     shortDescription: ordExtensions.shortDescription ?? "Example ODM Event",
-    description:  ordExtensions.description ?? 
-                  srvDefinition['@description'] ?? srvDefinition['@Core.Description'] ??
-                  `This is an example event catalog that contains only a partial ODM ${global.appName} V1 event`,
-    version:  ordExtensions.version ?? "1.0.0",
-    releaseStatus:  ordExtensions.releaseStatus ?? "beta",
-    partOfPackage: _getPackageID(global.capNamespace,packageIds,'event'),
+    description:
+      ordExtensions.description ??
+      srvDefinition["@description"] ??
+      srvDefinition["@Core.Description"] ??
+      `This is an example event catalog that contains only a partial ODM ${global.appName} V1 event`,
+    version: ordExtensions.version ?? "1.0.0",
+    releaseStatus: ordExtensions.releaseStatus ?? "beta",
+    partOfPackage: _getPackageID(global.capNamespace, packageIds, "event"),
     partOfGroups: [_getGroupID(srvName, defaults.groupTypeId, global, false)],
     visibility: ordExtensions.visibility ?? "public",
     resourceDefinitions: [
@@ -285,7 +314,6 @@ const fCreateEventResourceTemplate = (srv, srvDefinition, global,packageIds) => 
     extensible: { supported: ordExtensions["extensible.supported"] ?? "no" },
   };
 };
-
 
 /**
  * This is a function to check whether entity is a function or action.
@@ -332,16 +360,16 @@ function checkEntityFunctionAction(srvDefinition, global) {
 function _getPackageID(capNamespace, packageIds, apiOrEvent) {
   if (packageIds instanceof Set) {
     const packageArray = Array.from(packageIds);
-    
+
     if (apiOrEvent === "api") {
-      const apiPackage = packageArray.find(pkg => pkg.includes("-api"));
+      const apiPackage = packageArray.find((pkg) => pkg.includes("-api"));
       if (apiPackage) return apiPackage;
     } else if (apiOrEvent === "event") {
-      const eventPackage = packageArray.find(pkg => pkg.includes("-event"));
+      const eventPackage = packageArray.find((pkg) => pkg.includes("-event"));
       if (eventPackage) return eventPackage;
     }
-    
-    return packageArray.find(pkg => pkg.includes(capNamespace));
+
+    return packageArray.find((pkg) => pkg.includes(capNamespace));
   }
 }
 


### PR DESCRIPTION
### Addressing

**groups** 

- [x] `"title": "Catalog Service”` → i.e. without appending “ Title”

**packages**

- [x] `"title": "capire bookshop”` → take what is there, don’t add extra text like “sample title for"
- [x] `“shortDescription"` → take what is there, don’t add extra text like “Here’s the short description for ..."
- [x] `“description"` → take what is there, don’t add extra text like “Here’s the short description for ..."

**apiResources**

- [x] `"title": "Catalog Service”` → take what is there, don’t add extra text like “The service is for ..."
- [x] `“shortDescription": "Catalog Service” `→ take what is there, don’t add extra text like “Here we have the shortDescription for ..."
- [x] `“description": "Catalog Service”` → take what is there, don’t add extra text like “Here we have the description for ..."

from https://github.com/cap-js/ord/issues/38