### PR TITLE
fix: Use the fully-qualified names from .definitions instead of namespace

### DIFF
--- a/__tests__/__snapshots__/ord.test.js.snap
+++ b/__tests__/__snapshots__/ord.test.js.snap
@@ -22,7 +22,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:AdminService",
       ],
-      "partOfPackage": "capirebookshopordsample:package:capire.bookshopordsample:v1",
+      "partOfPackage": "capire.bookshopordsample:package:customer.capirebookshopordsample:v1",
       "releaseStatus": "active",
       "resourceDefinitions": [
         {
@@ -69,7 +69,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:CatalogService",
       ],
-      "partOfPackage": "capirebookshopordsample:package:capire.bookshopordsample:v1",
+      "partOfPackage": "capire.bookshopordsample:package:customer.capirebookshopordsample:v1",
       "releaseStatus": "active",
       "resourceDefinitions": [
         {
@@ -110,7 +110,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:AdminService",
       ],
-      "partOfPackage": "capirebookshopordsample:package:capire.bookshopordsample:v1",
+      "partOfPackage": "capire.bookshopordsample:package:customer.capirebookshopordsample:v1",
       "releaseStatus": "beta",
       "resourceDefinitions": [
         {
@@ -138,7 +138,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:CatalogService",
       ],
-      "partOfPackage": "capirebookshopordsample:package:capire.bookshopordsample:v1",
+      "partOfPackage": "capire.bookshopordsample:package:customer.capirebookshopordsample:v1",
       "releaseStatus": "beta",
       "resourceDefinitions": [
         {
@@ -174,7 +174,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   "packages": [
     {
       "description": "Description for capire bookshop ord sample",
-      "ordId": "capirebookshopordsample:package:capire.bookshopordsample:v1",
+      "ordId": "capire.bookshopordsample:package:customer.capirebookshopordsample:v1",
       "partOfProducts": [
         "customer:product:capire.bookshop.ord.sample:",
       ],

--- a/__tests__/__snapshots__/ord.test.js.snap
+++ b/__tests__/__snapshots__/ord.test.js.snap
@@ -18,9 +18,9 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capire.bookshopordsample:apiResource:undefined.AdminService:v1",
+      "ordId": "capire.bookshopordsample:apiResource:AdminService:v1",
       "partOfGroups": [
-        "sap.cds:service:capire.bookshopordsample:undefined.AdminService",
+        "sap.cds:service:capire.bookshopordsample:AdminService",
       ],
       "partOfPackage": "capirebookshopordsample:package:undefined:v1",
       "releaseStatus": "active",
@@ -65,9 +65,9 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capire.bookshopordsample:apiResource:undefined.CatalogService:v1",
+      "ordId": "capire.bookshopordsample:apiResource:CatalogService:v1",
       "partOfGroups": [
-        "sap.cds:service:capire.bookshopordsample:undefined.CatalogService",
+        "sap.cds:service:capire.bookshopordsample:CatalogService",
       ],
       "partOfPackage": "capirebookshopordsample:package:undefined:v1",
       "releaseStatus": "active",
@@ -106,9 +106,9 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capire.bookshopordsample:eventResource:undefined.AdminService:v1",
+      "ordId": "capire.bookshopordsample:eventResource:AdminService:v1",
       "partOfGroups": [
-        "sap.cds:service:capire.bookshopordsample:undefined.AdminService",
+        "sap.cds:service:capire.bookshopordsample:AdminService",
       ],
       "partOfPackage": "capirebookshopordsample:package:undefined:v1",
       "releaseStatus": "beta",
@@ -134,9 +134,9 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capire.bookshopordsample:eventResource:undefined.CatalogService:v1",
+      "ordId": "capire.bookshopordsample:eventResource:CatalogService:v1",
       "partOfGroups": [
-        "sap.cds:service:capire.bookshopordsample:undefined.CatalogService",
+        "sap.cds:service:capire.bookshopordsample:CatalogService",
       ],
       "partOfPackage": "capirebookshopordsample:package:undefined:v1",
       "releaseStatus": "beta",
@@ -160,12 +160,12 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   ],
   "groups": [
     {
-      "groupId": "sap.cds:service:capire.bookshopordsample:undefined.AdminService",
+      "groupId": "sap.cds:service:capire.bookshopordsample:AdminService",
       "groupTypeId": "sap.cds:service",
       "title": "Admin Service",
     },
     {
-      "groupId": "sap.cds:service:capire.bookshopordsample:undefined.CatalogService",
+      "groupId": "sap.cds:service:capire.bookshopordsample:CatalogService",
       "groupTypeId": "sap.cds:service",
       "title": "Catalog Service",
     },

--- a/__tests__/__snapshots__/ord.test.js.snap
+++ b/__tests__/__snapshots__/ord.test.js.snap
@@ -22,7 +22,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:AdminService",
       ],
-      "partOfPackage": "capire.bookshopordsample:package:customer.capirebookshopordsample:v1",
+      "partOfPackage": "customer.capirebookshopordsample:package:capirebookshopordsample:v1",
       "releaseStatus": "active",
       "resourceDefinitions": [
         {
@@ -69,7 +69,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:CatalogService",
       ],
-      "partOfPackage": "capire.bookshopordsample:package:customer.capirebookshopordsample:v1",
+      "partOfPackage": "customer.capirebookshopordsample:package:capirebookshopordsample:v1",
       "releaseStatus": "active",
       "resourceDefinitions": [
         {
@@ -110,7 +110,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:AdminService",
       ],
-      "partOfPackage": "capire.bookshopordsample:package:customer.capirebookshopordsample:v1",
+      "partOfPackage": "customer.capirebookshopordsample:package:capirebookshopordsample:v1",
       "releaseStatus": "beta",
       "resourceDefinitions": [
         {
@@ -138,7 +138,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:CatalogService",
       ],
-      "partOfPackage": "capire.bookshopordsample:package:customer.capirebookshopordsample:v1",
+      "partOfPackage": "customer.capirebookshopordsample:package:capirebookshopordsample:v1",
       "releaseStatus": "beta",
       "resourceDefinitions": [
         {
@@ -174,7 +174,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   "packages": [
     {
       "description": "Description for capire bookshop ord sample",
-      "ordId": "capire.bookshopordsample:package:customer.capirebookshopordsample:v1",
+      "ordId": "customer.capirebookshopordsample:package:capirebookshopordsample:v1",
       "partOfProducts": [
         "customer:product:capire.bookshop.ord.sample:",
       ],

--- a/__tests__/__snapshots__/ord.test.js.snap
+++ b/__tests__/__snapshots__/ord.test.js.snap
@@ -22,7 +22,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:AdminService",
       ],
-      "partOfPackage": "capirebookshopordsample:package:undefined:v1",
+      "partOfPackage": "capirebookshopordsample:package:capire.bookshopordsample:v1",
       "releaseStatus": "active",
       "resourceDefinitions": [
         {
@@ -69,7 +69,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:CatalogService",
       ],
-      "partOfPackage": "capirebookshopordsample:package:undefined:v1",
+      "partOfPackage": "capirebookshopordsample:package:capire.bookshopordsample:v1",
       "releaseStatus": "active",
       "resourceDefinitions": [
         {
@@ -110,7 +110,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:AdminService",
       ],
-      "partOfPackage": "capirebookshopordsample:package:undefined:v1",
+      "partOfPackage": "capirebookshopordsample:package:capire.bookshopordsample:v1",
       "releaseStatus": "beta",
       "resourceDefinitions": [
         {
@@ -138,7 +138,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "partOfGroups": [
         "sap.cds:service:capire.bookshopordsample:CatalogService",
       ],
-      "partOfPackage": "capirebookshopordsample:package:undefined:v1",
+      "partOfPackage": "capirebookshopordsample:package:capire.bookshopordsample:v1",
       "releaseStatus": "beta",
       "resourceDefinitions": [
         {
@@ -174,7 +174,7 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   "packages": [
     {
       "description": "Description for capire bookshop ord sample",
-      "ordId": "capirebookshopordsample:package:undefined:v1",
+      "ordId": "capirebookshopordsample:package:capire.bookshopordsample:v1",
       "partOfProducts": [
         "customer:product:capire.bookshop.ord.sample:",
       ],

--- a/__tests__/__snapshots__/ordCdsrc.test.js.snap
+++ b/__tests__/__snapshots__/ordCdsrc.test.js.snap
@@ -1,0 +1,208 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tests for default ORD document when .cdsrc.json is present Successfully create ORD Documents with defaults 1`] = `
+{
+  "$schema": "https://sap.github.io/open-resource-discovery/spec-v1/interfaces/Document.schema.json",
+  "apiResources": [
+    {
+      "apiProtocol": "odata-v4",
+      "description": "AdminService",
+      "entityTypeMappings": [
+        {
+          "entityTypeTargets": [],
+        },
+      ],
+      "entryPoints": [
+        "/odata/v4/admin",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "ordId": "sap.test.cdsrc.sample:apiResource:AdminService:v1",
+      "partOfGroups": [
+        "sap.cds:service:sap.test.cdsrc.sample:AdminService",
+      ],
+      "partOfPackage": "sap.test.cdsrc.sample:package:capirebookshopordsample-api:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/.well-known/open-resource-discovery/v1/api-metadata/AdminService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/.well-known/open-resource-discovery/v1/api-metadata/AdminService.edmx",
+        },
+      ],
+      "shortDescription": "AdminService",
+      "title": "AdminService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "odata-v4",
+      "description": "CatalogService",
+      "entityTypeMappings": [
+        {
+          "entityTypeTargets": [],
+        },
+      ],
+      "entryPoints": [
+        "/browse",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "ordId": "sap.test.cdsrc.sample:apiResource:CatalogService:v1",
+      "partOfGroups": [
+        "sap.cds:service:sap.test.cdsrc.sample:CatalogService",
+      ],
+      "partOfPackage": "sap.test.cdsrc.sample:package:capirebookshopordsample-api:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/.well-known/open-resource-discovery/v1/api-metadata/CatalogService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/.well-known/open-resource-discovery/v1/api-metadata/CatalogService.edmx",
+        },
+      ],
+      "shortDescription": "CatalogService",
+      "title": "CatalogService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "description": "this is my custom description",
+  "eventResources": [
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "ordId": "sap.test.cdsrc.sample:eventResource:AdminService:v1",
+      "partOfGroups": [
+        "sap.cds:service:sap.test.cdsrc.sample:AdminService",
+      ],
+      "partOfPackage": "sap.test.cdsrc.sample:package:capirebookshopordsample-event:v1",
+      "releaseStatus": "beta",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "/.well-known/open-resource-discovery/v1/api-metadata/AdminService.asyncapi2.json",
+        },
+      ],
+      "shortDescription": "Example ODM Event",
+      "title": "ODM capirebookshopordsample Events",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "ordId": "sap.test.cdsrc.sample:eventResource:CatalogService:v1",
+      "partOfGroups": [
+        "sap.cds:service:sap.test.cdsrc.sample:CatalogService",
+      ],
+      "partOfPackage": "sap.test.cdsrc.sample:package:capirebookshopordsample-event:v1",
+      "releaseStatus": "beta",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "/.well-known/open-resource-discovery/v1/api-metadata/CatalogService.asyncapi2.json",
+        },
+      ],
+      "shortDescription": "Example ODM Event",
+      "title": "ODM capirebookshopordsample Events",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "groups": [
+    {
+      "groupId": "sap.cds:service:sap.test.cdsrc.sample:AdminService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Admin Service",
+    },
+    {
+      "groupId": "sap.cds:service:sap.test.cdsrc.sample:CatalogService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Catalog Service",
+    },
+  ],
+  "openResourceDiscovery": "1.9",
+  "packages": [
+    {
+      "description": "Description for capire bookshop ord sample",
+      "ordId": "sap.test.cdsrc.sample:package:capirebookshopordsample-api:v1",
+      "partOfProducts": [
+        "customer:product:capire.bookshop.ord.sample:",
+      ],
+      "shortDescription": "Short description for capire bookshop ord sample",
+      "title": "capire bookshop ord sample",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+    {
+      "description": "Description for capire bookshop ord sample",
+      "ordId": "sap.test.cdsrc.sample:package:capirebookshopordsample-event:v1",
+      "partOfProducts": [
+        "customer:product:capire.bookshop.ord.sample:",
+      ],
+      "shortDescription": "Short description for capire bookshop ord sample",
+      "title": "capire bookshop ord sample",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+  ],
+  "policyLevel": "sap:core:v1",
+  "products": [
+    {
+      "ordId": "customer:product:capire.bookshop.ord.sample:",
+      "shortDescription": "Description for capire bookshop ord sample",
+      "title": "capire bookshop ord sample",
+      "vendor": "customer:vendor:customer:",
+    },
+  ],
+}
+`;

--- a/__tests__/__snapshots__/ordPackageJson.test.js.snap
+++ b/__tests__/__snapshots__/ordPackageJson.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tests for default ORD document Successfully create ORD Documents with defaults 1`] = `
+exports[`Tests for default ORD document when .cdsrc.json is not present Successfully create ORD Documents with defaults 1`] = `
 {
   "$schema": "https://sap.github.io/open-resource-discovery/spec-v1/interfaces/Document.schema.json",
   "apiResources": [
@@ -18,9 +18,9 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capire.bookshopordsample:apiResource:AdminService:v1",
+      "ordId": "customer.capirebookshopordsample:apiResource:AdminService:v1",
       "partOfGroups": [
-        "sap.cds:service:capire.bookshopordsample:AdminService",
+        "sap.cds:service:customer.capirebookshopordsample:AdminService",
       ],
       "partOfPackage": "customer.capirebookshopordsample:package:capirebookshopordsample:v1",
       "releaseStatus": "active",
@@ -65,9 +65,9 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capire.bookshopordsample:apiResource:CatalogService:v1",
+      "ordId": "customer.capirebookshopordsample:apiResource:CatalogService:v1",
       "partOfGroups": [
-        "sap.cds:service:capire.bookshopordsample:CatalogService",
+        "sap.cds:service:customer.capirebookshopordsample:CatalogService",
       ],
       "partOfPackage": "customer.capirebookshopordsample:package:capirebookshopordsample:v1",
       "releaseStatus": "active",
@@ -106,9 +106,9 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capire.bookshopordsample:eventResource:AdminService:v1",
+      "ordId": "customer.capirebookshopordsample:eventResource:AdminService:v1",
       "partOfGroups": [
-        "sap.cds:service:capire.bookshopordsample:AdminService",
+        "sap.cds:service:customer.capirebookshopordsample:AdminService",
       ],
       "partOfPackage": "customer.capirebookshopordsample:package:capirebookshopordsample:v1",
       "releaseStatus": "beta",
@@ -134,9 +134,9 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
       "extensible": {
         "supported": "no",
       },
-      "ordId": "capire.bookshopordsample:eventResource:CatalogService:v1",
+      "ordId": "customer.capirebookshopordsample:eventResource:CatalogService:v1",
       "partOfGroups": [
-        "sap.cds:service:capire.bookshopordsample:CatalogService",
+        "sap.cds:service:customer.capirebookshopordsample:CatalogService",
       ],
       "partOfPackage": "customer.capirebookshopordsample:package:capirebookshopordsample:v1",
       "releaseStatus": "beta",
@@ -160,12 +160,12 @@ exports[`Tests for default ORD document Successfully create ORD Documents with d
   ],
   "groups": [
     {
-      "groupId": "sap.cds:service:capire.bookshopordsample:AdminService",
+      "groupId": "sap.cds:service:customer.capirebookshopordsample:AdminService",
       "groupTypeId": "sap.cds:service",
       "title": "Admin Service",
     },
     {
-      "groupId": "sap.cds:service:capire.bookshopordsample:CatalogService",
+      "groupId": "sap.cds:service:customer.capirebookshopordsample:CatalogService",
       "groupTypeId": "sap.cds:service",
       "title": "Catalog Service",
     },

--- a/__tests__/bookshop/.cdsrc.json
+++ b/__tests__/bookshop/.cdsrc.json
@@ -1,0 +1,7 @@
+{
+    "ord": {
+        "namespace": "sap.test.cdsrc.sample",
+        "description": "this is my custom description",
+        "policyLevel": "sap:core:v1"
+    }
+}

--- a/__tests__/ordCdsrc.test.js
+++ b/__tests__/ordCdsrc.test.js
@@ -11,7 +11,7 @@ jest.mock("@sap/cds", () => {
 
 const cds = require("@sap/cds");
 
-describe("Tests for default ORD document", () => {
+describe("Tests for default ORD document when .cdsrc.json is present", () => {
     let csn;
 
     beforeAll(async () => {

--- a/__tests__/ordPackageJson.test.js
+++ b/__tests__/ordPackageJson.test.js
@@ -1,0 +1,88 @@
+const ord = require("../lib/ord");
+const { join } = require("path");
+
+// Mock the @sap/cds module
+jest.mock("@sap/cds", () => {
+    const { join } = require("path");
+    let originalCds = jest.requireActual("@sap/cds");
+    originalCds.root = join(__dirname, "bookshop");
+    return originalCds;
+});
+
+const cds = require("@sap/cds");
+
+describe("Tests for default ORD document when .cdsrc.json is not present", () => {
+    let csn;
+
+    beforeAll(async () => {
+        cds.env["ord"] = "";
+        csn = await cds.load(join(__dirname, "bookshop", "srv"));
+
+    });
+
+    test("Successfully create ORD Documents with defaults", () => {
+        const document = ord(csn);
+        expect(document).toMatchSnapshot();
+    });
+
+    describe("apiResources", () => {
+        // eslint-disable-next-line no-useless-escape
+        const PACKAGE_ID_REGEX = /^([a-z0-9]+(?:[.][a-z0-9]+)*):(package):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*)$/;
+
+        let document;
+
+        beforeAll(() => {
+            document = ord(csn);
+        });
+
+        test("partOfPackage values are valid ORD IDs ", () => {
+            for (const apiResource of document.apiResources) {
+                expect(apiResource.partOfPackage).toMatch(PACKAGE_ID_REGEX);
+            }
+        });
+
+        test("The partOfPackage references an existing package", () => {
+            for (const apiResource of document.apiResources) {
+                expect(
+                    document.packages.find(
+                        (pck) => pck.ordId === apiResource.partOfPackage
+                    )
+                ).toBeDefined();
+            }
+        });
+    });
+
+    describe("eventResources", () => {
+        // eslint-disable-next-line no-useless-escape
+        const GROUP_ID_REGEX = /^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-/]+):([a-z0-9-]+(?:[.][a-z0-9-]+)*):(?<service>[a-zA-Z0-9._\-/]+)$/;
+
+        let document;
+
+        beforeAll(() => {
+            document = ord(csn);
+        });
+
+        test("Assigned to exactly one CDS Service group", () => {
+            for (const eventResource of document.eventResources) {
+                expect(eventResource.partOfGroups.length).toEqual(1);
+            }
+        });
+
+        test("The CDS Service Group ID includes the CDS Service identifier", () => {
+            for (const eventResource of document.eventResources) {
+                const [groupId] = eventResource.partOfGroups;
+                expect(groupId).toMatch(GROUP_ID_REGEX);
+
+                const match = GROUP_ID_REGEX.exec(groupId);
+                if (match && match.groups?.service) {
+                    let service = match.groups?.service;
+                    if (service.startsWith("undefined"))
+                        service = service.replace("undefined.", "");
+                    const definition = csn.definitions[service];
+                    expect(definition).toBeDefined();
+                    expect(definition.kind).toEqual("service");
+                }
+            }
+        });
+    });
+});

--- a/__tests__/unittest/__snapshots__/defaults.test.js.snap
+++ b/__tests__/unittest/__snapshots__/defaults.test.js.snap
@@ -41,7 +41,7 @@ exports[`defaults packages should return default value if policyLevel contains s
 [
   {
     "description": "Description for My Package",
-    "ordId": "MyPackage:package:sample-api:v1",
+    "ordId": "sample:package:customer.MyPackage-api:v1",
     "partOfProducts": [
       "customer:product:My.Package:",
     ],
@@ -52,7 +52,7 @@ exports[`defaults packages should return default value if policyLevel contains s
   },
   {
     "description": "Description for My Package",
-    "ordId": "MyPackage:package:sample-event:v1",
+    "ordId": "sample:package:customer.MyPackage-event:v1",
     "partOfProducts": [
       "customer:product:My.Package:",
     ],
@@ -68,7 +68,7 @@ exports[`defaults packages should return default value if policyLevel does not c
 [
   {
     "description": "Description for My Package",
-    "ordId": "MyPackage:package:sample:v1",
+    "ordId": "sample:package:customer.MyPackage:v1",
     "partOfProducts": [
       "customer:product:My.Package:",
     ],

--- a/__tests__/unittest/__snapshots__/defaults.test.js.snap
+++ b/__tests__/unittest/__snapshots__/defaults.test.js.snap
@@ -41,7 +41,7 @@ exports[`defaults packages should return default value if policyLevel contains s
 [
   {
     "description": "Description for My Package",
-    "ordId": "sample:package:customer.MyPackage-api:v1",
+    "ordId": "customer.sample:package:MyPackage-api:v1",
     "partOfProducts": [
       "customer:product:My.Package:",
     ],
@@ -52,7 +52,7 @@ exports[`defaults packages should return default value if policyLevel contains s
   },
   {
     "description": "Description for My Package",
-    "ordId": "sample:package:customer.MyPackage-event:v1",
+    "ordId": "customer.sample:package:MyPackage-event:v1",
     "partOfProducts": [
       "customer:product:My.Package:",
     ],
@@ -68,7 +68,7 @@ exports[`defaults packages should return default value if policyLevel does not c
 [
   {
     "description": "Description for My Package",
-    "ordId": "sample:package:customer.MyPackage:v1",
+    "ordId": "customer.sample:package:MyPackage:v1",
     "partOfProducts": [
       "customer:product:My.Package:",
     ],

--- a/__tests__/unittest/__snapshots__/templates.test.js.snap
+++ b/__tests__/unittest/__snapshots__/templates.test.js.snap
@@ -42,9 +42,9 @@ exports[`templates fCreateAPIResourceTemplate should create API resource templat
     "extensible": {
       "supported": "no",
     },
-    "ordId": "customer:apiResource:MyService:v1",
+    "ordId": "customer.testNamespace:apiResource:MyService:v1",
     "partOfGroups": [
-      "sap.cds:service:customer:MyService",
+      "sap.cds:service:customer.testNamespace:MyService",
     ],
     "partOfPackage": undefined,
     "releaseStatus": "active",
@@ -84,9 +84,9 @@ exports[`templates fCreateEventResourceTemplate should create API resource templ
   "extensible": {
     "supported": "no",
   },
-  "ordId": "customer:eventResource:MyService:v1",
+  "ordId": "customer.testNamespace:eventResource:MyService:v1",
   "partOfGroups": [
-    "sap.cds:service:customer:MyService",
+    "sap.cds:service:customer.testNamespace:MyService",
   ],
   "partOfPackage": undefined,
   "releaseStatus": "beta",

--- a/__tests__/unittest/__snapshots__/templates.test.js.snap
+++ b/__tests__/unittest/__snapshots__/templates.test.js.snap
@@ -42,9 +42,9 @@ exports[`templates fCreateAPIResourceTemplate should create API resource templat
     "extensible": {
       "supported": "no",
     },
-    "ordId": "customer:apiResource:undefined.MyService:v1",
+    "ordId": "customer:apiResource:MyService:v1",
     "partOfGroups": [
-      "sap.cds:service:customer:undefined.MyService",
+      "sap.cds:service:customer:MyService",
     ],
     "partOfPackage": undefined,
     "releaseStatus": "active",
@@ -84,9 +84,9 @@ exports[`templates fCreateEventResourceTemplate should create API resource templ
   "extensible": {
     "supported": "no",
   },
-  "ordId": "customer:eventResource:undefined.MyService:v1",
+  "ordId": "customer:eventResource:MyService:v1",
   "partOfGroups": [
-    "sap.cds:service:customer:undefined.MyService",
+    "sap.cds:service:customer:MyService",
   ],
   "partOfPackage": undefined,
   "releaseStatus": "beta",

--- a/__tests__/unittest/defaults.test.js
+++ b/__tests__/unittest/defaults.test.js
@@ -40,7 +40,7 @@ describe('defaults', () => {
 
     describe('packages', () => {
         const testGetPackageDataName = 'My Package';
-        const testGetPackageOrdNamespace = 'sample';
+        const testGetPackageOrdNamespace = 'customer.sample';
         it('should return default value if policyLevel contains sap', () => {
             const testPolicyLevel = 'sap:policy';
 

--- a/__tests__/unittest/defaults.test.js
+++ b/__tests__/unittest/defaults.test.js
@@ -40,17 +40,17 @@ describe('defaults', () => {
 
     describe('packages', () => {
         const testGetPackageDataName = 'My Package';
-        const testGetPackageCapNamespace = 'sample';
+        const testGetPackageOrdNamespace = 'sample';
         it('should return default value if policyLevel contains sap', () => {
             const testPolicyLevel = 'sap:policy';
 
-            expect(defaults.packages(testGetPackageDataName, testPolicyLevel, testGetPackageCapNamespace)).toMatchSnapshot();
+            expect(defaults.packages(testGetPackageDataName, testPolicyLevel, testGetPackageOrdNamespace)).toMatchSnapshot();
         });
 
         it('should return default value if policyLevel does not contain sap', () => {
             const testPolicyLevel = 'policy';
 
-            expect(defaults.packages(testGetPackageDataName, testPolicyLevel, testGetPackageCapNamespace)).toMatchSnapshot();
+            expect(defaults.packages(testGetPackageDataName, testPolicyLevel, testGetPackageOrdNamespace)).toMatchSnapshot();
         });
     });
 

--- a/__tests__/unittest/templates.test.js
+++ b/__tests__/unittest/templates.test.js
@@ -32,23 +32,6 @@ describe('templates', () => {
         });
     })
 
-    describe('fReplaceSpecialCharacters', () => {
-        it('should return replaced dot', () => {
-            const testString = 'customer.testNamespace.123';
-            expect(templates.fReplaceSpecialCharacters(testString)).toEqual('customer.testNamespace123');
-        });
-
-        it('should return replaced dash', () => {
-            const testString = 'customer.testNamespace-123';
-            expect(templates.fReplaceSpecialCharacters(testString)).toEqual('customer.testNamespace123');
-        });
-
-        it('should return dash when there is no customer', () => {
-            const testString = 'testNamespace-123';
-            expect(templates.fReplaceSpecialCharacters(testString)).toEqual('testNamespace-123');
-        });
-    })
-
     describe('fCreateGroupsTemplateForService', () => {
         it('should return default value when groupIds do not have groupId', () => {
             const testSrv = 'testServiceName';

--- a/__tests__/unittest/templates.test.js
+++ b/__tests__/unittest/templates.test.js
@@ -55,7 +55,7 @@ describe('templates', () => {
             global.namespace = 'customer';
             const testGroupIds = new Set();
             const testResult = {
-                groupId: 'sap.cds:service:customer:undefined.testServiceName',
+                groupId: 'sap.cds:service:customer:testServiceName',
                 groupTypeId: 'sap.cds:service',
                 title: 'test Service'
             };
@@ -69,7 +69,7 @@ describe('templates', () => {
             global.namespace = 'customer';
             const testGroupIds = new Set();
             const testResult = {
-                groupId: 'sap.cds:service:customer:undefined.testEventName',
+                groupId: 'sap.cds:service:customer:testEventName',
                 groupTypeId: 'sap.cds:service',
                 // TODO: space because of service name missing
                 title: ' Service'
@@ -80,7 +80,7 @@ describe('templates', () => {
         it('should return null when groupIds has groupId', () => {
             const tesEvent = 'testEventName';
             global.namespace = 'customer';
-            const testGroupIds = new Set(['sap.cds:service:customer:undefined.testEventName']);
+            const testGroupIds = new Set(['sap.cds:service:customer:testEventName']);
             const testResult = null;
             expect(templates.fCreateGroupsTemplateForEvent(tesEvent, linkedModel, testGroupIds)).toEqual(testResult);
         });

--- a/__tests__/unittest/templates.test.js
+++ b/__tests__/unittest/templates.test.js
@@ -52,7 +52,7 @@ describe('templates', () => {
     describe('fCreateGroupsTemplateForService', () => {
         it('should return default value when groupIds do not have groupId', () => {
             const testSrv = 'testServiceName';
-            global.namespace = 'customer';
+            global.ordNamespace = 'customer';
             const testGroupIds = new Set();
             const testResult = {
                 groupId: 'sap.cds:service:customer:testServiceName',
@@ -66,7 +66,7 @@ describe('templates', () => {
     describe('fCreateGroupsTemplateForEvent', () => {
         it('should return default value when groupIds do not have groupId', () => {
             const tesEvent = 'testEventName';
-            global.namespace = 'customer';
+            global.ordNamespace = 'customer';
             const testGroupIds = new Set();
             const testResult = {
                 groupId: 'sap.cds:service:customer:testEventName',
@@ -79,7 +79,7 @@ describe('templates', () => {
 
         it('should return null when groupIds has groupId', () => {
             const tesEvent = 'testEventName';
-            global.namespace = 'customer';
+            global.ordNamespace = 'customer';
             const testGroupIds = new Set(['sap.cds:service:customer:testEventName']);
             const testResult = null;
             expect(templates.fCreateGroupsTemplateForEvent(tesEvent, linkedModel, testGroupIds)).toEqual(testResult);
@@ -90,7 +90,7 @@ describe('templates', () => {
         it('should create API resource template correctly', () => {
             const srv = 'MyService';
             const srvDefinition = linkedModel
-            global.namespace = 'customer';
+            global.ordNamespace = 'customer';
             const packageIds = ['package1'];
             expect(templates.fCreateAPIResourceTemplate(srv, srvDefinition, global, packageIds)).toMatchSnapshot();
         });
@@ -100,7 +100,7 @@ describe('templates', () => {
         it('should create API resource template correctly', () => {
             const srv = 'MyService';
             const srvDefinition = linkedModel
-            global.namespace = 'customer';
+            global.ordNamespace = 'customer';
             global.appName = 'testAppName';
             const packageIds = ['package1'];
 

--- a/__tests__/unittest/templates.test.js
+++ b/__tests__/unittest/templates.test.js
@@ -52,10 +52,10 @@ describe('templates', () => {
     describe('fCreateGroupsTemplateForService', () => {
         it('should return default value when groupIds do not have groupId', () => {
             const testSrv = 'testServiceName';
-            global.ordNamespace = 'customer';
+            global.ordNamespace = 'customer.testNamespace';
             const testGroupIds = new Set();
             const testResult = {
-                groupId: 'sap.cds:service:customer:testServiceName',
+                groupId: 'sap.cds:service:customer.testNamespace:testServiceName',
                 groupTypeId: 'sap.cds:service',
                 title: 'test Service'
             };
@@ -66,10 +66,10 @@ describe('templates', () => {
     describe('fCreateGroupsTemplateForEvent', () => {
         it('should return default value when groupIds do not have groupId', () => {
             const tesEvent = 'testEventName';
-            global.ordNamespace = 'customer';
+            global.ordNamespace = 'customer.testNamespace';
             const testGroupIds = new Set();
             const testResult = {
-                groupId: 'sap.cds:service:customer:testEventName',
+                groupId: 'sap.cds:service:customer.testNamespace:testEventName',
                 groupTypeId: 'sap.cds:service',
                 // TODO: space because of service name missing
                 title: ' Service'
@@ -79,8 +79,8 @@ describe('templates', () => {
 
         it('should return null when groupIds has groupId', () => {
             const tesEvent = 'testEventName';
-            global.ordNamespace = 'customer';
-            const testGroupIds = new Set(['sap.cds:service:customer:testEventName']);
+            global.ordNamespace = 'customer.testNamespace';
+            const testGroupIds = new Set(['sap.cds:service:customer.testNamespace:testEventName']);
             const testResult = null;
             expect(templates.fCreateGroupsTemplateForEvent(tesEvent, linkedModel, testGroupIds)).toEqual(testResult);
         });
@@ -90,7 +90,7 @@ describe('templates', () => {
         it('should create API resource template correctly', () => {
             const srv = 'MyService';
             const srvDefinition = linkedModel
-            global.ordNamespace = 'customer';
+            global.ordNamespace = 'customer.testNamespace';
             const packageIds = ['package1'];
             expect(templates.fCreateAPIResourceTemplate(srv, srvDefinition, global, packageIds)).toMatchSnapshot();
         });
@@ -100,7 +100,7 @@ describe('templates', () => {
         it('should create API resource template correctly', () => {
             const srv = 'MyService';
             const srvDefinition = linkedModel
-            global.ordNamespace = 'customer';
+            global.ordNamespace = 'customer.testNamespace';
             global.appName = 'testAppName';
             const packageIds = ['package1'];
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -33,10 +33,10 @@ module.exports = {
     },
   ],
   groupTypeId: "sap.cds:service",
-  packages: function getPackageData (name, policyLevel,capNamespace) {
+  packages: function getPackageData (name, policyLevel,namespace) {
     function createPackage(name, tag) {
       return {
-        ordId: `${regexWithRemoval(name)}:package:${capNamespace}${tag}`,
+        ordId: `${regexWithRemoval(name)}:package:${namespace}${tag}`,
         title: nameWithSpaces(name),
         shortDescription: "Short description for " + nameWithSpaces(name),
         description: "Description for " + nameWithSpaces(name),

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -42,7 +42,7 @@ module.exports = {
     packages: function getPackageData(name, policyLevel, ordNamespace) {
         function createPackage(name, tag) {
             return {
-                ordId: `customer.${regexWithRemoval(ordNamespace)}:package:${regexWithRemoval(name
+                ordId: `${ordNamespace}:package:${regexWithRemoval(name
                 )}${tag}`,
                 title: nameWithSpaces(name),
                 shortDescription:

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -42,8 +42,7 @@ module.exports = {
     packages: function getPackageData(name, policyLevel, ordNamespace) {
         function createPackage(name, tag) {
             return {
-                ordId: `${ordNamespace}:package:customer.${regexWithRemoval(
-                    name
+                ordId: `${ordNamespace}:package:${regexWithRemoval(name
                 )}${tag}`,
                 title: nameWithSpaces(name),
                 shortDescription:

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,74 +1,85 @@
-
 const regexWithRemoval = (name) => {
-  if(name){
-    return name.replace(/[^a-zA-Z0-9]/g,'');
-  }
-}
+    if (name) {
+        return name.replace(/[^a-zA-Z0-9]/g, "");
+    }
+};
 
 const nameWithDot = (name) => {
-  return regexWithRemoval(name.charAt(0)) + name.slice(1, name.length).replace(/[^a-zA-Z0-9]/g,'.');
-}
+    return (
+        regexWithRemoval(name.charAt(0)) +
+        name.slice(1, name.length).replace(/[^a-zA-Z0-9]/g, ".")
+    );
+};
 
 const nameWithSpaces = (name) => {
-  return regexWithRemoval(name.charAt(0)) + name.slice(1, name.length).replace(/[^a-zA-Z0-9]/g,' ');
-}
+    return (
+        regexWithRemoval(name.charAt(0)) +
+        name.slice(1, name.length).replace(/[^a-zA-Z0-9]/g, " ")
+    );
+};
 
-const defaultProductOrdId = (name) => `customer:product:${nameWithDot(name)}:`
+const defaultProductOrdId = (name) => `customer:product:${nameWithDot(name)}:`;
 
 /**
  * Module containing default configuration for ORD Document.
  * @module defaults
  */
 module.exports = {
-  $schema: "https://sap.github.io/open-resource-discovery/spec-v1/interfaces/Document.schema.json",
-  openResourceDiscovery: "1.9",
-  policyLevel: "none",
-  description: "this is an application description",
-  products: (name) => [
-    {
-      ordId: defaultProductOrdId(name),
-      title: nameWithSpaces(name),
-      shortDescription: "Description for " +  nameWithSpaces(name),
-      vendor: "customer:vendor:customer:",
-    },
-  ],
-  groupTypeId: "sap.cds:service",
-  packages: function getPackageData (name, policyLevel,namespace) {
-    function createPackage(name, tag) {
-      return {
-        ordId: `${regexWithRemoval(name)}:package:${namespace}${tag}`,
-        title: nameWithSpaces(name),
-        shortDescription: "Short description for " + nameWithSpaces(name),
-        description: "Description for " + nameWithSpaces(name),
-        version: "1.0.0",
-        partOfProducts: [defaultProductOrdId(name)],
-        vendor: "customer:vendor:Customer:"
-      };
-    }
+    $schema:
+        "https://sap.github.io/open-resource-discovery/spec-v1/interfaces/Document.schema.json",
+    openResourceDiscovery: "1.9",
+    policyLevel: "none",
+    description: "this is an application description",
+    products: (name) => [
+        {
+            ordId: defaultProductOrdId(name),
+            title: nameWithSpaces(name),
+            shortDescription: "Description for " + nameWithSpaces(name),
+            vendor: "customer:vendor:customer:",
+        },
+    ],
+    groupTypeId: "sap.cds:service",
+    packages: function getPackageData(name, policyLevel, ordNamespace) {
+        function createPackage(name, tag) {
+            return {
+                ordId: `${ordNamespace}:package:customer.${regexWithRemoval(
+                    name
+                )}${tag}`,
+                title: nameWithSpaces(name),
+                shortDescription:
+                    "Short description for " + nameWithSpaces(name),
+                description: "Description for " + nameWithSpaces(name),
+                version: "1.0.0",
+                partOfProducts: [defaultProductOrdId(name)],
+                vendor: "customer:vendor:Customer:",
+            };
+        }
 
-    if(policyLevel.split(':')[0].toLowerCase() === 'sap') {
-        return [createPackage(name, "-api:v1"), createPackage(name, "-event:v1")];
-    }
-    else {
-        return [createPackage(name, ":v1")];
-    }
-  },
-  consumptionBundles: (name) => [
-    {
-      ordId: `${regexWithRemoval(name)}:consumptionBundle:unknown:v1`,
-      version: "1.0.0",
-      title: "Unprotected resources",
-      shortDescription:
-        "If we have another protected API then it will be another object",
-      description:
-        "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+        if (policyLevel.split(":")[0].toLowerCase() === "sap") {
+            return [
+                createPackage(name, "-api:v1"),
+                createPackage(name, "-event:v1"),
+            ];
+        } else {
+            return [createPackage(name, ":v1")];
+        }
     },
-  ],
+    consumptionBundles: (name) => [
+        {
+            ordId: `${regexWithRemoval(name)}:consumptionBundle:unknown:v1`,
+            version: "1.0.0",
+            title: "Unprotected resources",
+            shortDescription:
+                "If we have another protected API then it will be another object",
+            description:
+                "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+        },
+    ],
 
     apiResources: [],
     eventResources: [],
     entityTypes: [],
-    baseTemplate : {
+    baseTemplate: {
         openResourceDiscoveryV1: {
             documents: [
                 {
@@ -81,5 +92,5 @@ module.exports = {
                 },
             ],
         },
-    }
-}
+    },
+};

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -42,7 +42,7 @@ module.exports = {
     packages: function getPackageData(name, policyLevel, ordNamespace) {
         function createPackage(name, tag) {
             return {
-                ordId: `${ordNamespace}:package:${regexWithRemoval(name
+                ordId: `customer.${regexWithRemoval(ordNamespace)}:package:${regexWithRemoval(name
                 )}${tag}`,
                 title: nameWithSpaces(name),
                 shortDescription:

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -31,7 +31,7 @@ const fInitializeGlobal = (csn) => {
 
     // namespace variable value if present in cdsrc.json take it there or else from package.json
     //if cdsrc.json does not have applicationNamespace, then use just the namespace
-    const ordNamespace = cds.env["ord"]?.namespace || 'customer.' + packageName.replace(/[^\w/]/g, "").replace(/\//, ".");
+    const ordNamespace = cds.env["ord"]?.namespace || packageName.replace(/[^\w/]/g, "").replace(/\//, ".");
     const eventApplicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
 
     if (eventApplicationNamespace && fGetNamespaceComponents(ordNamespace) !== fGetNamespaceComponents(eventApplicationNamespace)) {

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -31,10 +31,10 @@ const fInitializeGlobal = (csn) => {
 
     // namespace variable value if present in cdsrc.json take it there or else from package.json
     //if cdsrc.json does not have applicationNamespace, then use just the namespace
-    const namespace = cds.env["ord"]?.namespace || packageName.replace(/[^\w/]/g, "").replace(/\//, ".");
-    const applicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
+    const ordNamespace = cds.env["ord"]?.namespace || packageName.replace(/[^\w/]/g, "").replace(/\//, ".");
+    const eventApplicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
 
-    if (applicationNamespace && fGetNamespaceComponents(namespace) !== fGetNamespaceComponents(applicationNamespace)) {
+    if (eventApplicationNamespace && fGetNamespaceComponents(ordNamespace) !== fGetNamespaceComponents(eventApplicationNamespace)) {
         console.warn('ORD and AsyncAPI namespaces should be the same.');
     }
 
@@ -64,8 +64,8 @@ const fInitializeGlobal = (csn) => {
         aEvents,
         aServices,
         aODMEntity,
-        namespace,
-        applicationNamespace,
+        ordNamespace,
+        eventApplicationNamespace,
         packageName
     }
 }
@@ -95,7 +95,7 @@ const fGetDescription = (global) => global.env?.description || defaults.descript
  * Retrieves the products.
  * Hierarchy to check data: cdsrc.json > defaults
  * @returns {Array<object>} The products array.
- * if global.namespace is defined in cdsrc.json, then use it, else use the appName from package.json
+ * if global.ordNamespace is defined in cdsrc.json, then use it, else use the appName from package.json
  */
 const fGetProducts = (global) => global.env?.products || defaults.products(global.packageName);
 
@@ -116,7 +116,7 @@ const fGetGroups = (csn, global) => {
  * Hierarchy to check data: cdsrc.json > defaults.
  * @returns {Array<object>} The packages array.
  */
-const fGetPackages = (policyLevel,global) => global.env?.packages || (global.aEvents.length) ? defaults.packages(global.appName,policyLevel,global.namespace) : defaults.packages(global.appName,policyLevel,global.namespace).slice(0, 1)
+const fGetPackages = (policyLevel,global) => global.env?.packages || (global.aEvents.length) ? defaults.packages(global.appName,policyLevel,global.ordNamespace) : defaults.packages(global.appName,policyLevel,global.ordNamespace).slice(0, 1)
 
 /**
  * Retrieves the API Resources
@@ -161,9 +161,9 @@ const fGetEventResources = (csn, global, packageIds) => {
 module.exports = (csn) => {
     const linkedCsn = cds.linked(csn);
     Object.assign(global, fInitializeGlobal(linkedCsn));
-    const validateSystemNamespace = new RegExp(`^${global.applicationNamespace}\\.[^.]+\\..+$`);
-    if (global.namespace === undefined && !validateSystemNamespace.test(global.namespace)) {
-        let error = new Error(`Namespace is not defined in cdsrc.json or it is not in the format of ${global.applicationNamespace}.<appName>.<service>`);
+    const validateSystemNamespace = new RegExp(`^${global.eventApplicationNamespace}\\.[^.]+\\..+$`);
+    if (global.ordNamespace === undefined && !validateSystemNamespace.test(global.ordNamespace)) {
+        let error = new Error(`Namespace is not defined in cdsrc.json or it is not in the format of ${global.eventApplicationNamespace}.<appName>.<service>`);
         console.error('Namespace error:', error.message);
         throw error;
     }

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -6,8 +6,8 @@ const {
     fCreateAPIResourceTemplate,
     fCreateEventResourceTemplate,
     fCreateGroupsTemplateForService,
-    fCreateEntityTypeTemplate
-} = require('./templates');
+    fCreateEntityTypeTemplate,
+} = require("./templates");
 
 /**
  * Initializes global object based on package.json and CSN object.
@@ -15,7 +15,7 @@ const {
  * @returns {Object} An object containing global variables.
  */
 const fInitializeGlobal = (csn) => {
-    let packagejsonPath = join(cds.root,'package.json')
+    let packagejsonPath = join(cds.root, "package.json");
     let packageJson;
     if (exists(packagejsonPath)) {
         packageJson = require(packagejsonPath);
@@ -31,32 +31,41 @@ const fInitializeGlobal = (csn) => {
 
     // namespace variable value if present in cdsrc.json take it there or else from package.json
     //if cdsrc.json does not have applicationNamespace, then use just the namespace
-    const ordNamespace = cds.env["ord"]?.namespace || packageName.replace(/[^\w/]/g, "").replace(/\//, ".");
-    const eventApplicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
+    const vendorNamespace = "customer";
+    const ordNamespace =
+        cds.env["ord"]?.namespace ||
+        `${vendorNamespace}.${packageName.replace(/[^a-zA-Z0-9]/g, "")}`;
+    const eventApplicationNamespace =
+        cds.env?.export?.asyncapi?.applicationNamespace;
 
-    if (eventApplicationNamespace && fGetNamespaceComponents(ordNamespace) !== fGetNamespaceComponents(eventApplicationNamespace)) {
-        console.warn('ORD and AsyncAPI namespaces should be the same.');
+    if (
+        eventApplicationNamespace &&
+        ordNamespace !== eventApplicationNamespace
+    ) {
+        console.warn("ORD and AsyncAPI namespaces should be the same.");
     }
 
     const fEventFilter = (keyDefinition) => keyDefinition.kind === "event";
-    const fServicesFilter = (keyDefinition) => keyDefinition.kind === "service" && !keyDefinition['@cds.external'];
+    const fServicesFilter = (keyDefinition) =>
+        keyDefinition.kind === "service" && !keyDefinition["@cds.external"];
     const fODMEntityFilter = (key, keyDefinition) => {
-        return keyDefinition.kind === "entity"
-            && !key.includes(".texts")
-            && keyDefinition["@ODM.entityName"];
-    }
+        return (
+            keyDefinition.kind === "entity" &&
+            !key.includes(".texts") &&
+            keyDefinition["@ODM.entityName"]
+        );
+    };
 
     aModelKeys.forEach((key) => {
         const keyDefinition = csn.definitions[key];
-        if(fServicesFilter(keyDefinition)){
+        if (fServicesFilter(keyDefinition)) {
             aServices.push(key);
-        } else if(fODMEntityFilter(key, keyDefinition)) {
+        } else if (fODMEntityFilter(key, keyDefinition)) {
             aODMEntity.push(fCreateEntityTypeTemplate(keyDefinition));
-        } else if(fEventFilter(keyDefinition)){
+        } else if (fEventFilter(keyDefinition)) {
             aEvents.push(key);
         }
     });
-
 
     return {
         env: cds.env["ord"],
@@ -66,30 +75,25 @@ const fInitializeGlobal = (csn) => {
         aODMEntity,
         ordNamespace,
         eventApplicationNamespace,
-        packageName
-    }
-}
-
-/**
- * Retrieves first two components of the namespace.
- * @param {string} namespace
- * @returns {string} The first two components of the namespace.
- */
-const fGetNamespaceComponents = (namespace) => namespace.split('.').slice(0, 2).join('.');
+        packageName,
+    };
+};
 
 /**
  * Retrieves the policy level.
  * Hierarchy to check data: cdsrc.json > defaults
  * @returns {string} The policy level.
  */
-const fGetPolicyLevel = (global) => global.env?.policyLevel || defaults.policyLevel;
+const fGetPolicyLevel = (global) =>
+    global.env?.policyLevel || defaults.policyLevel;
 
 /**
  * Retrieves the root level ORD document description.
  * Hierarchy to check data: cdsrc.json > defaults
  * @returns {string} The ORD document description.
  */
-const fGetDescription = (global) => global.env?.description || defaults.description;
+const fGetDescription = (global) =>
+    global.env?.description || defaults.description;
 
 /**
  * Retrieves the products.
@@ -97,7 +101,8 @@ const fGetDescription = (global) => global.env?.description || defaults.descript
  * @returns {Array<object>} The products array.
  * if global.ordNamespace is defined in cdsrc.json, then use it, else use the appName from package.json
  */
-const fGetProducts = (global) => global.env?.products || defaults.products(global.packageName);
+const fGetProducts = (global) =>
+    global.env?.products || defaults.products(global.packageName);
 
 /**
  * Retrieves the groups that services belongs to.
@@ -107,8 +112,10 @@ const fGetProducts = (global) => global.env?.products || defaults.products(globa
  */
 const fGetGroups = (csn, global) => {
     return global.aServices
-            .map((srv) => fCreateGroupsTemplateForService(srv, csn.definitions[srv]))
-            .filter((resource) => resource !== null && resource !== undefined);
+        .map((srv) =>
+            fCreateGroupsTemplateForService(srv, csn.definitions[srv])
+        )
+        .filter((resource) => resource !== null && resource !== undefined);
 };
 
 /**
@@ -116,7 +123,12 @@ const fGetGroups = (csn, global) => {
  * Hierarchy to check data: cdsrc.json > defaults.
  * @returns {Array<object>} The packages array.
  */
-const fGetPackages = (policyLevel,global) => global.env?.packages || (global.aEvents.length) ? defaults.packages(global.appName,policyLevel,global.ordNamespace) : defaults.packages(global.appName,policyLevel,global.ordNamespace).slice(0, 1)
+const fGetPackages = (policyLevel, global) =>
+    global.env?.packages || global.aEvents.length
+        ? defaults.packages(global.appName, policyLevel, global.ordNamespace)
+        : defaults
+              .packages(global.appName, policyLevel, global.ordNamespace)
+              .slice(0, 1);
 
 /**
  * Retrieves the API Resources
@@ -124,18 +136,21 @@ const fGetPackages = (policyLevel,global) => global.env?.packages || (global.aEv
  * @param {Object} csn object
  * @returns {Array<object>} The API Resources array.
  */
-const fGetAPIResources = (csn, global,packageIds) => {
-  const apiResources = [];
-  global.aServices.forEach((srv) => {
-    fCreateAPIResourceTemplate(srv, csn.definitions[srv], global,packageIds)?.forEach(
-      (resource) => {
-        if (resource !== null && resource !== undefined) {
-          apiResources.push(resource);
-        }
-      }
-    );
-  });
-  return apiResources;
+const fGetAPIResources = (csn, global, packageIds) => {
+    const apiResources = [];
+    global.aServices.forEach((srv) => {
+        fCreateAPIResourceTemplate(
+            srv,
+            csn.definitions[srv],
+            global,
+            packageIds
+        )?.forEach((resource) => {
+            if (resource !== null && resource !== undefined) {
+                apiResources.push(resource);
+            }
+        });
+    });
+    return apiResources;
 };
 
 /**
@@ -145,53 +160,78 @@ const fGetAPIResources = (csn, global,packageIds) => {
  * @returns {Array<object>} The Event Resources array.
  */
 const fGetEventResources = (csn, global, packageIds) => {
-    if(global.aEvents.length === 0) return []
+    if (global.aEvents.length === 0) return [];
 
-    const services = []
+    const services = [];
     for (const serviceName of global.aServices) {
-        const hasEvents = global.aEvents.find((eventName) => eventName.startsWith(serviceName));
+        const hasEvents = global.aEvents.find((eventName) =>
+            eventName.startsWith(serviceName)
+        );
         if (hasEvents) {
-            services.push(serviceName)
+            services.push(serviceName);
         }
     }
 
-    return services.map((serviceName) => fCreateEventResourceTemplate(serviceName, csn.definitions[serviceName], global, packageIds))
+    return services.map((serviceName) =>
+        fCreateEventResourceTemplate(
+            serviceName,
+            csn.definitions[serviceName],
+            global,
+            packageIds
+        )
+    );
 };
 
 module.exports = (csn) => {
     const linkedCsn = cds.linked(csn);
     Object.assign(global, fInitializeGlobal(linkedCsn));
-    const validateSystemNamespace = new RegExp(`^${global.eventApplicationNamespace}\\.[^.]+\\..+$`);
-    if (global.ordNamespace === undefined && !validateSystemNamespace.test(global.ordNamespace)) {
-        let error = new Error(`Namespace is not defined in cdsrc.json or it is not in the format of ${global.eventApplicationNamespace}.<appName>.<service>`);
-        console.error('Namespace error:', error.message);
+    const validateSystemNamespace = new RegExp(
+        `^${global.eventApplicationNamespace}\\.[^.]+\\..+$`
+    );
+    if (
+        global.ordNamespace === undefined &&
+        !validateSystemNamespace.test(global.ordNamespace)
+    ) {
+        let error = new Error(
+            `Namespace is not defined in cdsrc.json or it is not in the format of ${global.eventApplicationNamespace}.<appName>.<service>`
+        );
+        console.error("Namespace error:", error.message);
         throw error;
     }
 
-    let oReturn = { $schema: "https://sap.github.io/open-resource-discovery/spec-v1/interfaces/Document.schema.json",
+    let oReturn = {
+        $schema:
+            "https://sap.github.io/open-resource-discovery/spec-v1/interfaces/Document.schema.json",
         openResourceDiscovery: "1.9",
         policyLevel: fGetPolicyLevel(global),
         description: fGetDescription(global),
         products: fGetProducts(global),
         groups: fGetGroups(linkedCsn, global),
     };
-    if(fGetAPIResources(linkedCsn, global).length > 0 && (fGetEventResources(linkedCsn, global).length>0)){
+    if (
+        fGetAPIResources(linkedCsn, global).length > 0 &&
+        fGetEventResources(linkedCsn, global).length > 0
+    ) {
         oReturn.packages = fGetPackages(oReturn.policyLevel, global);
     }
 
     // check if oReturn.packages is defined and extract the ordId from the packages and store in a set
     let packageIds = new Set();
-    if(oReturn.packages){
+    if (oReturn.packages) {
         oReturn.packages.forEach((pkg) => {
             packageIds.add(pkg.ordId);
         });
     }
     oReturn = {
         ...oReturn,
-        apiResources: fGetAPIResources(linkedCsn, global,packageIds),
+        apiResources: fGetAPIResources(linkedCsn, global, packageIds),
     };
-    if(fGetEventResources(linkedCsn, global,packageIds).length > 0) {
-        oReturn.eventResources= fGetEventResources(linkedCsn, global,packageIds);
+    if (fGetEventResources(linkedCsn, global, packageIds).length > 0) {
+        oReturn.eventResources = fGetEventResources(
+            linkedCsn,
+            global,
+            packageIds
+        );
     }
     return oReturn;
-}
+};

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -29,8 +29,7 @@ const fInitializeGlobal = (csn) => {
     const aServices = [];
     const aODMEntity = [];
 
-    const capNamespace = csn.namespace;
-     // namespace variable value if present in cdsrc.json take it there or else from package.json
+    // namespace variable value if present in cdsrc.json take it there or else from package.json
     //if cdsrc.json does not have applicationNamespace, then use just the namespace
     const namespace = cds.env["ord"]?.namespace || packageName.replace(/[^\w/]/g, "").replace(/\//, ".");
     const applicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
@@ -43,7 +42,6 @@ const fInitializeGlobal = (csn) => {
     const fServicesFilter = (keyDefinition) => keyDefinition.kind === "service" && !keyDefinition['@cds.external'];
     const fODMEntityFilter = (key, keyDefinition) => {
         return keyDefinition.kind === "entity"
-            && key.includes(capNamespace)
             && !key.includes(".texts")
             && keyDefinition["@ODM.entityName"];
     }
@@ -62,7 +60,6 @@ const fInitializeGlobal = (csn) => {
 
     return {
         env: cds.env["ord"],
-        capNamespace,
         appName,
         aEvents,
         aServices,
@@ -119,7 +116,7 @@ const fGetGroups = (csn, global) => {
  * Hierarchy to check data: cdsrc.json > defaults.
  * @returns {Array<object>} The packages array.
  */
-const fGetPackages = (policyLevel,global) => global.env?.packages || (global.aEvents.length) ? defaults.packages(global.appName,policyLevel,global.capNamespace) : defaults.packages(global.appName,policyLevel,global.capNamespace).slice(0, 1)
+const fGetPackages = (policyLevel,global) => global.env?.packages || (global.aEvents.length) ? defaults.packages(global.appName,policyLevel,global.namespace) : defaults.packages(global.appName,policyLevel,global.namespace).slice(0, 1)
 
 /**
  * Retrieves the API Resources

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -31,7 +31,7 @@ const fInitializeGlobal = (csn) => {
 
     // namespace variable value if present in cdsrc.json take it there or else from package.json
     //if cdsrc.json does not have applicationNamespace, then use just the namespace
-    const ordNamespace = cds.env["ord"]?.namespace || packageName.replace(/[^\w/]/g, "").replace(/\//, ".");
+    const ordNamespace = cds.env["ord"]?.namespace || 'customer.' + packageName.replace(/[^\w/]/g, "").replace(/\//, ".");
     const eventApplicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
 
     if (eventApplicationNamespace && fGetNamespaceComponents(ordNamespace) !== fGetNamespaceComponents(eventApplicationNamespace)) {

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -28,13 +28,13 @@ const fInitializeGlobal = (csn) => {
     const aEvents = [];
     const aServices = [];
     const aODMEntity = [];
-    
+
     const capNamespace = csn.namespace;
      // namespace variable value if present in cdsrc.json take it there or else from package.json
     //if cdsrc.json does not have applicationNamespace, then use just the namespace
     const namespace = cds.env["ord"]?.namespace || packageName.replace(/[^\w/]/g, "").replace(/\//, ".");
     const applicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
-    
+
     if (applicationNamespace && fGetNamespaceComponents(namespace) !== fGetNamespaceComponents(applicationNamespace)) {
         console.warn('ORD and AsyncAPI namespaces should be the same.');
     }
@@ -105,7 +105,7 @@ const fGetProducts = (global) => global.env?.products || defaults.products(globa
 /**
  * Retrieves the groups that services belongs to.
  * Gets list of groups from CDS runtime object.
- * @param {Object} csn object 
+ * @param {Object} csn object
  * @returns {Array<object>} The groups array.
  */
 const fGetGroups = (csn, global) => {
@@ -116,7 +116,7 @@ const fGetGroups = (csn, global) => {
 
 /**
  * Retrieves the packages.
- * Hierarchy to check data: cdsrc.json > defaults
+ * Hierarchy to check data: cdsrc.json > defaults. TODO: Check if this is still valid.
  * @returns {Array<object>} The packages array.
  */
 const fGetPackages = (policyLevel,global) => global.env?.packages || (global.aEvents.length) ? defaults.packages(global.namespace,policyLevel,global.capNamespace) : defaults.packages(global.namespace,policyLevel,global.capNamespace).slice(0, 1)

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -116,7 +116,7 @@ const fGetGroups = (csn, global) => {
 
 /**
  * Retrieves the packages.
- * Hierarchy to check data: cdsrc.json > defaults. TODO: Check if this is still valid.
+ * Hierarchy to check data: cdsrc.json > defaults.
  * @returns {Array<object>} The packages array.
  */
 const fGetPackages = (policyLevel,global) => global.env?.packages || (global.aEvents.length) ? defaults.packages(global.appName,policyLevel,global.capNamespace) : defaults.packages(global.appName,policyLevel,global.capNamespace).slice(0, 1)

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -1,13 +1,6 @@
 const defaults = require("./defaults");
 const cds = require("@sap/cds");
 
-const fReplaceSpecialCharacters = (namespace) => {
-  return namespace.replace(
-    /customer\.(.+)/,
-    (match, group1) => "customer." + group1.replace(/[^a-zA-Z0-9]/g, "")
-  );
-};
-
 /**
  * Reads the ORD (Open Resource Discovery) annotation from a given service definition object and returns them as an object.
  *
@@ -80,12 +73,10 @@ function _getGroupID(
   isService = true
 ) {
   if (isService) {
-    return `${groupTypeId}:${fReplaceSpecialCharacters(
-      global.ordNamespace
-    )}:${fullyQualifiedName}`;
+    return `${groupTypeId}:${global.ordNamespace}:${fullyQualifiedName}`;
   } else {
     return (
-      `${groupTypeId}:${fReplaceSpecialCharacters(global.ordNamespace)}:` +
+      `${groupTypeId}:${global.ordNamespace}:` +
       `${fullyQualifiedName.slice(0, fullyQualifiedName.lastIndexOf("."))}`
     );
   }
@@ -205,9 +196,7 @@ const fCreateAPIResourceTemplate = (serviceName, serviceDefinition, global, pack
       }
 
       let obj = {
-        ordId: `${fReplaceSpecialCharacters(
-          global.ordNamespace
-        )}:apiResource:${serviceName}:v1`,
+        ordId: `${global.ordNamespace}:apiResource:${serviceName}:v1`,
         title:
           ordExtensions.title ??
           serviceDefinition["@title"] ??
@@ -220,7 +209,7 @@ const fCreateAPIResourceTemplate = (serviceName, serviceDefinition, global, pack
           serviceName,
         version: ordExtensions.version ?? "1.0.0",
         visibility: ordExtensions.visibility ?? "public",
-        partOfPackage: _getPackageID('customer.' + global.ordNamespace.replace(/[^a-zA-Z0-9]/g, ""), packageIds, "api"),
+        partOfPackage: _getPackageID(global.ordNamespace, packageIds, "api"),
         partOfGroups: [_getGroupID(serviceName, defaults.groupTypeId, global)],
         releaseStatus: ordExtensions.active ?? "active",
         apiProtocol:
@@ -242,36 +231,34 @@ const fCreateAPIResourceTemplate = (serviceName, serviceDefinition, global, pack
 /**
  * This is a template function to create Event Resource object for Event Resource Array.
  *
- * @param {string} srv The name of the event.
- * @param {object} srvDefinition The definition of the event.
+ * @param {string} eventName The name of the event.
+ * @param {object} eventDefinition The definition of the event.
  * @returns {Object} An object for the Event Resource.
  */
 // TODO: wrong name srvDefinition, should be model
-const fCreateEventResourceTemplate = (srv, srvDefinition, global,packageIds) => {
-  const ordExtensions = fReadORDExtensions(srvDefinition);
+const fCreateEventResourceTemplate = (eventName, eventDefinition, global,packageIds) => {
+  const ordExtensions = fReadORDExtensions(eventDefinition);
   return {
-    ordId: `${fReplaceSpecialCharacters(
-      global.ordNamespace
-    )}:eventResource:${srv}:v1`,
+    ordId: `${global.ordNamespace}:eventResource:${eventName}:v1`,
     title:
       ordExtensions.title ??
-      srvDefinition["@title"] ??
-      srvDefinition["@Common.Label"] ??
+      eventDefinition["@title"] ??
+      eventDefinition["@Common.Label"] ??
       `ODM ${global.appName.replace(/[^a-zA-Z0-9]/g, "")} Events`,
     shortDescription: ordExtensions.shortDescription ?? "Example ODM Event",
     description:  ordExtensions.description ??
-                  srvDefinition['@description'] ?? srvDefinition['@Core.Description'] ??
+                  eventDefinition['@description'] ?? eventDefinition['@Core.Description'] ??
                   "CAP Event resource describing events / messages.",
     version:  ordExtensions.version ?? "1.0.0",
     releaseStatus:  ordExtensions.releaseStatus ?? "beta",
-    partOfPackage: _getPackageID('customer.' + global.ordNamespace.replace(/[^a-zA-Z0-9]/g, ""),packageIds,'event'),
-    partOfGroups: [_getGroupID(srv, defaults.groupTypeId, global, false)],
+    partOfPackage: _getPackageID(global.ordNamespace, packageIds,'event'),
+    partOfGroups: [_getGroupID(eventName, defaults.groupTypeId, global, false)],
     visibility: ordExtensions.visibility ?? "public",
     resourceDefinitions: [
       {
         type: "asyncapi-v2",
         mediaType: "application/json",
-        url: `/.well-known/open-resource-discovery/v1/api-metadata/${srv}.asyncapi2.json`,
+        url: `/.well-known/open-resource-discovery/v1/api-metadata/${eventName}.asyncapi2.json`,
         accessStrategies: [
           {
             type: "open",
@@ -350,6 +337,5 @@ module.exports = {
   fCreateEventResourceTemplate,
 
   // TODO: remove these functions after finished testing, this is temporary for unittesting
-  checkEntityFunctionAction,
-  fReplaceSpecialCharacters
+  checkEntityFunctionAction
 };

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -110,25 +110,25 @@ function _getTitleFromServiceName(srv) {
 /**
  * This is a template function to create group object of a service for groups array in ORD doc.
  *
- * @param {string} srv The name of the service.
+ * @param {string} srvName The name of the service.
  * @param {object} srvDefinition The definition of the service
  * @param {Set} groupIds A set of group ids.
  * @returns {Object} A group object.
  */
-const fCreateGroupsTemplateForService = (srv, srvDefinition) => {
+const fCreateGroupsTemplateForService = (srvName, srvDefinition) => {
     const ordExtensions = fReadORDExtensions(srvDefinition);
 
     if(!srvDefinition) {
-      console.warn("Unable to find service definition:", srv)
+      console.warn("Unable to find service definition:", srvName)
       return undefined
     }
 
     if (srvDefinition && checkEntityFunctionAction(srvDefinition, global).length > 0) {
-      let groupId = _getGroupID(srv, defaults.groupTypeId);
+      let groupId = _getGroupID(srvName, defaults.groupTypeId);
       return {
           groupId: groupId,
           groupTypeId: `${defaults.groupTypeId}`,
-          title: ordExtensions.title ?? _getTitleFromServiceName(srv)
+          title: ordExtensions.title ?? _getTitleFromServiceName(srvName)
       };
     }
   }

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -220,7 +220,7 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
           srv,
         version: ordExtensions.version ?? "1.0.0",
         visibility: ordExtensions.visibility ?? "public",
-        partOfPackage: _getPackageID(global.capNamespace, packageIds, "api"),
+        partOfPackage: _getPackageID(global.namespace, packageIds, "api"),
         partOfGroups: [_getGroupID(srv, defaults.groupTypeId, global)],
         releaseStatus: ordExtensions.active ?? "active",
         apiProtocol:
@@ -264,7 +264,7 @@ const fCreateEventResourceTemplate = (srv, srvDefinition, global,packageIds) => 
                   "CAP Event resource describing events / messages.",
     version:  ordExtensions.version ?? "1.0.0",
     releaseStatus:  ordExtensions.releaseStatus ?? "beta",
-    partOfPackage: _getPackageID(global.capNamespace,packageIds,'event'),
+    partOfPackage: _getPackageID(global.namespace,packageIds,'event'),
     partOfGroups: [_getGroupID(srv, defaults.groupTypeId, global, false)],
     visibility: ordExtensions.visibility ?? "public",
     resourceDefinitions: [
@@ -326,7 +326,7 @@ function checkEntityFunctionAction(srvDefinition, global) {
  * This is a function to get the corresponding package ordId mapped to the service.
  */
 
-function _getPackageID(capNamespace, packageIds, apiOrEvent) {
+function _getPackageID(namespace, packageIds, apiOrEvent) {
   if (packageIds instanceof Set) {
     const packageArray = Array.from(packageIds);
 
@@ -338,7 +338,7 @@ function _getPackageID(capNamespace, packageIds, apiOrEvent) {
       if (eventPackage) return eventPackage;
     }
 
-    return packageArray.find(pkg => pkg.includes(capNamespace));
+    return packageArray.find(pkg => pkg.includes(namespace));
   }
 }
 

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -220,7 +220,7 @@ const fCreateAPIResourceTemplate = (serviceName, serviceDefinition, global, pack
           serviceName,
         version: ordExtensions.version ?? "1.0.0",
         visibility: ordExtensions.visibility ?? "public",
-        partOfPackage: _getPackageID(global.ordNamespace, packageIds, "api"),
+        partOfPackage: _getPackageID('customer.' + global.ordNamespace.replace(/[^a-zA-Z0-9]/g, ""), packageIds, "api"),
         partOfGroups: [_getGroupID(serviceName, defaults.groupTypeId, global)],
         releaseStatus: ordExtensions.active ?? "active",
         apiProtocol:
@@ -264,7 +264,7 @@ const fCreateEventResourceTemplate = (srv, srvDefinition, global,packageIds) => 
                   "CAP Event resource describing events / messages.",
     version:  ordExtensions.version ?? "1.0.0",
     releaseStatus:  ordExtensions.releaseStatus ?? "beta",
-    partOfPackage: _getPackageID(global.ordNamespace,packageIds,'event'),
+    partOfPackage: _getPackageID('customer.' + global.ordNamespace.replace(/[^a-zA-Z0-9]/g, ""),packageIds,'event'),
     partOfGroups: [_getGroupID(srv, defaults.groupTypeId, global, false)],
     visibility: ordExtensions.visibility ?? "public",
     resourceDefinitions: [

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -110,25 +110,25 @@ function _getTitleFromServiceName(srv) {
 /**
  * This is a template function to create group object of a service for groups array in ORD doc.
  *
- * @param {string} srvName The name of the service.
- * @param {object} srvDefinition The definition of the service
+ * @param {string} serviceName The name of the service.
+ * @param {object} serviceDefinition The definition of the service
  * @param {Set} groupIds A set of group ids.
  * @returns {Object} A group object.
  */
-const fCreateGroupsTemplateForService = (srvName, srvDefinition) => {
-    const ordExtensions = fReadORDExtensions(srvDefinition);
+const fCreateGroupsTemplateForService = (serviceName, serviceDefinition) => {
+    const ordExtensions = fReadORDExtensions(serviceDefinition);
 
-    if(!srvDefinition) {
-      console.warn("Unable to find service definition:", srvName)
+    if(!serviceDefinition) {
+      console.warn("Unable to find service definition:", serviceName)
       return undefined
     }
 
-    if (srvDefinition && checkEntityFunctionAction(srvDefinition, global).length > 0) {
-      let groupId = _getGroupID(srvName, defaults.groupTypeId);
+    if (serviceDefinition && checkEntityFunctionAction(serviceDefinition, global).length > 0) {
+      let groupId = _getGroupID(serviceName, defaults.groupTypeId);
       return {
           groupId: groupId,
           groupTypeId: `${defaults.groupTypeId}`,
-          title: ordExtensions.title ?? _getTitleFromServiceName(srvName)
+          title: ordExtensions.title ?? _getTitleFromServiceName(serviceName)
       };
     }
   }
@@ -146,15 +146,15 @@ function _getEventTitle(event) {
 /**
  * This is a template function to create group object of an event for groups array in ORD doc.
  *
- * @param {string} event The name of the event.
+ * @param {string} eventName The name of the event.
  * @param {object} eventDefinition The definition of the event.
  * @param {Set} groupIds A set of group ids.
  * @returns {Object} A group object.
  */
-const fCreateGroupsTemplateForEvent = (event, eventDefinition, groupIds) => {
+const fCreateGroupsTemplateForEvent = (eventName, eventDefinition, groupIds) => {
   const ordExtensions = fReadORDExtensions(eventDefinition);
   let groupId = _getGroupID(
-    event,
+    eventName,
     defaults.groupTypeId,
     global,
     false
@@ -166,7 +166,7 @@ const fCreateGroupsTemplateForEvent = (event, eventDefinition, groupIds) => {
     return {
       groupId: groupId,
       groupTypeId: `${defaults.groupTypeId}`,
-      title: ordExtensions.title ?? _getEventTitle(event),
+      title: ordExtensions.title ?? _getEventTitle(eventName),
     };
   }
 };
@@ -174,22 +174,22 @@ const fCreateGroupsTemplateForEvent = (event, eventDefinition, groupIds) => {
 /**
  * This is a template function to create API Resource object for API Resource Array.
  *
- * @param {string} srv The name of the service.
- * @param {object} srvDefinition The definition of the service
+ * @param {string} serviceName The name of the service.
+ * @param {object} serviceDefinition The definition of the service
  * @returns {Array} An array of objects for the API Resources.
  */
-const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
-  const ordExtensions = fReadORDExtensions(srvDefinition);
-  const paths = fGeneratePaths(srv, srvDefinition);
+const fCreateAPIResourceTemplate = (serviceName, serviceDefinition, global, packageIds) => {
+  const ordExtensions = fReadORDExtensions(serviceDefinition);
+  const paths = fGeneratePaths(serviceName, serviceDefinition);
   const apiResources = [];
 
-  if (checkEntityFunctionAction(srvDefinition, global).length > 0) {
+  if (checkEntityFunctionAction(serviceDefinition, global).length > 0) {
     paths.forEach((generatedPath) => {
       let resourceDefinitions = [
         {
           type: "openapi-v3",
           mediaType: "application/json",
-          url: `/.well-known/open-resource-discovery/v1/api-metadata/${srv}.oas3.json`,
+          url: `/.well-known/open-resource-discovery/v1/api-metadata/${serviceName}.oas3.json`,
           accessStrategies: [{ type: "open" }],
         },
       ];
@@ -199,7 +199,7 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
         resourceDefinitions.push({
           type: "edmx",
           mediaType: "application/xml",
-          url: `/.well-known/open-resource-discovery/v1/api-metadata/${srv}.edmx`,
+          url: `/.well-known/open-resource-discovery/v1/api-metadata/${serviceName}.edmx`,
           accessStrategies: [{ type: "open" }],
         });
       }
@@ -207,21 +207,21 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
       let obj = {
         ordId: `${fReplaceSpecialCharacters(
           global.ordNamespace
-        )}:apiResource:${srv}:v1`,
+        )}:apiResource:${serviceName}:v1`,
         title:
           ordExtensions.title ??
-          srvDefinition["@title"] ??
-          srvDefinition["@Common.Label"] ??
-          srv,
-        shortDescription: ordExtensions.shortDescription ?? srv,
+          serviceDefinition["@title"] ??
+          serviceDefinition["@Common.Label"] ??
+          serviceName,
+        shortDescription: ordExtensions.shortDescription ?? serviceName,
         description:
           ordExtensions.description ??
-          srvDefinition["@Core.Description"] ??
-          srv,
+          serviceDefinition["@Core.Description"] ??
+          serviceName,
         version: ordExtensions.version ?? "1.0.0",
         visibility: ordExtensions.visibility ?? "public",
         partOfPackage: _getPackageID(global.ordNamespace, packageIds, "api"),
-        partOfGroups: [_getGroupID(srv, defaults.groupTypeId, global)],
+        partOfGroups: [_getGroupID(serviceName, defaults.groupTypeId, global)],
         releaseStatus: ordExtensions.active ?? "active",
         apiProtocol:
           generatedPath.kind === "odata" ? "odata-v4" : generatedPath.kind,

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -118,18 +118,13 @@ function _getTitleFromServiceName(srv) {
 const fCreateGroupsTemplateForService = (srv, srvDefinition) => {
     const ordExtensions = fReadORDExtensions(srvDefinition);
 
-  let fullyQualifiedServiceName = srv;
-  if (!srv.includes(global.capNamespace)) {
-    fullyQualifiedServiceName = global.capNamespace + "." + srv;
-  }
-
     if(!srvDefinition) {
       console.warn("Unable to find service definition:", srv)
       return undefined
     }
 
     if (srvDefinition && checkEntityFunctionAction(srvDefinition, global).length > 0) {
-      let groupId = _getGroupID(fullyQualifiedServiceName, defaults.groupTypeId);
+      let groupId = _getGroupID(srv, defaults.groupTypeId);
       return {
           groupId: groupId,
           groupTypeId: `${defaults.groupTypeId}`,
@@ -158,14 +153,8 @@ function _getEventTitle(event) {
  */
 const fCreateGroupsTemplateForEvent = (event, eventDefinition, groupIds) => {
   const ordExtensions = fReadORDExtensions(eventDefinition);
-
-  let fullyQualifiedEventName = event;
-  if (!event.includes(global.capNamespace)) {
-    fullyQualifiedEventName = global.capNamespace + "." + event;
-  }
-
   let groupId = _getGroupID(
-    fullyQualifiedEventName,
+    event,
     defaults.groupTypeId,
     global,
     false
@@ -194,11 +183,6 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
   const paths = fGeneratePaths(srv, srvDefinition);
   const apiResources = [];
 
-  let srvName = srv;
-  if (!srvName.includes(global.capNamespace)) {
-    srvName = global.capNamespace + "." + srv;
-  }
-
   if (checkEntityFunctionAction(srvDefinition, global).length > 0) {
     paths.forEach((generatedPath) => {
       let resourceDefinitions = [
@@ -223,7 +207,7 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
       let obj = {
         ordId: `${fReplaceSpecialCharacters(
           global.namespace
-        )}:apiResource:${srvName}:v1`,
+        )}:apiResource:${srv}:v1`,
         title:
           ordExtensions.title ??
           srvDefinition["@title"] ??
@@ -237,7 +221,7 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
         version: ordExtensions.version ?? "1.0.0",
         visibility: ordExtensions.visibility ?? "public",
         partOfPackage: _getPackageID(global.capNamespace, packageIds, "api"),
-        partOfGroups: [_getGroupID(srvName, defaults.groupTypeId, global)],
+        partOfGroups: [_getGroupID(srv, defaults.groupTypeId, global)],
         releaseStatus: ordExtensions.active ?? "active",
         apiProtocol:
           generatedPath.kind === "odata" ? "odata-v4" : generatedPath.kind,
@@ -265,14 +249,10 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
 // TODO: wrong name srvDefinition, should be model
 const fCreateEventResourceTemplate = (srv, srvDefinition, global,packageIds) => {
   const ordExtensions = fReadORDExtensions(srvDefinition);
-  let srvName = srv;
-  if (!srvName.includes(global.capNamespace)) {
-    srvName = global.capNamespace + "." + srv;
-  }
   return {
     ordId: `${fReplaceSpecialCharacters(
       global.namespace
-    )}:eventResource:${srvName}:v1`,
+    )}:eventResource:${srv}:v1`,
     title:
       ordExtensions.title ??
       srvDefinition["@title"] ??
@@ -285,7 +265,7 @@ const fCreateEventResourceTemplate = (srv, srvDefinition, global,packageIds) => 
     version:  ordExtensions.version ?? "1.0.0",
     releaseStatus:  ordExtensions.releaseStatus ?? "beta",
     partOfPackage: _getPackageID(global.capNamespace,packageIds,'event'),
-    partOfGroups: [_getGroupID(srvName, defaults.groupTypeId, global, false)],
+    partOfGroups: [_getGroupID(srv, defaults.groupTypeId, global, false)],
     visibility: ordExtensions.visibility ?? "public",
     resourceDefinitions: [
       {

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -81,11 +81,11 @@ function _getGroupID(
 ) {
   if (isService) {
     return `${groupTypeId}:${fReplaceSpecialCharacters(
-      global.namespace
+      global.ordNamespace
     )}:${fullyQualifiedName}`;
   } else {
     return (
-      `${groupTypeId}:${fReplaceSpecialCharacters(global.namespace)}:` +
+      `${groupTypeId}:${fReplaceSpecialCharacters(global.ordNamespace)}:` +
       `${fullyQualifiedName.slice(0, fullyQualifiedName.lastIndexOf("."))}`
     );
   }
@@ -206,7 +206,7 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
 
       let obj = {
         ordId: `${fReplaceSpecialCharacters(
-          global.namespace
+          global.ordNamespace
         )}:apiResource:${srv}:v1`,
         title:
           ordExtensions.title ??
@@ -220,7 +220,7 @@ const fCreateAPIResourceTemplate = (srv, srvDefinition, global, packageIds) => {
           srv,
         version: ordExtensions.version ?? "1.0.0",
         visibility: ordExtensions.visibility ?? "public",
-        partOfPackage: _getPackageID(global.namespace, packageIds, "api"),
+        partOfPackage: _getPackageID(global.ordNamespace, packageIds, "api"),
         partOfGroups: [_getGroupID(srv, defaults.groupTypeId, global)],
         releaseStatus: ordExtensions.active ?? "active",
         apiProtocol:
@@ -251,7 +251,7 @@ const fCreateEventResourceTemplate = (srv, srvDefinition, global,packageIds) => 
   const ordExtensions = fReadORDExtensions(srvDefinition);
   return {
     ordId: `${fReplaceSpecialCharacters(
-      global.namespace
+      global.ordNamespace
     )}:eventResource:${srv}:v1`,
     title:
       ordExtensions.title ??
@@ -264,7 +264,7 @@ const fCreateEventResourceTemplate = (srv, srvDefinition, global,packageIds) => 
                   "CAP Event resource describing events / messages.",
     version:  ordExtensions.version ?? "1.0.0",
     releaseStatus:  ordExtensions.releaseStatus ?? "beta",
-    partOfPackage: _getPackageID(global.namespace,packageIds,'event'),
+    partOfPackage: _getPackageID(global.ordNamespace,packageIds,'event'),
     partOfGroups: [_getGroupID(srv, defaults.groupTypeId, global, false)],
     visibility: ordExtensions.visibility ?? "public",
     resourceDefinitions: [
@@ -297,8 +297,8 @@ function checkEntityFunctionAction(srvDefinition, global) {
         name: entity.name,
         entityType: entity.name,
         entitySet: entity.name,
-        entityTypeMapping: `${global.namespace}:entityType:${entity.name}:v1`,
-        entitySetMapping: `${global.namespace}:entitySet:${entity.name}:v1`,
+        entityTypeMapping: `${global.ordNamespace}:entityType:${entity.name}:v1`,
+        entitySetMapping: `${global.ordNamespace}:entitySet:${entity.name}:v1`,
       };
     });
   } else if (srvDefinition.actions) {
@@ -307,7 +307,7 @@ function checkEntityFunctionAction(srvDefinition, global) {
         type: "action",
         name: action.name,
         actionType: action.name,
-        actionMapping: `${global.namespace}:action:${action.name}:v1`,
+        actionMapping: `${global.ordNamespace}:action:${action.name}:v1`,
       };
     });
   } else if (srvDefinition.functions) {
@@ -316,7 +316,7 @@ function checkEntityFunctionAction(srvDefinition, global) {
         type: "function",
         name: func.name,
         functionType: func.name,
-        functionMapping: `${global.namespace}:function:${func.name}:v1`,
+        functionMapping: `${global.ordNamespace}:function:${func.name}:v1`,
       };
     });
   }


### PR DESCRIPTION
Addressing the following issue from #38 :

> Never use CSN's .namespace property but always just use the fully-qualified names from .definitions

Instead of `csn.namespace`, we should use e.g. `cds.model.definitions["AdminService"].model.namespace`
