### PR TITLE
feat: Address issues with packages

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -13,6 +13,8 @@ const nameWithSpaces = (name) => {
   return regexWithRemoval(name.charAt(0)) + name.slice(1, name.length).replace(/[^a-zA-Z0-9]/g,' ');
 }
 
+const defaultProductOrdId = (name) => `customer:product:${nameWithDot(name)}:`
+
 /**
  * Module containing default configuration for ORD Document.
  * @module defaults
@@ -24,7 +26,7 @@ module.exports = {
   description: "this is an application description",
   products: (name) => [
     { 
-      ordId: `customer:product:${nameWithDot(name)}:`,
+      ordId: defaultProductOrdId(name),
       title: nameWithSpaces(name),
       shortDescription: "Description for " +  nameWithSpaces(name),
       vendor: "customer:vendor:customer:",
@@ -35,12 +37,12 @@ module.exports = {
     function createPackage(name, tag) {
       return {
         ordId: `${regexWithRemoval(name)}:package:${capNamespace}${tag}`,
-        title: `sample title for ${regexWithRemoval(name)}`,
-        shortDescription: "Here is the shortDescription for packages",
-        description: "Here is the description for packages",
+        title: nameWithSpaces(name),
+        shortDescription: "Description for " + nameWithSpaces(name),
+        description: "Description for " + nameWithSpaces(name),
         version: "1.0.0",
-        partOfProducts: [`customer:product:${nameWithDot(name)}:`],
-        vendor: "customer:vendor:SAP:"
+        partOfProducts: [defaultProductOrdId(name)],
+        vendor: "customer:vendor:customer:"
       };
     }
     

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -42,7 +42,7 @@ module.exports = {
         description: "Description for " + nameWithSpaces(name),
         version: "1.0.0",
         partOfProducts: [defaultProductOrdId(name)],
-        vendor: "customer:vendor:customer:"
+        vendor: "customer:vendor:Customer:"
       };
     }
     

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -38,7 +38,7 @@ module.exports = {
       return {
         ordId: `${regexWithRemoval(name)}:package:${capNamespace}${tag}`,
         title: nameWithSpaces(name),
-        shortDescription: "Description for " + nameWithSpaces(name),
+        shortDescription: "Short description for " + nameWithSpaces(name),
         description: "Description for " + nameWithSpaces(name),
         version: "1.0.0",
         partOfProducts: [defaultProductOrdId(name)],


### PR DESCRIPTION
- [x] → the namespace was wrong and the package name shall be `package.name.replace(/@/,'').replace(/\//g,'.')`
- [x] `"partOfProducts": [ "customer:product:capire.bookstore:” ]` → has to be the same as the product name in the products section
- [x] `"vendor": "customer:vendor:customer:”` → has to be the same as the vendor in the products section
- [x] `"title": "capire bookshop”` → take what is there, don’t add extra text like “sample title for"
- [x] `“shortDescription"` → take what is there, don’t add extra text like “Here’s the short description for ..."
- [x] `“description"` → take what is there, don’t add extra text like “Here’s the short description for ..."

In https://github.com/cap-js/ord/issues/38