### PR TITLE
Fix: Reduce duplicate app namespace

### DIFF
--- a/__tests__/unittest/__snapshots__/namespace.test.js.snap
+++ b/__tests__/unittest/__snapshots__/namespace.test.js.snap
@@ -1,88 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`namespace should strip application namespace from local namespace 1`] = `
-[
-  {
-    "apiProtocol": "odata-v4",
-    "description": "Description for MyService",
-    "entryPoints": [
-      "/odata/v4/my",
-    ],
-    "extensible": {
-      "supported": "no",
-    },
-    "lastUpdate": "2022-12-19T15:47:04+00:00",
-    "ordId": "customer.testNamespace:apiResource:nested.MyService:v1",
-    "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:MyService",
-    ],
-    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
-    "releaseStatus": "active",
-    "resourceDefinitions": [
-      {
-        "accessStrategies": [
-          {
-            "type": "open",
-          },
-        ],
-        "mediaType": "application/json",
-        "type": "openapi-v3",
-        "url": "/ord/v1/customer.testNamespace:apiResource:nested.MyService:v1/MyService.oas3.json",
-      },
-      {
-        "accessStrategies": [
-          {
-            "type": "open",
-          },
-        ],
-        "mediaType": "application/xml",
-        "type": "edmx",
-        "url": "/ord/v1/customer.testNamespace:apiResource:nested.MyService:v1/MyService.edmx",
-      },
-    ],
-    "shortDescription": "Short description of MyService",
-    "title": "MyService",
-    "version": "1.0.0",
-    "visibility": "public",
-  },
-]
-`;
-
-exports[`namespace should strip application namespace from local namespace 2`] = `
-[
-  {
-    "description": "CAP Event resource describing events / messages.",
-    "extensible": {
-      "supported": "no",
-    },
-    "lastUpdate": "2022-12-19T15:47:04+00:00",
-    "ordId": "customer.testNamespace:eventResource:nested.MyService:v1",
-    "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:MyService",
-    ],
-    "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
-    "releaseStatus": "active",
-    "resourceDefinitions": [
-      {
-        "accessStrategies": [
-          {
-            "type": "open",
-          },
-        ],
-        "mediaType": "application/json",
-        "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:nested.MyService:v1/MyService.asyncapi2.json",
-      },
-    ],
-    "shortDescription": "MyService event resource",
-    "title": "ODM testAppName Events",
-    "version": "1.0.0",
-    "visibility": "public",
-  },
-]
-`;
-
-exports[`namespace should strip contain full local namespace 1`] = `
+exports[`namespace local and global should not strip a different local namespace 1`] = `
 [
   {
     "apiProtocol": "odata-v4",
@@ -96,7 +14,7 @@ exports[`namespace should strip contain full local namespace 1`] = `
     "lastUpdate": "2022-12-19T15:47:04+00:00",
     "ordId": "customer.testNamespace:apiResource:other.namespace.MyService:v1",
     "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:MyService",
+      "sap.cds:service:customer.testNamespace:other.namespace.MyService",
     ],
     "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
     "releaseStatus": "active",
@@ -130,7 +48,7 @@ exports[`namespace should strip contain full local namespace 1`] = `
 ]
 `;
 
-exports[`namespace should strip contain full local namespace 2`] = `
+exports[`namespace local and global should not strip a different local namespace 2`] = `
 [
   {
     "description": "CAP Event resource describing events / messages.",
@@ -140,7 +58,7 @@ exports[`namespace should strip contain full local namespace 2`] = `
     "lastUpdate": "2022-12-19T15:47:04+00:00",
     "ordId": "customer.testNamespace:eventResource:other.namespace.MyService:v1",
     "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:MyService",
+      "sap.cds:service:customer.testNamespace:other.namespace.MyService",
     ],
     "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
     "releaseStatus": "active",
@@ -154,6 +72,88 @@ exports[`namespace should strip contain full local namespace 2`] = `
         "mediaType": "application/json",
         "type": "asyncapi-v2",
         "url": "/ord/v1/customer.testNamespace:eventResource:other.namespace.MyService:v1/MyService.asyncapi2.json",
+      },
+    ],
+    "shortDescription": "MyService event resource",
+    "title": "ODM testAppName Events",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;
+
+exports[`namespace local and global should strip application namespace from local namespace 1`] = `
+[
+  {
+    "apiProtocol": "odata-v4",
+    "description": "Description for MyService",
+    "entryPoints": [
+      "/odata/v4/my",
+    ],
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:apiResource:nested.MyService:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:nested.MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "openapi-v3",
+        "url": "/ord/v1/customer.testNamespace:apiResource:nested.MyService:v1/MyService.oas3.json",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/xml",
+        "type": "edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:nested.MyService:v1/MyService.edmx",
+      },
+    ],
+    "shortDescription": "Short description of MyService",
+    "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;
+
+exports[`namespace local and global should strip application namespace from local namespace 2`] = `
+[
+  {
+    "description": "CAP Event resource describing events / messages.",
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:eventResource:nested.MyService:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:nested.MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "asyncapi-v2",
+        "url": "/ord/v1/customer.testNamespace:eventResource:nested.MyService:v1/MyService.asyncapi2.json",
       },
     ],
     "shortDescription": "MyService event resource",

--- a/__tests__/unittest/__snapshots__/namespace.test.js.snap
+++ b/__tests__/unittest/__snapshots__/namespace.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`namespace should have namespace 1`] = `
+[
+  {
+    "apiProtocol": "odata-v4",
+    "description": "Description for MyService",
+    "entryPoints": [
+      "/odata/v4/my",
+    ],
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:apiResource:MyService:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "openapi-v3",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.oas3.json",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/xml",
+        "type": "edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.edmx",
+      },
+    ],
+    "shortDescription": "Short description of MyService",
+    "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;

--- a/__tests__/unittest/__snapshots__/namespace.test.js.snap
+++ b/__tests__/unittest/__snapshots__/namespace.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`namespace should have namespace 1`] = `
+exports[`namespace should strip application namespace from local namespace 1`] = `
 [
   {
     "apiProtocol": "odata-v4",
@@ -12,7 +12,7 @@ exports[`namespace should have namespace 1`] = `
       "supported": "no",
     },
     "lastUpdate": "2022-12-19T15:47:04+00:00",
-    "ordId": "customer.testNamespace:apiResource:MyService:v1",
+    "ordId": "customer.testNamespace:apiResource:nested.MyService:v1",
     "partOfGroups": [
       "sap.cds:service:customer.testNamespace:MyService",
     ],
@@ -27,7 +27,7 @@ exports[`namespace should have namespace 1`] = `
         ],
         "mediaType": "application/json",
         "type": "openapi-v3",
-        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.oas3.json",
+        "url": "/ord/v1/customer.testNamespace:apiResource:nested.MyService:v1/MyService.oas3.json",
       },
       {
         "accessStrategies": [
@@ -37,11 +37,127 @@ exports[`namespace should have namespace 1`] = `
         ],
         "mediaType": "application/xml",
         "type": "edmx",
-        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:nested.MyService:v1/MyService.edmx",
       },
     ],
     "shortDescription": "Short description of MyService",
     "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;
+
+exports[`namespace should strip application namespace from local namespace 2`] = `
+[
+  {
+    "description": "CAP Event resource describing events / messages.",
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:eventResource:nested.MyService:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "asyncapi-v2",
+        "url": "/ord/v1/customer.testNamespace:eventResource:nested.MyService:v1/MyService.asyncapi2.json",
+      },
+    ],
+    "shortDescription": "MyService event resource",
+    "title": "ODM testAppName Events",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;
+
+exports[`namespace should strip contain full local namespace 1`] = `
+[
+  {
+    "apiProtocol": "odata-v4",
+    "description": "Description for MyService",
+    "entryPoints": [
+      "/odata/v4/my",
+    ],
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:apiResource:other.namespace.MyService:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "openapi-v3",
+        "url": "/ord/v1/customer.testNamespace:apiResource:other.namespace.MyService:v1/MyService.oas3.json",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/xml",
+        "type": "edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:other.namespace.MyService:v1/MyService.edmx",
+      },
+    ],
+    "shortDescription": "Short description of MyService",
+    "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;
+
+exports[`namespace should strip contain full local namespace 2`] = `
+[
+  {
+    "description": "CAP Event resource describing events / messages.",
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:eventResource:other.namespace.MyService:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "asyncapi-v2",
+        "url": "/ord/v1/customer.testNamespace:eventResource:other.namespace.MyService:v1/MyService.asyncapi2.json",
+      },
+    ],
+    "shortDescription": "MyService event resource",
+    "title": "ODM testAppName Events",
     "version": "1.0.0",
     "visibility": "public",
   },

--- a/__tests__/unittest/__snapshots__/namespace.test.js.snap
+++ b/__tests__/unittest/__snapshots__/namespace.test.js.snap
@@ -163,3 +163,85 @@ exports[`namespace local and global should strip application namespace from loca
   },
 ]
 `;
+
+exports[`namespace local and global should strip application namespace if its the same as local namespace 1`] = `
+[
+  {
+    "apiProtocol": "odata-v4",
+    "description": "Description for MyService",
+    "entryPoints": [
+      "/odata/v4/my",
+    ],
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:apiResource:MyService:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "openapi-v3",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.oas3.json",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/xml",
+        "type": "edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.edmx",
+      },
+    ],
+    "shortDescription": "Short description of MyService",
+    "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;
+
+exports[`namespace local and global should strip application namespace if its the same as local namespace 2`] = `
+[
+  {
+    "description": "CAP Event resource describing events / messages.",
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:eventResource:MyService:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "asyncapi-v2",
+        "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v1/MyService.asyncapi2.json",
+      },
+    ],
+    "shortDescription": "MyService event resource",
+    "title": "ODM testAppName Events",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;

--- a/__tests__/unittest/namespace.test.js
+++ b/__tests__/unittest/namespace.test.js
@@ -14,7 +14,7 @@ jest.spyOn(cds, "context", "get").mockReturnValue({
 });
 const { createAPIResourceTemplate, createEventResourceTemplate } = require("../../lib/templates");
 
-describe("namespace", () => {
+describe("namespace local and global", () => {
     it("should strip application namespace from local namespace", () => {
         const appConfig = {
             ordNamespace: "customer.testNamespace",
@@ -42,7 +42,7 @@ describe("namespace", () => {
         expect(createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
     });
 
-    it("should strip contain full local namespace", () => {
+    it("should not strip a different local namespace", () => {
         const appConfig = {
             ordNamespace: "customer.testNamespace",
             appName: "testAppName",

--- a/__tests__/unittest/namespace.test.js
+++ b/__tests__/unittest/namespace.test.js
@@ -1,0 +1,43 @@
+const cds = require("@sap/cds");
+const {
+    AUTHENTICATION_TYPE,
+    ORD_ODM_ENTITY_NAME_ANNOTATION,
+    ENTITY_RELATIONSHIP_ANNOTATION,
+    ORD_EXTENSIONS_PREFIX,
+    RESOURCE_VISIBILITY,
+} = require("../../lib/constants");
+
+jest.spyOn(cds, "context", "get").mockReturnValue({
+    authConfig: {
+        types: [AUTHENTICATION_TYPE.Open],
+    },
+});
+const { createAPIResourceTemplate } = require("../../lib/templates");
+
+describe("namespace", () => {
+    it("should have namespace", () => {
+        const appConfig = {
+            ordNamespace: "customer.testNamespace",
+            appName: "testAppName",
+            lastUpdate: "2022-12-19T15:47:04+00:00",
+        };
+        const serviceName = "MyService";
+        const testNamespace = "customer.testNamespace.nested.";
+        const model = cds.linked(`
+                namespace customer.testNamespace.nested;
+
+                service MyService {
+                    entity Books {
+                        key ID: UUID;
+                        title: String;
+                    }
+                };
+                annotate MyService with @ORD.Extensions : {
+                    visibility : 'public'
+                };
+            `);
+        const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
+        const srvDefinition = model.definitions[testNamespace + serviceName];
+        expect(createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+    });
+});

--- a/__tests__/unittest/namespace.test.js
+++ b/__tests__/unittest/namespace.test.js
@@ -12,10 +12,10 @@ jest.spyOn(cds, "context", "get").mockReturnValue({
         types: [AUTHENTICATION_TYPE.Open],
     },
 });
-const { createAPIResourceTemplate } = require("../../lib/templates");
+const { createAPIResourceTemplate, createEventResourceTemplate } = require("../../lib/templates");
 
 describe("namespace", () => {
-    it("should have namespace", () => {
+    it("should strip application namespace from local namespace", () => {
         const appConfig = {
             ordNamespace: "customer.testNamespace",
             appName: "testAppName",
@@ -39,5 +39,33 @@ describe("namespace", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions[testNamespace + serviceName];
         expect(createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+    });
+
+    it("should strip contain full local namespace", () => {
+        const appConfig = {
+            ordNamespace: "customer.testNamespace",
+            appName: "testAppName",
+            lastUpdate: "2022-12-19T15:47:04+00:00",
+        };
+        const serviceName = "MyService";
+        const testNamespace = "other.namespace.";
+        const model = cds.linked(`
+                namespace other.namespace;
+
+                service MyService {
+                    entity Books {
+                        key ID: UUID;
+                        title: String;
+                    }
+                };
+                annotate MyService with @ORD.Extensions : {
+                    visibility : 'public'
+                };
+            `);
+        const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
+        const srvDefinition = model.definitions[testNamespace + serviceName];
+        expect(createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
     });
 });

--- a/__tests__/unittest/namespace.test.js
+++ b/__tests__/unittest/namespace.test.js
@@ -42,6 +42,33 @@ describe("namespace local and global", () => {
         expect(createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
     });
 
+    it("should strip application namespace if its the same as local namespace", () => {
+        const appConfig = {
+            ordNamespace: "customer.testNamespace",
+            appName: "testAppName",
+            lastUpdate: "2022-12-19T15:47:04+00:00",
+        };
+        const serviceName = "MyService";
+        const testNamespace = "customer.testNamespace.";
+        const model = cds.linked(`
+                namespace customer.testNamespace;
+
+                service MyService {
+                    entity Books {
+                        key ID: UUID;
+                        title: String;
+                    }
+                };
+                annotate MyService with @ORD.Extensions : {
+                    visibility : 'public'
+                };
+            `);
+        const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
+        const srvDefinition = model.definitions[testNamespace + serviceName];
+        expect(createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+    });
+
     it("should not strip a different local namespace", () => {
         const appConfig = {
             ordNamespace: "customer.testNamespace",

--- a/__tests__/unittest/ordVisibilitySplit.test.js
+++ b/__tests__/unittest/ordVisibilitySplit.test.js
@@ -112,7 +112,7 @@ describe("templates", () => {
 
         it("should assign the correct partOfPackage for public API", () => {
             const serviceName = "PublicAPI";
-            const serviceDefinition = { "@ORD.Extensions.visibility": "public", "entities": [] };
+            const serviceDefinition = { "@ORD.Extensions.visibility": "public", "entities": [], "name": serviceName };
 
             const apiResource = createAPIResourceTemplate(serviceName, serviceDefinition, appConfig, packageIds, {});
 
@@ -122,7 +122,7 @@ describe("templates", () => {
 
         it("should assign the correct partOfPackage for internal API", () => {
             const serviceName = "InternalAPI";
-            const serviceDefinition = { "@ORD.Extensions.visibility": "internal", "entities": [] };
+            const serviceDefinition = { "@ORD.Extensions.visibility": "internal", "entities": [], "name": serviceName };
 
             const apiResource = createAPIResourceTemplate(serviceName, serviceDefinition, appConfig, packageIds, {});
 
@@ -132,7 +132,7 @@ describe("templates", () => {
 
         it("should return null for private API", () => {
             const serviceName = "PrivateAPI";
-            const serviceDefinition = { "@ORD.Extensions.visibility": "private", "entities": [] };
+            const serviceDefinition = { "@ORD.Extensions.visibility": "private", "entities": [], "name": serviceName };
 
             const apiResource = createAPIResourceTemplate(serviceName, serviceDefinition, appConfig, packageIds, {});
 
@@ -149,7 +149,7 @@ describe("templates", () => {
 
         it("should assign the correct partOfPackage for public Event", () => {
             const serviceName = "PublicEvent";
-            const serviceDefinition = { "@ORD.Extensions.visibility": "public", "entities": [] };
+            const serviceDefinition = { "@ORD.Extensions.visibility": "public", "entities": [], "name": serviceName };
 
             const eventResource = createEventResourceTemplate(
                 serviceName,
@@ -165,7 +165,7 @@ describe("templates", () => {
 
         it("should assign the correct partOfPackage for internal Event", () => {
             const serviceName = "InternalEvent";
-            const serviceDefinition = { "@ORD.Extensions.visibility": "internal", "entities": [] };
+            const serviceDefinition = { "@ORD.Extensions.visibility": "internal", "entities": [], "name": serviceName };
 
             const eventResource = createEventResourceTemplate(
                 serviceName,
@@ -181,7 +181,7 @@ describe("templates", () => {
 
         it("should return an empty array for private Event", () => {
             const serviceName = "PrivateEvent";
-            const serviceDefinition = { "@ORD.Extensions.visibility": "private", "entities": [] };
+            const serviceDefinition = { "@ORD.Extensions.visibility": "private", "entities": [], "name": serviceName };
 
             const eventResource = createEventResourceTemplate(
                 serviceName,

--- a/__tests__/unittest/templates.test.js
+++ b/__tests__/unittest/templates.test.js
@@ -85,6 +85,19 @@ describe("templates", () => {
     });
 
     describe("createGroupsTemplateForService", () => {
+        let serviceDefinition;
+        beforeAll(() => {
+            const model = cds.linked(`
+                service testServiceName {
+                    entity Books {
+                        key ID: UUID;
+                        title: String;
+                    }
+                };
+            `);
+            serviceDefinition = model.definitions["testServiceName"];
+        });
+
         it("should return default value when groupIds do not have groupId", () => {
             const testServiceName = "testServiceName";
             const testResult = {
@@ -92,17 +105,17 @@ describe("templates", () => {
                 groupTypeId: "sap.cds:service",
                 title: "test Service",
             };
-            expect(createGroupsTemplateForService(testServiceName, linkedModel, appConfig)).toEqual(testResult);
+            expect(createGroupsTemplateForService(testServiceName, serviceDefinition, appConfig)).toEqual(testResult);
         });
 
         it('should return default value with a proper Service title when "Service" keyword is missing', () => {
             const testServiceName = "testServName";
             const testResult = {
-                groupId: "sap.cds:service:customer.testNamespace:testServName",
+                groupId: "sap.cds:service:customer.testNamespace:testServiceName",
                 groupTypeId: "sap.cds:service",
                 title: "testServName Service",
             };
-            expect(createGroupsTemplateForService(testServiceName, linkedModel, appConfig)).toEqual(testResult);
+            expect(createGroupsTemplateForService(testServiceName, serviceDefinition, appConfig)).toEqual(testResult);
         });
 
         it("should return undefined when no service definition", () => {

--- a/__tests__/unittest/templates.test.js
+++ b/__tests__/unittest/templates.test.js
@@ -114,7 +114,15 @@ describe("templates", () => {
     describe("createAPIResourceTemplate", () => {
         it("should create API resource template correctly", () => {
             const serviceName = "MyService";
-            const srvDefinition = linkedModel;
+            const model = cds.linked(`
+                service MyService {
+                   entity Books {
+                       key ID: UUID;
+                       title: String;
+                   }
+                };
+            `);
+            const srvDefinition = model.definitions["MyService"];
             const packageIds = [
                 "sap.test.cdsrc.sample:package:test-event:v1",
                 "sap.test.cdsrc.sample:package:test-api:v1",
@@ -149,7 +157,15 @@ describe("templates", () => {
     describe("createEventResourceTemplate", () => {
         it("should create event resource template correctly", () => {
             const serviceName = "MyService";
-            const srvDefinition = linkedModel;
+            const model = cds.linked(`
+                service MyService {
+                   entity Books {
+                       key ID: UUID;
+                       title: String;
+                   }
+                };
+            `);
+            const srvDefinition = model.definitions["MyService"];
             const packageIds = [
                 "sap.test.cdsrc.sample:package:test-event:v1",
                 "sap.test.cdsrc.sample:package:test-api:v1",
@@ -159,7 +175,15 @@ describe("templates", () => {
 
         it("should create event resource template correctly with packageIds including namespace", () => {
             const serviceName = "MyService";
-            const srvDefinition = linkedModel;
+            const model = cds.linked(`
+                service MyService {
+                   entity Books {
+                       key ID: UUID;
+                       title: String;
+                   }
+                };
+            `);
+            const srvDefinition = model.definitions["MyService"];
             const packageIds = ["customer.testNamespace:package:test:v1"];
             expect(createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
         });

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -248,6 +248,11 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
 
     const paths = _generatePaths(serviceName, serviceDefinition);
     const apiResources = [];
+    if (serviceName.startsWith(appConfig.ordNamespace)) {
+        // Remove the local namespace from the service name
+        console.log(serviceName);
+        serviceName = serviceName.substring(appConfig.ordNamespace.length + 1);
+    }
     const ordId = `${appConfig.ordNamespace}:apiResource:${serviceName}:v1`;
 
     paths.forEach((generatedPath) => {
@@ -328,6 +333,11 @@ const createEventResourceTemplate = (serviceName, serviceDefinition, appConfig, 
     const ordExtensions = readORDExtensions(serviceDefinition);
     const visibility = _handleVisibility(ordExtensions, serviceDefinition);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.event, visibility);
+    if (serviceName.startsWith(appConfig.ordNamespace)) {
+        // Remove the local namespace from the service name
+        console.log(serviceName);
+        serviceName = serviceName.substring(appConfig.ordNamespace.length + 1);
+    }
     const ordId = `${appConfig.ordNamespace}:eventResource:${serviceName}:v1`;
     const entityTypeMappings = _getEntityTypeMappings(serviceDefinition);
 

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -249,8 +249,6 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
     const paths = _generatePaths(serviceName, serviceDefinition);
     const apiResources = [];
     if (serviceName.startsWith(appConfig.ordNamespace)) {
-        // Remove the local namespace from the service name
-        console.log(serviceName);
         serviceName = serviceName.substring(appConfig.ordNamespace.length + 1);
     }
     const ordId = `${appConfig.ordNamespace}:apiResource:${serviceName}:v1`;
@@ -334,8 +332,6 @@ const createEventResourceTemplate = (serviceName, serviceDefinition, appConfig, 
     const visibility = _handleVisibility(ordExtensions, serviceDefinition);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.event, visibility);
     if (serviceName.startsWith(appConfig.ordNamespace)) {
-        // Remove the local namespace from the service name
-        console.log(serviceName);
         serviceName = serviceName.substring(appConfig.ordNamespace.length + 1);
     }
     const ordId = `${appConfig.ordNamespace}:eventResource:${serviceName}:v1`;

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -95,8 +95,19 @@ const createEntityTypeMappingsItemTemplate = (entity) => {
     }
 };
 
-function _getGroupID(fullyQualifiedName, groupTypeId = defaults.groupTypeId, appConfig) {
-    return `${groupTypeId}:${appConfig.ordNamespace}:${fullyQualifiedName}`;
+function _getGroupID(serviceDefinition, groupTypeId = defaults.groupTypeId, appConfig) {
+    return `${groupTypeId}:${appConfig.ordNamespace}:${_getGroupNameWithNestedNamespace(serviceDefinition, appConfig)}`;
+}
+
+function _getGroupNameWithNestedNamespace({ name }, appConfig) {
+    if (!name.startsWith(appConfig.ordNamespace)) {
+        return name;
+    }
+    let sortedName = name.substring(appConfig.ordNamespace.length);
+    if (sortedName.startsWith(".")) {
+        sortedName = sortedName.substring(1);
+    }
+    return sortedName;
 }
 
 /**
@@ -174,7 +185,7 @@ const createGroupsTemplateForService = (serviceName, serviceDefinition, appConfi
         return undefined;
     }
 
-    const groupId = _getGroupID(serviceName, defaults.groupTypeId, appConfig);
+    const groupId = _getGroupID(serviceDefinition, defaults.groupTypeId, appConfig);
     return {
         groupId: groupId,
         groupTypeId: defaults.groupTypeId,
@@ -248,11 +259,7 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
 
     const paths = _generatePaths(serviceName, serviceDefinition);
     const apiResources = [];
-    let ordIdName = serviceDefinition.name;
-    if (ordIdName.startsWith(appConfig.ordNamespace)) {
-        ordIdName = ordIdName.substring(appConfig.ordNamespace.length + 1);
-    }
-    const ordId = `${appConfig.ordNamespace}:apiResource:${ordIdName}:v1`;
+    const ordId = `${appConfig.ordNamespace}:apiResource:${_getGroupNameWithNestedNamespace(serviceDefinition, appConfig)}:v1`;
 
     paths.forEach((generatedPath) => {
         let resourceDefinitions = [
@@ -277,7 +284,7 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
             lastUpdate: appConfig.lastUpdate,
             visibility,
             partOfPackage: packageId,
-            partOfGroups: [_getGroupID(serviceName, defaults.groupTypeId, appConfig)],
+            partOfGroups: [_getGroupID(serviceDefinition, defaults.groupTypeId, appConfig)],
             releaseStatus: "active",
             apiProtocol: generatedPath.kind === "odata" ? "odata-v4" : generatedPath.kind,
             resourceDefinitions: resourceDefinitions,
@@ -332,11 +339,7 @@ const createEventResourceTemplate = (serviceName, serviceDefinition, appConfig, 
     const ordExtensions = readORDExtensions(serviceDefinition);
     const visibility = _handleVisibility(ordExtensions, serviceDefinition);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.event, visibility);
-    let ordIdName = serviceDefinition.name;
-    if (ordIdName.startsWith(appConfig.ordNamespace)) {
-        ordIdName = ordIdName.substring(appConfig.ordNamespace.length + 1);
-    }
-    const ordId = `${appConfig.ordNamespace}:eventResource:${ordIdName}:v1`;
+    const ordId = `${appConfig.ordNamespace}:eventResource:${_getGroupNameWithNestedNamespace(serviceDefinition, appConfig)}:v1`;
     const entityTypeMappings = _getEntityTypeMappings(serviceDefinition);
 
     let obj = {
@@ -354,7 +357,7 @@ const createEventResourceTemplate = (serviceName, serviceDefinition, appConfig, 
         lastUpdate: appConfig.lastUpdate,
         releaseStatus: "active",
         partOfPackage: packageId,
-        partOfGroups: [_getGroupID(serviceName, defaults.groupTypeId, appConfig)],
+        partOfGroups: [_getGroupID(serviceDefinition, defaults.groupTypeId, appConfig)],
         visibility,
         resourceDefinitions: [
             _getResourceDefinition("asyncapi-v2", "json", ordId, serviceName, "asyncapi2.json", accessStrategies),

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -248,10 +248,11 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
 
     const paths = _generatePaths(serviceName, serviceDefinition);
     const apiResources = [];
-    if (serviceName.startsWith(appConfig.ordNamespace)) {
-        serviceName = serviceName.substring(appConfig.ordNamespace.length + 1);
+    let ordIdName = serviceDefinition.name;
+    if (ordIdName.startsWith(appConfig.ordNamespace)) {
+        ordIdName = ordIdName.substring(appConfig.ordNamespace.length + 1);
     }
-    const ordId = `${appConfig.ordNamespace}:apiResource:${serviceName}:v1`;
+    const ordId = `${appConfig.ordNamespace}:apiResource:${ordIdName}:v1`;
 
     paths.forEach((generatedPath) => {
         let resourceDefinitions = [
@@ -331,10 +332,11 @@ const createEventResourceTemplate = (serviceName, serviceDefinition, appConfig, 
     const ordExtensions = readORDExtensions(serviceDefinition);
     const visibility = _handleVisibility(ordExtensions, serviceDefinition);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.event, visibility);
-    if (serviceName.startsWith(appConfig.ordNamespace)) {
-        serviceName = serviceName.substring(appConfig.ordNamespace.length + 1);
+    let ordIdName = serviceDefinition.name;
+    if (ordIdName.startsWith(appConfig.ordNamespace)) {
+        ordIdName = ordIdName.substring(appConfig.ordNamespace.length + 1);
     }
-    const ordId = `${appConfig.ordNamespace}:eventResource:${serviceName}:v1`;
+    const ordId = `${appConfig.ordNamespace}:eventResource:${ordIdName}:v1`;
     const entityTypeMappings = _getEntityTypeMappings(serviceDefinition);
 
     let obj = {


### PR DESCRIPTION
Reduce duplicate app namespace for resource names

This covers:
- API Ressource ordID generation
- Event Ressource ordID generation