### PR TITLE
Feat: backward compatible (policyLevels to be plural)

### DIFF
--- a/__tests__/__snapshots__/mockedCsn.test.js.snap
+++ b/__tests__/__snapshots__/mockedCsn.test.js.snap
@@ -297,7 +297,9 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
       "version": "1.0.0",
     },
   ],
-  "policyLevels": "none",
+  "policyLevels": [
+    "none",
+  ],
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",

--- a/__tests__/__snapshots__/mockedCsn.test.js.snap
+++ b/__tests__/__snapshots__/mockedCsn.test.js.snap
@@ -297,7 +297,7 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
       "version": "1.0.0",
     },
   ],
-  "policyLevel": "none",
+  "policyLevels": "none",
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",

--- a/__tests__/__snapshots__/ord.e2e.test.js.snap
+++ b/__tests__/__snapshots__/ord.e2e.test.js.snap
@@ -293,7 +293,7 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "version": "1.0.0",
     },
   ],
-  "policyLevel": "sap:core:v1",
+  "policyLevels": "sap:core:v1",
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",
@@ -598,7 +598,7 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "version": "1.0.0",
     },
   ],
-  "policyLevel": "sap:core:v1",
+  "policyLevels": "sap:core:v1",
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",
@@ -903,7 +903,7 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "version": "1.0.0",
     },
   ],
-  "policyLevel": "sap:core:v1",
+  "policyLevels": "sap:core:v1",
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",
@@ -1140,7 +1140,7 @@ exports[`Tests for products and packages should not contain products property if
       "version": "1.0.0",
     },
   ],
-  "policyLevel": "none",
+  "policyLevels": "none",
 }
 `;
 
@@ -1369,7 +1369,7 @@ exports[`Tests for products and packages should raise error log when custom prod
       "version": "1.0.0",
     },
   ],
-  "policyLevel": "none",
+  "policyLevels": "none",
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",
@@ -1606,7 +1606,7 @@ exports[`Tests for products and packages should use valid custom products ordId 
       "version": "1.0.0",
     },
   ],
-  "policyLevel": "none",
+  "policyLevels": "none",
   "products": [
     {
       "ordId": "customer:product:eb.bm.tests:",

--- a/__tests__/__snapshots__/ord.e2e.test.js.snap
+++ b/__tests__/__snapshots__/ord.e2e.test.js.snap
@@ -293,7 +293,9 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "version": "1.0.0",
     },
   ],
-  "policyLevels": "sap:core:v1",
+  "policyLevels": [
+    "sap:core:v1",
+  ],
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",
@@ -598,7 +600,9 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "version": "1.0.0",
     },
   ],
-  "policyLevels": "sap:core:v1",
+  "policyLevels": [
+    "sap:core:v1",
+  ],
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",
@@ -903,7 +907,9 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "version": "1.0.0",
     },
   ],
-  "policyLevels": "sap:core:v1",
+  "policyLevels": [
+    "sap:core:v1",
+  ],
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",
@@ -1140,7 +1146,9 @@ exports[`Tests for products and packages should not contain products property if
       "version": "1.0.0",
     },
   ],
-  "policyLevels": "none",
+  "policyLevels": [
+    "none",
+  ],
 }
 `;
 
@@ -1369,7 +1377,9 @@ exports[`Tests for products and packages should raise error log when custom prod
       "version": "1.0.0",
     },
   ],
-  "policyLevels": "none",
+  "policyLevels": [
+    "none",
+  ],
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",
@@ -1606,7 +1616,9 @@ exports[`Tests for products and packages should use valid custom products ordId 
       "version": "1.0.0",
     },
   ],
-  "policyLevels": "none",
+  "policyLevels": [
+    "none",
+  ],
   "products": [
     {
       "ordId": "customer:product:eb.bm.tests:",

--- a/__tests__/__snapshots__/splitUpPackagesCsn.test.js.snap
+++ b/__tests__/__snapshots__/splitUpPackagesCsn.test.js.snap
@@ -494,7 +494,9 @@ exports[`ORD Generation for Business Accelerator Hub Tests for ORD document for 
       "version": "1.0.0",
     },
   ],
-  "policyLevels": "sap:core:v1",
+  "policyLevels": [
+    "sap:core:v1",
+  ],
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",

--- a/__tests__/__snapshots__/splitUpPackagesCsn.test.js.snap
+++ b/__tests__/__snapshots__/splitUpPackagesCsn.test.js.snap
@@ -494,7 +494,7 @@ exports[`ORD Generation for Business Accelerator Hub Tests for ORD document for 
       "version": "1.0.0",
     },
   ],
-  "policyLevel": "sap:core:v1",
+  "policyLevels": "sap:core:v1",
   "products": [
     {
       "ordId": "customer:product:capire.bookshop.ord.sample:",

--- a/__tests__/bookshop/.cdsrc.json
+++ b/__tests__/bookshop/.cdsrc.json
@@ -3,7 +3,7 @@
         "namespace": "sap.test.cdsrc.sample",
         "openResourceDiscovery": "1.10",
         "description": "this is my custom description",
-        "policyLevel": "sap:core:v1",
+        "policyLevels": "sap:core:v1",
         "customOrdContentFile": "./ord/custom.ord.json"
     },
     "DEBUG": false

--- a/__tests__/bookshop/.cdsrc.json
+++ b/__tests__/bookshop/.cdsrc.json
@@ -3,7 +3,7 @@
         "namespace": "sap.test.cdsrc.sample",
         "openResourceDiscovery": "1.10",
         "description": "this is my custom description",
-        "policyLevels": "sap:core:v1",
+        "policyLevels": ["sap:core:v1"],
         "customOrdContentFile": "./ord/custom.ord.json"
     },
     "DEBUG": false

--- a/__tests__/mockedCsn.test.js
+++ b/__tests__/mockedCsn.test.js
@@ -39,7 +39,7 @@ describe("Tests for ORD document generated out of mocked csn files", () => {
             namespace: "sap.test.cdsrc.sample",
             openResourceDiscovery: "1.10",
             description: "this is my custom description",
-            policyLevels: "sap:core:v1",
+            policyLevels: ["sap:core:v1"],
         };
     });
 

--- a/__tests__/mockedCsn.test.js
+++ b/__tests__/mockedCsn.test.js
@@ -39,7 +39,7 @@ describe("Tests for ORD document generated out of mocked csn files", () => {
             namespace: "sap.test.cdsrc.sample",
             openResourceDiscovery: "1.10",
             description: "this is my custom description",
-            policyLevel: "sap:core:v1",
+            policyLevels: "sap:core:v1",
         };
     });
 

--- a/__tests__/splitUpPackagesCsn.test.js
+++ b/__tests__/splitUpPackagesCsn.test.js
@@ -20,7 +20,7 @@ describe("ORD Generation for Business Accelerator Hub", () => {
             namespace: "sap.test.cdsrc.sample",
             openResourceDiscovery: "1.10",
             description: "Business Accelerator Hub ORD Test",
-            policyLevels: "sap:core:v1",
+            policyLevel: "sap:core:v1", //old value, check for compatibility
         };
     });
 
@@ -38,7 +38,7 @@ describe("ORD Generation for Business Accelerator Hub", () => {
             document.consumptionBundles.forEach((con) => delete con.lastUpdate);
             expect(document).toMatchSnapshot();
             expect(document.openResourceDiscovery).toBe("1.10");
-            expect(document.policyLevels).toBe("sap:core:v1");
+            expect(document.policyLevels).toEqual(["sap:core:v1"]);
             expect(document.description).toBe("Business Accelerator Hub ORD Test");
             expect(document.apiResources).toHaveLength(6);
             expect(document.eventResources).toHaveLength(6);

--- a/__tests__/splitUpPackagesCsn.test.js
+++ b/__tests__/splitUpPackagesCsn.test.js
@@ -20,7 +20,7 @@ describe("ORD Generation for Business Accelerator Hub", () => {
             namespace: "sap.test.cdsrc.sample",
             openResourceDiscovery: "1.10",
             description: "Business Accelerator Hub ORD Test",
-            policyLevel: "sap:core:v1",
+            policyLevels: "sap:core:v1",
         };
     });
 
@@ -38,7 +38,7 @@ describe("ORD Generation for Business Accelerator Hub", () => {
             document.consumptionBundles.forEach((con) => delete con.lastUpdate);
             expect(document).toMatchSnapshot();
             expect(document.openResourceDiscovery).toBe("1.10");
-            expect(document.policyLevel).toBe("sap:core:v1");
+            expect(document.policyLevels).toBe("sap:core:v1");
             expect(document.description).toBe("Business Accelerator Hub ORD Test");
             expect(document.apiResources).toHaveLength(6);
             expect(document.eventResources).toHaveLength(6);

--- a/__tests__/unittest/__snapshots__/defaults.test.js.snap
+++ b/__tests__/unittest/__snapshots__/defaults.test.js.snap
@@ -274,7 +274,11 @@ exports[`defaults packages should use existingProductId if provided in .cdsrc.js
 ]
 `;
 
-exports[`defaults policyLevels should return default value 1`] = `"none"`;
+exports[`defaults policyLevels should return default value 1`] = `
+[
+  "none",
+]
+`;
 
 exports[`defaults products should return default value 1`] = `
 [

--- a/__tests__/unittest/__snapshots__/defaults.test.js.snap
+++ b/__tests__/unittest/__snapshots__/defaults.test.js.snap
@@ -67,7 +67,7 @@ exports[`defaults packages should return custom value if user defined in .cdsrc.
 ]
 `;
 
-exports[`defaults packages should return default value if policyLevel contains sap 1`] = `
+exports[`defaults packages should return default value if policyLevels contains sap 1`] = `
 [
   {
     "description": "This package contains public APIs for My Package.",
@@ -216,7 +216,7 @@ exports[`defaults packages should return default value if policyLevel contains s
 ]
 `;
 
-exports[`defaults packages should return default value if policyLevel does not contain sap 1`] = `
+exports[`defaults packages should return default value if policyLevels does not contain sap 1`] = `
 [
   {
     "description": "This package contains public General for My Package.",
@@ -274,7 +274,7 @@ exports[`defaults packages should use existingProductId if provided in .cdsrc.js
 ]
 `;
 
-exports[`defaults policyLevel should return default value 1`] = `"none"`;
+exports[`defaults policyLevels should return default value 1`] = `"none"`;
 
 exports[`defaults products should return default value 1`] = `
 [

--- a/__tests__/unittest/defaults.test.js
+++ b/__tests__/unittest/defaults.test.js
@@ -21,9 +21,9 @@ describe("defaults", () => {
         });
     });
 
-    describe("policyLevel", () => {
+    describe("policyLevels", () => {
         it("should return default value", () => {
-            expect(defaults.policyLevel).toMatchSnapshot();
+            expect(defaults.policyLevels).toMatchSnapshot();
         });
     });
 
@@ -50,26 +50,26 @@ describe("defaults", () => {
         const testGetPackageDataName = "My Package";
         const testGetPackageOrdNamespace = "customer.sample";
         var appConfig = {};
-        it("should return default value if policyLevel contains sap", () => {
-            const testPolicyLevel = "sap:policy";
+        it("should return default value if policyLevels contains sap", () => {
+            const testpolicyLevels = "sap:policy";
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
             };
-            expect(defaults.packages(appConfig, testPolicyLevel)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
         });
 
-        it("should return default value if policyLevel does not contain sap", () => {
-            const testPolicyLevel = "policy";
+        it("should return default value if policyLevels does not contain sap", () => {
+            const testpolicyLevels = "policy";
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
             };
-            expect(defaults.packages(appConfig, testPolicyLevel)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
         });
 
         it("should return custom value if user defined in .cdsrc.json", () => {
-            const testPolicyLevel = "policy";
+            const testpolicyLevels = "policy";
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
@@ -87,21 +87,21 @@ describe("defaults", () => {
                     ],
                 },
             };
-            expect(defaults.packages(appConfig, testPolicyLevel)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
         });
 
         it("should use existingProductId if provided in .cdsrc.json", () => {
-            const testPolicyLevel = "policy";
+            const testpolicyLevels = "policy";
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
                 existingProductORDId: "sap:product:SAPServiceCloudV2:",
             };
-            expect(defaults.packages(appConfig, testPolicyLevel)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
         });
 
         it("should use existingProductId if existingProductId and custom product both provided in .cdsrc.json", () => {
-            const testPolicyLevel = "policy";
+            const testpolicyLevels = "policy";
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
@@ -113,11 +113,11 @@ describe("defaults", () => {
                     },
                 ],
             };
-            expect(defaults.packages(appConfig, testPolicyLevel)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
         });
 
         it("should use custom vendor if it defined in .cdsrc.json", () => {
-            const testPolicyLevel = "policy";
+            const testpolicyLevels = "policy";
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
@@ -129,16 +129,16 @@ describe("defaults", () => {
                     ],
                 },
             };
-            expect(defaults.packages(appConfig, testPolicyLevel)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
         });
 
         it("should not contain partOfProducts if no productsOrdId found", () => {
-            const testPolicyLevel = "policy";
+            const testpolicyLevels = "policy";
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
             };
-            expect(defaults.packages(appConfig, testPolicyLevel)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
         });
     });
 

--- a/__tests__/unittest/defaults.test.js
+++ b/__tests__/unittest/defaults.test.js
@@ -51,25 +51,25 @@ describe("defaults", () => {
         const testGetPackageOrdNamespace = "customer.sample";
         var appConfig = {};
         it("should return default value if policyLevels contains sap", () => {
-            const testpolicyLevels = "sap:policy";
+            const testPolicyLevels = ["sap:policy"];
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
             };
-            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testPolicyLevels)).toMatchSnapshot();
         });
 
         it("should return default value if policyLevels does not contain sap", () => {
-            const testpolicyLevels = "policy";
+            const testPolicyLevels = ["policy"];
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
             };
-            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testPolicyLevels)).toMatchSnapshot();
         });
 
         it("should return custom value if user defined in .cdsrc.json", () => {
-            const testpolicyLevels = "policy";
+            const testPolicyLevels = ["policy"];
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
@@ -87,21 +87,21 @@ describe("defaults", () => {
                     ],
                 },
             };
-            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testPolicyLevels)).toMatchSnapshot();
         });
 
         it("should use existingProductId if provided in .cdsrc.json", () => {
-            const testpolicyLevels = "policy";
+            const testPolicyLevels = ["policy"];
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
                 existingProductORDId: "sap:product:SAPServiceCloudV2:",
             };
-            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testPolicyLevels)).toMatchSnapshot();
         });
 
         it("should use existingProductId if existingProductId and custom product both provided in .cdsrc.json", () => {
-            const testpolicyLevels = "policy";
+            const testPolicyLevels = ["policy"];
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
@@ -113,11 +113,11 @@ describe("defaults", () => {
                     },
                 ],
             };
-            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testPolicyLevels)).toMatchSnapshot();
         });
 
         it("should use custom vendor if it defined in .cdsrc.json", () => {
-            const testpolicyLevels = "policy";
+            const testPolicyLevels = ["policy"];
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
@@ -129,16 +129,16 @@ describe("defaults", () => {
                     ],
                 },
             };
-            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testPolicyLevels)).toMatchSnapshot();
         });
 
         it("should not contain partOfProducts if no productsOrdId found", () => {
-            const testpolicyLevels = "policy";
+            const testPolicyLevels = ["policy"];
             appConfig = {
                 appName: testGetPackageDataName,
                 ordNamespace: testGetPackageOrdNamespace,
             };
-            expect(defaults.packages(appConfig, testpolicyLevels)).toMatchSnapshot();
+            expect(defaults.packages(appConfig, testPolicyLevels)).toMatchSnapshot();
         });
     });
 

--- a/docs/ord.md
+++ b/docs/ord.md
@@ -15,7 +15,7 @@ Global settings can be defined using the `present configuration` in your `cdsrc.
     "ord": {
         "namespace": "sap.sample",
         "description": "This is my custom description",
-        "policyLevel": "sap:core:v1"
+        "policyLevels": ["sap:core:v1"]
     }
 }
 ```
@@ -62,7 +62,7 @@ customOrdContent > ORD.Extensions Annotations > CAP Annotations > Plugin Default
     "ord": {
         "namespace": "sap.sample",
         "description": "This is my custom description",
-        "policyLevel": "sap:core:v1",
+        "policyLevels": ["sap:core:v1"],
         "customOrdContentFile": "./path/to/custom.ord.json"
     }
 }
@@ -123,7 +123,7 @@ To associate your resources with an existing SAP product, define `existingProduc
     "ord": {
         "namespace": "sap.sample",
         "description": "This is my custom description",
-        "policyLevel": "sap:core:v1",
+        "policyLevels": ["sap:core:v1"],
         "customOrdContentFile": "./ord/custom.ord.json",
         "existingProductORDId": "sap:product:SAPServiceCloudV2:"
     }
@@ -159,7 +159,7 @@ If defining a **custom product**, make sure its `ordId` **does not** start with 
     "ord": {
         "namespace": "sap.sample",
         "description": "This is my custom description",
-        "policyLevel": "sap:core:v1",
+        "policyLevels": ["sap:core:v1"],
         "customOrdContentFile": "./ord/custom.ord.json",
         "products": [
             {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -45,13 +45,22 @@ const generateUniquePackageOrdId = (ordNamespace, name, tag, visibility) => {
 };
 
 /**
+ * Checks if at least one policy level in the array is SAP.
+ *
+ * @param {string[]} policyLevels - Array of policy levels.
+ */
+function hasSAPPolicyLevel(policyLevels) {
+    return policyLevels.some((policyLevel)=> policyLevel.split(":")[0].toLowerCase() === "sap");
+}
+
+/**
  * Module containing default configuration for ORD Document.
  * @module defaults
  */
 module.exports = {
     $schema: "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
     openResourceDiscovery: OPEN_RESOURCE_DISCOVERY_VERSION,
-    policyLevels: "none",
+    policyLevels: ["none"],
     description: "this is an application description",
     products: (name) => [
         {
@@ -67,7 +76,7 @@ module.exports = {
         const ordNamespace = appConfig.ordNamespace;
         const productsOrdId = appConfig.existingProductORDId || appConfig.products?.[0]?.ordId;
         const vendor = appConfig.env?.packages?.[0]?.vendor;
-        if (policyLevels.split(":")[0].toLowerCase() === "sap") {
+        if (hasSAPPolicyLevel(policyLevels)) {
             return _.uniqBy(
                 packageTypes.flatMap(({ tag, type }) =>
                     Object.values(RESOURCE_VISIBILITY).map((visibility) => ({

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -51,7 +51,7 @@ const generateUniquePackageOrdId = (ordNamespace, name, tag, visibility) => {
 module.exports = {
     $schema: "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
     openResourceDiscovery: OPEN_RESOURCE_DISCOVERY_VERSION,
-    policyLevel: "none",
+    policyLevels: "none",
     description: "this is an application description",
     products: (name) => [
         {
@@ -62,12 +62,12 @@ module.exports = {
         },
     ],
     groupTypeId: "sap.cds:service",
-    packages: function getPackageData(appConfig, policyLevel) {
+    packages: function getPackageData(appConfig, policyLevels) {
         const name = appConfig.appName;
         const ordNamespace = appConfig.ordNamespace;
         const productsOrdId = appConfig.existingProductORDId || appConfig.products?.[0]?.ordId;
         const vendor = appConfig.env?.packages?.[0]?.vendor;
-        if (policyLevel.split(":")[0].toLowerCase() === "sap") {
+        if (policyLevels.split(":")[0].toLowerCase() === "sap") {
             return _.uniqBy(
                 packageTypes.flatMap(({ tag, type }) =>
                     Object.values(RESOURCE_VISIBILITY).map((visibility) => ({

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -90,7 +90,10 @@ const initializeAppConfig = (csn) => {
     };
 };
 
-const _getPolicyLevels = (appConfig) => appConfig.env?.policyLevels || defaults.policyLevels;
+const _getPolicyLevels = (
+    appConfig) => appConfig.env?.policyLevels ||
+    appConfig.env?.policyLevel && [appConfig.env?.policyLevel] ||
+    defaults.policyLevels;
 
 const _getDescription = (appConfig) => appConfig.env?.description || defaults.description;
 

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -90,7 +90,7 @@ const initializeAppConfig = (csn) => {
     };
 };
 
-const _getPolicyLevel = (appConfig) => appConfig.env?.policyLevel || defaults.policyLevel;
+const _getPolicyLevels = (appConfig) => appConfig.env?.policyLevels || defaults.policyLevels;
 
 const _getDescription = (appConfig) => appConfig.env?.description || defaults.description;
 
@@ -100,8 +100,8 @@ const _getGroups = (csn, appConfig) => {
         .filter((resource) => !!resource);
 };
 
-const _getPackages = (policyLevel, appConfig) => {
-    return defaults.packages(appConfig, policyLevel);
+const _getPackages = (policyLevels, appConfig) => {
+    return defaults.packages(appConfig, policyLevels);
 };
 
 const _getEntityTypes = (appConfig, packageIds) => {
@@ -150,7 +150,7 @@ function createDefaultORDDocument(linkedCsn, appConfig) {
     let ordDocument = {
         $schema: "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
         openResourceDiscovery: _getOpenResourceDiscovery(appConfig),
-        policyLevel: _getPolicyLevel(appConfig),
+        policyLevels: _getPolicyLevels(appConfig),
         description: _getDescription(appConfig),
         groups: _getGroups(linkedCsn, appConfig),
         consumptionBundles: _getConsumptionBundles(appConfig),
@@ -166,7 +166,7 @@ function createDefaultORDDocument(linkedCsn, appConfig) {
     const eventResources = _getEventResources(linkedCsn, appConfig);
 
     if (apiResources.length > 0 || eventResources.length > 0) {
-        ordDocument.packages = _getPackages(ordDocument.policyLevel, appConfig);
+        ordDocument.packages = _getPackages(ordDocument.policyLevels, appConfig);
     }
 
     return ordDocument;

--- a/xmpl/.cdsrc.json
+++ b/xmpl/.cdsrc.json
@@ -13,7 +13,7 @@
     "ord": {
         "namespace": "sap.sample",
         "description": "this is my custom description",
-        "policyLevel": "sap:core:v1",
+        "policyLevels": ["sap:core:v1"],
         "customOrdContentFile": "./ord/custom.ord.json",
         "existingProductORDId": "sap:product:SAPServiceCloudV2:",
         "products": [


### PR DESCRIPTION
ORD root property `policyLevel` is [deprecated](https://pages.github.tools.sap/CentralEngineering/open-resource-discovery-specification/spec-v1/interfaces/document#ord-document_policylevel). We need to update it.

However, we need to be compatible with older versions.  Here is open discussion,