### PR TITLE
Fix: error "Invalid array length"

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -365,9 +365,10 @@ function _getEntityTypeMappings(definitionObj) {
     if (!definitionObj.entities) {
         return;
     }
-    const entities = Object.values(definitionObj.entities)
-        .flatMap((entity) => _flattenEntityGraph(entity))
-        .map(createEntityTypeMappingsItemTemplate);
+    const entities = Object.values(definitionObj.entities).flatMap((entity) => {
+        const entityData = _flattenEntityGraph(entity).map(createEntityTypeMappingsItemTemplate);
+        return _.uniqBy(entityData, CONTENT_MERGE_KEY);
+    });
     const entityTypeTargets = _.uniqBy(entities, CONTENT_MERGE_KEY)
         .filter((entity) => entity !== undefined)
         .map(({ ordId }) => ({


### PR DESCRIPTION
Error "Invalid array length" occurred since Array.flatMap tryed to create an array larger than 2^32 - 1

This error can occur in large applications. See #176 