### PR TITLE
fix: correct REUSE badge link to point to ord repository #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![REUSE status](https://api.reuse.software/badge/github.com/cap-js/ord)](https://api.reuse.software/info/github.com/cap-js/cds-plugin-for-ord)
+[![REUSE status](https://api.reuse.software/badge/github.com/cap-js/ord)](https://api.reuse.software/info/github.com/cap-js/ord)
 
 # CDS Plugin for ORD
 


### PR DESCRIPTION
[Issue #39](https://github.com/cap-js/ord/issues/39)
### Summary
- Fixed incorrect REUSE badge link in `README.md`.
- The previous link pointed to `cds-plugin-for-ord` instead of `ord`.
- This should resolve the issue flagged by the SAP OSPO Bot.

### How to test?
- Click the REUSE badge in the README and verify that it now leads to the correct repository.