### PR TITLE
chore: adapt license entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "repository": "cap-js/ord",
     "author": "SAP SE (https://www.sap.com)",
     "homepage": "https://cap.cloud.sap/",
-    "license": "SEE LICENSE IN LICENSE",
+    "license": "Apache-2.0",
     "main": "cds-plugin.js",
     "files": [
         "lib",


### PR DESCRIPTION
Replaces the placeholder value "SEE LICENSE IN LICENSE" with "Apache-2.0" as the project is licensed under Apache 2.0, and the LICENSE file contains the full license text.