### PR TITLE
fix: Use appName as package name in the apiResources.partOfPackage

### DIFF
--- a/__tests__/__snapshots__/ord.test.js.snap
+++ b/__tests__/__snapshots__/ord.test.js.snap
@@ -173,13 +173,13 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   "openResourceDiscovery": "1.9",
   "packages": [
     {
-      "description": "Description for capjs ord",
+      "description": "Description for cap js ord",
       "ordId": "capjsord:package:undefined:v1",
       "partOfProducts": [
-        "customer:product:capjs.ord:",
+        "customer:product:cap.js.ord:",
       ],
-      "shortDescription": "Short description for capjs ord",
-      "title": "capjs ord",
+      "shortDescription": "Short description for cap js ord",
+      "title": "cap js ord",
       "vendor": "customer:vendor:Customer:",
       "version": "1.0.0",
     },

--- a/__tests__/__snapshots__/ord.test.js.snap
+++ b/__tests__/__snapshots__/ord.test.js.snap
@@ -18,11 +18,11 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "bookshop:apiResource:undefined.AdminService:v1",
+      "ordId": "capire.bookshopordsample:apiResource:undefined.AdminService:v1",
       "partOfGroups": [
-        "sap.cds:service:bookshop:undefined.AdminService",
+        "sap.cds:service:capire.bookshopordsample:undefined.AdminService",
       ],
-      "partOfPackage": "bookshop:package:undefined:v1",
+      "partOfPackage": "capirebookshopordsample:package:undefined:v1",
       "releaseStatus": "active",
       "resourceDefinitions": [
         {
@@ -65,11 +65,11 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "bookshop:apiResource:undefined.CatalogService:v1",
+      "ordId": "capire.bookshopordsample:apiResource:undefined.CatalogService:v1",
       "partOfGroups": [
-        "sap.cds:service:bookshop:undefined.CatalogService",
+        "sap.cds:service:capire.bookshopordsample:undefined.CatalogService",
       ],
-      "partOfPackage": "bookshop:package:undefined:v1",
+      "partOfPackage": "capirebookshopordsample:package:undefined:v1",
       "releaseStatus": "active",
       "resourceDefinitions": [
         {
@@ -106,11 +106,11 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "bookshop:eventResource:undefined.AdminService:v1",
+      "ordId": "capire.bookshopordsample:eventResource:undefined.AdminService:v1",
       "partOfGroups": [
-        "sap.cds:service:bookshop:undefined.AdminService",
+        "sap.cds:service:capire.bookshopordsample:undefined.AdminService",
       ],
-      "partOfPackage": "bookshop:package:undefined:v1",
+      "partOfPackage": "capirebookshopordsample:package:undefined:v1",
       "releaseStatus": "beta",
       "resourceDefinitions": [
         {
@@ -125,7 +125,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
         },
       ],
       "shortDescription": "Example ODM Event",
-      "title": "ODM bookshop Events",
+      "title": "ODM capirebookshopordsample Events",
       "version": "1.0.0",
       "visibility": "public",
     },
@@ -134,11 +134,11 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "bookshop:eventResource:undefined.CatalogService:v1",
+      "ordId": "capire.bookshopordsample:eventResource:undefined.CatalogService:v1",
       "partOfGroups": [
-        "sap.cds:service:bookshop:undefined.CatalogService",
+        "sap.cds:service:capire.bookshopordsample:undefined.CatalogService",
       ],
-      "partOfPackage": "bookshop:package:undefined:v1",
+      "partOfPackage": "capirebookshopordsample:package:undefined:v1",
       "releaseStatus": "beta",
       "resourceDefinitions": [
         {
@@ -153,19 +153,19 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
         },
       ],
       "shortDescription": "Example ODM Event",
-      "title": "ODM bookshop Events",
+      "title": "ODM capirebookshopordsample Events",
       "version": "1.0.0",
       "visibility": "public",
     },
   ],
   "groups": [
     {
-      "groupId": "sap.cds:service:bookshop:undefined.AdminService",
+      "groupId": "sap.cds:service:capire.bookshopordsample:undefined.AdminService",
       "groupTypeId": "sap.cds:service",
       "title": "Admin Service",
     },
     {
-      "groupId": "sap.cds:service:bookshop:undefined.CatalogService",
+      "groupId": "sap.cds:service:capire.bookshopordsample:undefined.CatalogService",
       "groupTypeId": "sap.cds:service",
       "title": "Catalog Service",
     },
@@ -173,13 +173,13 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   "openResourceDiscovery": "1.9",
   "packages": [
     {
-      "description": "Description for bookshop",
-      "ordId": "bookshop:package:undefined:v1",
+      "description": "Description for capire bookshop ord sample",
+      "ordId": "capirebookshopordsample:package:undefined:v1",
       "partOfProducts": [
-        "customer:product:bookshop:",
+        "customer:product:capire.bookshop.ord.sample:",
       ],
-      "shortDescription": "Short description for bookshop",
-      "title": "bookshop",
+      "shortDescription": "Short description for capire bookshop ord sample",
+      "title": "capire bookshop ord sample",
       "vendor": "customer:vendor:Customer:",
       "version": "1.0.0",
     },
@@ -187,9 +187,9 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   "policyLevel": "none",
   "products": [
     {
-      "ordId": "customer:product:bookshop:",
-      "shortDescription": "Description for bookshop",
-      "title": "bookshop",
+      "ordId": "customer:product:capire.bookshop.ord.sample:",
+      "shortDescription": "Description for capire bookshop ord sample",
+      "title": "capire bookshop ord sample",
       "vendor": "customer:vendor:customer:",
     },
   ],

--- a/__tests__/__snapshots__/ord.test.js.snap
+++ b/__tests__/__snapshots__/ord.test.js.snap
@@ -18,11 +18,11 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capjs.ord:apiResource:undefined.AdminService:v1",
+      "ordId": "bookshop:apiResource:undefined.AdminService:v1",
       "partOfGroups": [
-        "sap.cds:service:capjs.ord:undefined.AdminService",
+        "sap.cds:service:bookshop:undefined.AdminService",
       ],
-      "partOfPackage": "capjsord:package:undefined:v1",
+      "partOfPackage": "bookshop:package:undefined:v1",
       "releaseStatus": "active",
       "resourceDefinitions": [
         {
@@ -65,11 +65,11 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capjs.ord:apiResource:undefined.CatalogService:v1",
+      "ordId": "bookshop:apiResource:undefined.CatalogService:v1",
       "partOfGroups": [
-        "sap.cds:service:capjs.ord:undefined.CatalogService",
+        "sap.cds:service:bookshop:undefined.CatalogService",
       ],
-      "partOfPackage": "capjsord:package:undefined:v1",
+      "partOfPackage": "bookshop:package:undefined:v1",
       "releaseStatus": "active",
       "resourceDefinitions": [
         {
@@ -106,11 +106,11 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capjs.ord:eventResource:undefined.AdminService:v1",
+      "ordId": "bookshop:eventResource:undefined.AdminService:v1",
       "partOfGroups": [
-        "sap.cds:service:capjs.ord:undefined.AdminService",
+        "sap.cds:service:bookshop:undefined.AdminService",
       ],
-      "partOfPackage": "capjsord:package:undefined:v1",
+      "partOfPackage": "bookshop:package:undefined:v1",
       "releaseStatus": "beta",
       "resourceDefinitions": [
         {
@@ -125,7 +125,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
         },
       ],
       "shortDescription": "Example ODM Event",
-      "title": "ODM capjsord Events",
+      "title": "ODM bookshop Events",
       "version": "1.0.0",
       "visibility": "public",
     },
@@ -134,11 +134,11 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capjs.ord:eventResource:undefined.CatalogService:v1",
+      "ordId": "bookshop:eventResource:undefined.CatalogService:v1",
       "partOfGroups": [
-        "sap.cds:service:capjs.ord:undefined.CatalogService",
+        "sap.cds:service:bookshop:undefined.CatalogService",
       ],
-      "partOfPackage": "capjsord:package:undefined:v1",
+      "partOfPackage": "bookshop:package:undefined:v1",
       "releaseStatus": "beta",
       "resourceDefinitions": [
         {
@@ -153,19 +153,19 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
         },
       ],
       "shortDescription": "Example ODM Event",
-      "title": "ODM capjsord Events",
+      "title": "ODM bookshop Events",
       "version": "1.0.0",
       "visibility": "public",
     },
   ],
   "groups": [
     {
-      "groupId": "sap.cds:service:capjs.ord:undefined.AdminService",
+      "groupId": "sap.cds:service:bookshop:undefined.AdminService",
       "groupTypeId": "sap.cds:service",
       "title": "Admin Service",
     },
     {
-      "groupId": "sap.cds:service:capjs.ord:undefined.CatalogService",
+      "groupId": "sap.cds:service:bookshop:undefined.CatalogService",
       "groupTypeId": "sap.cds:service",
       "title": "Catalog Service",
     },
@@ -173,13 +173,13 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   "openResourceDiscovery": "1.9",
   "packages": [
     {
-      "description": "Description for cap js ord",
-      "ordId": "capjsord:package:undefined:v1",
+      "description": "Description for bookshop",
+      "ordId": "bookshop:package:undefined:v1",
       "partOfProducts": [
-        "customer:product:cap.js.ord:",
+        "customer:product:bookshop:",
       ],
-      "shortDescription": "Short description for cap js ord",
-      "title": "cap js ord",
+      "shortDescription": "Short description for bookshop",
+      "title": "bookshop",
       "vendor": "customer:vendor:Customer:",
       "version": "1.0.0",
     },
@@ -187,9 +187,9 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   "policyLevel": "none",
   "products": [
     {
-      "ordId": "customer:product:cap.js.ord:",
-      "shortDescription": "Description for cap js ord",
-      "title": "cap js ord",
+      "ordId": "customer:product:bookshop:",
+      "shortDescription": "Description for bookshop",
+      "title": "bookshop",
       "vendor": "customer:vendor:customer:",
     },
   ],

--- a/__tests__/bookshop/package.json
+++ b/__tests__/bookshop/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bookshop",
+  "name": "@capire/bookshop-ord-sample",
   "version": "1.0.0",
   "description": "A simple CAP project.",
   "repository": "<Add your repository here>",

--- a/__tests__/ord.test.js
+++ b/__tests__/ord.test.js
@@ -24,7 +24,9 @@ describe("Tests for default ORD document", () => {
     });
 
     describe("apiResources", () => {
-        const PACKAGE_ID_REGEX = /^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._-]+):(v0|v[1-9][0-9]*)$/;
+        // eslint-disable-next-line no-useless-escape
+        const PACKAGE_ID_REGEX = /^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$/;
+
         let document;
 
         beforeAll(() => {
@@ -49,8 +51,8 @@ describe("Tests for default ORD document", () => {
     });
 
     describe("eventResources", () => {
-        const GROUP_ID_REGEX =
-            /^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):(?<service>[a-zA-Z0-9._\-/]+)$/;
+        // eslint-disable-next-line no-useless-escape
+        const GROUP_ID_REGEX = /^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):(?<service>[a-zA-Z0-9._\-/]+)$/;
 
         let document;
 

--- a/__tests__/ord.test.js
+++ b/__tests__/ord.test.js
@@ -5,8 +5,8 @@ const { join } = require("path");
 jest.mock("@sap/cds", () => {
     const { join } = require("path");
     let originalCds = jest.requireActual("@sap/cds");
-    originalCds.root = join(__dirname, "bookshop")
-    return originalCds
+    originalCds.root = join(__dirname, "bookshop");
+    return originalCds;
 });
 
 const cds = require("@sap/cds");
@@ -24,9 +24,7 @@ describe("Tests for default ORD document", () => {
     });
 
     describe("apiResources", () => {
-        const PACKAGE_ID_REGEX =
-            /^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$/;
-
+        const PACKAGE_ID_REGEX = /^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._-]+):(v0|v[1-9][0-9]*)$/;
         let document;
 
         beforeAll(() => {

--- a/__tests__/ord.test.js
+++ b/__tests__/ord.test.js
@@ -14,6 +14,27 @@ describe("Tests for default ORD document", () => {
     expect(document).toMatchSnapshot();
   });
 
+  describe("apiResources", () => {
+    const PACKAGE_ID_REGEX = /^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$/
+
+    let document;
+
+    beforeAll(()=> {
+      document = ord(csn);
+    })
+
+    test("partOfPackage values are valid ORD IDs ", () => {
+      for (const apiResource of document.apiResources) {
+        expect(apiResource.partOfPackage).toMatch(PACKAGE_ID_REGEX)
+      }
+    })
+
+    test("The partOfPackage references an existing package", () => {
+        for (const apiResource of document.apiResources) {
+          expect(document.packages.find((pck) => pck.ordId == apiResource.partOfPackage)).toBeDefined
+        }
+      })
+  })
 
   describe("eventResources", () => {
     const GROUP_ID_REGEX = /^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):(?<service>[a-zA-Z0-9._\-/]+)$/
@@ -24,12 +45,12 @@ describe("Tests for default ORD document", () => {
       document = ord(csn);
     })
 
-    test("Assigned to excactly one CDS Service group", () => {
+    test("Assigned to exactly one CDS Service group", () => {
       for (const eventResource of document.eventResources) {
         expect(eventResource.partOfGroups.length).toEqual(1)
       }
     });
-  
+
     test("The CDS Service Group ID includes the CDS Service identifier", () => {
       for (const eventResource of document.eventResources) {
         const [groupId] = eventResource.partOfGroups

--- a/__tests__/ord.test.js
+++ b/__tests__/ord.test.js
@@ -1,70 +1,86 @@
-const cds = require("@sap/cds");
 const ord = require("../lib/ord");
-const path = require("path");
+const { join } = require("path");
+
+// Mock the @sap/cds module
+jest.mock("@sap/cds", () => {
+    const { join } = require("path");
+    let originalCds = jest.requireActual("@sap/cds");
+    originalCds.root = join(__dirname, "bookshop")
+    return originalCds
+});
+
+const cds = require("@sap/cds");
 
 describe("Tests for default ORD document", () => {
-  let csn;
+    let csn;
 
-  beforeAll(async () => {
-    csn = await cds.load(path.join(__dirname, "bookshop", "srv"));
-  });
-
-  test("Successfully create ORD Documents with defaults", () => {
-    const document = ord(csn);
-    expect(document).toMatchSnapshot();
-  });
-
-  describe("apiResources", () => {
-    const PACKAGE_ID_REGEX = /^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$/
-
-    let document;
-
-    beforeAll(()=> {
-      document = ord(csn);
-    })
-
-    test("partOfPackage values are valid ORD IDs ", () => {
-      for (const apiResource of document.apiResources) {
-        expect(apiResource.partOfPackage).toMatch(PACKAGE_ID_REGEX)
-      }
-    })
-
-    test("The partOfPackage references an existing package", () => {
-        for (const apiResource of document.apiResources) {
-          expect(document.packages.find((pck) => pck.ordId == apiResource.partOfPackage)).toBeDefined
-        }
-      })
-  })
-
-  describe("eventResources", () => {
-    const GROUP_ID_REGEX = /^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):(?<service>[a-zA-Z0-9._\-/]+)$/
-
-    let document;
-
-    beforeAll(()=> {
-      document = ord(csn);
-    })
-
-    test("Assigned to exactly one CDS Service group", () => {
-      for (const eventResource of document.eventResources) {
-        expect(eventResource.partOfGroups.length).toEqual(1)
-      }
+    beforeAll(async () => {
+        csn = await cds.load(join(__dirname, "bookshop", "srv"));
     });
 
-    test("The CDS Service Group ID includes the CDS Service identifier", () => {
-      for (const eventResource of document.eventResources) {
-        const [groupId] = eventResource.partOfGroups
-        expect(groupId).toMatch(GROUP_ID_REGEX)
+    test("Successfully create ORD Documents with defaults", () => {
+        const document = ord(csn);
+        expect(document).toMatchSnapshot();
+    });
 
-        const match = GROUP_ID_REGEX.exec(groupId)
-        if (match && match.groups?.service) {
-          let service = match.groups?.service
-          if (service.startsWith("undefined")) service = service.replace("undefined.", "")
-          const definition = csn.definitions[service]
-          expect(definition).toBeDefined()
-          expect(definition.kind).toEqual("service")
-        }
-      }
-    })
-  })
+    describe("apiResources", () => {
+        const PACKAGE_ID_REGEX =
+            /^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$/;
+
+        let document;
+
+        beforeAll(() => {
+            document = ord(csn);
+        });
+
+        test("partOfPackage values are valid ORD IDs ", () => {
+            for (const apiResource of document.apiResources) {
+                expect(apiResource.partOfPackage).toMatch(PACKAGE_ID_REGEX);
+            }
+        });
+
+        test("The partOfPackage references an existing package", () => {
+            for (const apiResource of document.apiResources) {
+                expect(
+                    document.packages.find(
+                        (pck) => pck.ordId == apiResource.partOfPackage
+                    )
+                ).toBeDefined;
+            }
+        });
+    });
+
+    describe("eventResources", () => {
+        const GROUP_ID_REGEX =
+            /^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):(?<service>[a-zA-Z0-9._\-/]+)$/;
+
+        let document;
+
+        beforeAll(() => {
+            document = ord(csn);
+        });
+
+        test("Assigned to exactly one CDS Service group", () => {
+            for (const eventResource of document.eventResources) {
+                expect(eventResource.partOfGroups.length).toEqual(1);
+            }
+        });
+
+        test("The CDS Service Group ID includes the CDS Service identifier", () => {
+            for (const eventResource of document.eventResources) {
+                const [groupId] = eventResource.partOfGroups;
+                expect(groupId).toMatch(GROUP_ID_REGEX);
+
+                const match = GROUP_ID_REGEX.exec(groupId);
+                if (match && match.groups?.service) {
+                    let service = match.groups?.service;
+                    if (service.startsWith("undefined"))
+                        service = service.replace("undefined.", "");
+                    const definition = csn.definitions[service];
+                    expect(definition).toBeDefined();
+                    expect(definition.kind).toEqual("service");
+                }
+            }
+        });
+    });
 });

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const { join } = require("path");
 const cds = require("@sap/cds");
 const { exists } = cds.utils;
 const defaults = require("./defaults");
@@ -15,7 +15,7 @@ const {
  * @returns {Object} An object containing global variables.
  */
 const fInitializeGlobal = (csn) => {
-    let packagejsonPath = path.join(cds.root,'package.json')
+    let packagejsonPath = join(cds.root,'package.json')
     let packageJson;
     if (exists(packagejsonPath)) {
         packageJson = require(packagejsonPath);

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -28,13 +28,13 @@ const fInitializeGlobal = (csn) => {
     const aEvents = [];
     const aServices = [];
     const aODMEntity = [];
-    
+
     const capNamespace = csn.namespace;
      // namespace variable value if present in cdsrc.json take it there or else from package.json
     //if cdsrc.json does not have applicationNamespace, then use just the namespace
     const namespace = cds.env["ord"]?.namespace || packageName.replace(/[^\w/]/g, "").replace(/\//, ".");
     const applicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
-    
+
     if (applicationNamespace && fGetNamespaceComponents(namespace) !== fGetNamespaceComponents(applicationNamespace)) {
         console.warn('ORD and AsyncAPI namespaces should be the same.');
     }
@@ -105,7 +105,7 @@ const fGetProducts = (global) => global.env?.products || defaults.products(globa
 /**
  * Retrieves the groups that services belongs to.
  * Gets list of groups from CDS runtime object.
- * @param {Object} csn object 
+ * @param {Object} csn object
  * @returns {Array<object>} The groups array.
  */
 const fGetGroups = (csn, global) => {
@@ -119,7 +119,7 @@ const fGetGroups = (csn, global) => {
  * Hierarchy to check data: cdsrc.json > defaults
  * @returns {Array<object>} The packages array.
  */
-const fGetPackages = (policyLevel,global) => global.env?.packages || (global.aEvents.length) ? defaults.packages(global.namespace,policyLevel,global.capNamespace) : defaults.packages(global.namespace,policyLevel,global.capNamespace).slice(0, 1)
+const fGetPackages = (policyLevel,global) => global.env?.packages || (global.aEvents.length) ? defaults.packages(global.appName,policyLevel,global.capNamespace) : defaults.packages(global.appName,policyLevel,global.capNamespace).slice(0, 1)
 
 /**
  * Retrieves the API Resources


### PR DESCRIPTION
Addressing the following issue given in the issue #38 

> "partOfPackage": "customer.capirebookstore:package:capire.bookshop:v1” → correct namespace prefix in package ref - use appName as packageName as a fallback.
