### PR TITLE
Fix: adjust ordId including entity composition root

### DIFF
--- a/__tests__/mockedCsn.test.js
+++ b/__tests__/mockedCsn.test.js
@@ -83,8 +83,8 @@ describe("Tests for ORD document generated out of mocked csn files", () => {
             expect(document.entityTypes[0].partOfPackage).toEqual(expect.stringContaining("entityType"));
             expect(document.entityTypes[0].level).toEqual(expect.stringContaining("root-entity"));
             expect(document.apiResources[0].entityTypeMappings[0].entityTypeTargets).toEqual(expect.arrayContaining([
-                { "ordId": "sap.odm:entityType:SomeODMEntity:v1" },
-                { "ordId": "sap.sm:entityType:SomeAribaDummyEntity:v1" }
+                { "ordId": "sap.odm:entityType:SomeODMEntityRoot:v1" },
+                { "ordId": "sap.sm:entityType:SomeAribaDummyEntityRoot:v1" }
             ]));
         });
     });

--- a/__tests__/unittest/templates.test.js
+++ b/__tests__/unittest/templates.test.js
@@ -1,5 +1,6 @@
 const cds = require('@sap/cds');
-const { AUTHENTICATION_TYPE } = require('../../lib/constants');
+const { AUTHENTICATION_TYPE, ORD_ODM_ENTITY_NAME_ANNOTATION} = require('../../lib/constants');
+const { cloneDeep } = require('lodash');
 
 jest.spyOn(cds, "context", "get").mockReturnValue({
     authConfig: {
@@ -36,6 +37,19 @@ describe('templates', () => {
     });
 
     describe('createEntityTypeMappingsItemTemplate', () => {
+        it('should return ORD_ODM_ENTITY_NAME_ANNOTATION for ordID', () => {
+            const model = cloneDeep(linkedModel.definitions['customer.testNamespace123.Books']);
+            model[ORD_ODM_ENTITY_NAME_ANNOTATION] = 'namespace customer.testNamespace123';
+            expect(createEntityTypeMappingsItemTemplate(model).ordId).toEqual('sap.odm:entityType:namespace customer.testNamespace123:v1');
+        });
+
+        it('should return append root to ordID if it is an root element', () => {
+            const model = cloneDeep(linkedModel.definitions['customer.testNamespace123.Books']);
+            model[ORD_ODM_ENTITY_NAME_ANNOTATION] = 'namespace customer.testNamespace123';
+            model['@ODM.root'] = true;
+            expect(createEntityTypeMappingsItemTemplate(model).ordId).toEqual('sap.odm:entityType:namespace customer.testNamespace123Root:v1');
+        });
+
         it('should return default value', () => {
             expect(createEntityTypeMappingsItemTemplate(linkedModel.definitions['customer.testNamespace123.Books'])).toBeUndefined();
         });

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -75,9 +75,10 @@ const _generatePaths = (srv, srvDefinition) => {
  * @returns {Object} An entry of the entityTypeMappings array.
  */
 const createEntityTypeMappingsItemTemplate = (entity) => {
+    const root = entity["@ObjectModel.compositionRoot"] || entity["@ODM.root"] ? 'Root' : '';
     if (entity[ORD_ODM_ENTITY_NAME_ANNOTATION]) {
         return {
-            ordId: `sap.odm:entityType:${entity[ORD_ODM_ENTITY_NAME_ANNOTATION]}:v1`,
+            ordId: `sap.odm:entityType:${entity[ORD_ODM_ENTITY_NAME_ANNOTATION]}${root}:v1`,
             entityName: entity[ORD_ODM_ENTITY_NAME_ANNOTATION],
             ...entity
         }
@@ -87,7 +88,7 @@ const createEntityTypeMappingsItemTemplate = (entity) => {
         const entityName = ordIdParts[1];
         const version = ordIdParts[2] || "v1";
         return {
-            ordId: `${namespace}:entityType:${entityName}:${version}`,
+            ordId: `${namespace}:entityType:${entityName}${root}:${version}`,
             entityName,
             ...entity
         };


### PR DESCRIPTION
Adjust ordId to be <systemnamespace>: entityType:<ord-name>:v1 or <systemnamespace>: entityType:<ord-name>Root:v1 for for ORD entitytypes with attribute level containing value of "root-entity".

This should mark root level entities as such within their ordId.