### PR TITLE
FIX: Customer vendor case

### DIFF
--- a/__tests__/__snapshots__/mockedCsn.test.js.snap
+++ b/__tests__/__snapshots__/mockedCsn.test.js.snap
@@ -305,7 +305,7 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
       "ordId": "customer:product:capire.bookshop.ord.sample:",
       "shortDescription": "Short description of capire bookshop ord sample",
       "title": "capire bookshop ord sample",
-      "vendor": "customer:vendor:customer:",
+      "vendor": "customer:vendor:Customer:",
     },
   ],
 }
@@ -430,7 +430,7 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
       "ordId": "customer:product:capire.bookshop.ord.sample:",
       "shortDescription": "Short description of capire bookshop ord sample",
       "title": "capire bookshop ord sample",
-      "vendor": "customer:vendor:customer:",
+      "vendor": "customer:vendor:Customer:",
     },
   ],
 }

--- a/__tests__/__snapshots__/ord.e2e.test.js.snap
+++ b/__tests__/__snapshots__/ord.e2e.test.js.snap
@@ -301,7 +301,7 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "ordId": "customer:product:capire.bookshop.ord.sample:",
       "shortDescription": "Short description of capire bookshop ord sample",
       "title": "capire bookshop ord sample",
-      "vendor": "customer:vendor:customer:",
+      "vendor": "customer:vendor:Customer:",
     },
   ],
 }
@@ -608,7 +608,7 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "ordId": "customer:product:capire.bookshop.ord.sample:",
       "shortDescription": "Short description of capire bookshop ord sample",
       "title": "capire bookshop ord sample",
-      "vendor": "customer:vendor:customer:",
+      "vendor": "customer:vendor:Customer:",
     },
   ],
 }
@@ -915,7 +915,7 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "ordId": "customer:product:capire.bookshop.ord.sample:",
       "shortDescription": "Short description of capire bookshop ord sample",
       "title": "capire bookshop ord sample",
-      "vendor": "customer:vendor:customer:",
+      "vendor": "customer:vendor:Customer:",
     },
   ],
 }
@@ -1040,7 +1040,7 @@ exports[`Tests for eventResource and apiResource should block MTXServices when m
       "ordId": "customer:product:capire.bookshop.ord.sample:",
       "shortDescription": "Short description of capire bookshop ord sample",
       "title": "capire bookshop ord sample",
-      "vendor": "customer:vendor:customer:",
+      "vendor": "customer:vendor:Customer:",
     },
   ],
 }
@@ -1510,7 +1510,7 @@ exports[`Tests for products and packages should raise error log when custom prod
       "ordId": "customer:product:capire.bookshop.ord.sample:",
       "shortDescription": "Short description of capire bookshop ord sample",
       "title": "capire bookshop ord sample",
-      "vendor": "customer:vendor:customer:",
+      "vendor": "customer:vendor:Customer:",
     },
   ],
 }

--- a/__tests__/__snapshots__/splitUpPackagesCsn.test.js.snap
+++ b/__tests__/__snapshots__/splitUpPackagesCsn.test.js.snap
@@ -409,7 +409,7 @@ exports[`ORD Generation for Business Accelerator Hub Tests for ORD document for 
       "ordId": "customer:product:capire.bookshop.ord.sample:",
       "shortDescription": "Short description of capire bookshop ord sample",
       "title": "capire bookshop ord sample",
-      "vendor": "customer:vendor:customer:",
+      "vendor": "customer:vendor:Customer:",
     },
   ],
 }

--- a/__tests__/unittest/__snapshots__/defaults.test.js.snap
+++ b/__tests__/unittest/__snapshots__/defaults.test.js.snap
@@ -286,7 +286,7 @@ exports[`defaults products should return default value 1`] = `
     "ordId": "customer:product:My.Product:",
     "shortDescription": "Short description of My Product",
     "title": "My Product",
-    "vendor": "customer:vendor:customer:",
+    "vendor": "customer:vendor:Customer:",
   },
 ]
 `;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -58,7 +58,7 @@ module.exports = {
             ordId: defaultProductOrdId(name),
             title: nameWithSpaces(name),
             shortDescription: SHORT_DESCRIPTION_PREFIX + nameWithSpaces(name),
-            vendor: "customer:vendor:customer:",
+            vendor: "customer:vendor:Customer:",
         },
     ],
     groupTypeId: "sap.cds:service",


### PR DESCRIPTION
Fix #190 

Global registry has
````
# Reserved Customer namespace (for when we don't want customers to register and use their own namespaces)
# Use this to indicate that ORD content has been created by the customer / owner of the tenant
# This is relevant for in-app extensions, where customers build their own resources within a platform.
# They could register their own vendor, but in many cases they
- ordId: 'customer:vendor:Customer:'
  title: Customer
  partners: []`
````