### PR TITLE
Feat: introducing defaultVisibility parameter in config

### DIFF
--- a/__tests__/unittest/templates.test.js
+++ b/__tests__/unittest/templates.test.js
@@ -5,6 +5,7 @@ const {
     ENTITY_RELATIONSHIP_ANNOTATION,
     ORD_EXTENSIONS_PREFIX,
     RESOURCE_VISIBILITY,
+    ALLOWED_VISIBILITY,
 } = require("../../lib/constants");
 
 jest.spyOn(cds, "context", "get").mockReturnValue({
@@ -20,7 +21,79 @@ const {
     createEventResourceTemplate,
     _getEntityTypeMappings,
     _propagateORDVisibility,
+    _handleVisibility,
 } = require("../../lib/templates");
+
+const { Logger } = require("../../lib/logger");
+
+describe("visibility handling", () => {
+    let loggerSpy;
+    beforeEach(() => {
+        loggerSpy = jest.spyOn(Logger, "warn").mockImplementation(() => {});
+    });
+    afterEach(() => {
+        loggerSpy.mockRestore();
+    });
+
+    it("returns internal for primary data product service", () => {
+        const ordExtensions = {};
+        const definition = { "@DataIntegration.dataProduct.type": "primary" };
+        expect(_handleVisibility(ordExtensions, definition, RESOURCE_VISIBILITY.public)).toBe(
+            RESOURCE_VISIBILITY.internal,
+        );
+    });
+
+    it("returns extension visibility if present and valid", () => {
+        const ordExtensions = { visibility: "internal" };
+        const definition = {};
+        expect(_handleVisibility(ordExtensions, definition, RESOURCE_VISIBILITY.public)).toBe("internal");
+    });
+
+    it("returns config value if valid", () => {
+        const ordExtensions = {};
+        const definition = {};
+        expect(_handleVisibility(ordExtensions, definition, "public")).toBe("public");
+    });
+
+    it("falls back to public and logs warning for invalid config value", () => {
+        const ordExtensions = {};
+        const definition = {};
+        expect(_handleVisibility(ordExtensions, definition, "notallowed")).toBe("public");
+        expect(loggerSpy).toHaveBeenCalledWith(
+            'Default visibility "notallowed" is not supported. Using "public" as fallback.',
+        );
+    });
+
+    it("returns public for implementationStandard sap:ord-document-api:v1", () => {
+        const ordExtensions = { implementationStandard: "sap:ord-document-api:v1" };
+        const definition = {};
+        expect(_handleVisibility(ordExtensions, definition, "private")).toBe("public");
+    });
+
+    it("returns definition[ORD_EXTENSIONS_PREFIX + visibility] if present", () => {
+        const ordExtensions = {};
+        const definition = { "@ORD.Extensions.visibility": "internal" };
+        expect(_handleVisibility(ordExtensions, definition, "public")).toBe("internal");
+    });
+
+    it("returns public if no visibility is defined", () => {
+        const ordExtensions = {};
+        const definition = {};
+        expect(_handleVisibility(ordExtensions, definition)).toBe("public");
+    });
+
+    it("Allowed visibility values are respected", () => {
+        const ordExtensions = {};
+        const definition = {};
+        expect(ALLOWED_VISIBILITY).toContain(RESOURCE_VISIBILITY.public);
+        expect(ALLOWED_VISIBILITY).toContain(RESOURCE_VISIBILITY.internal);
+        expect(ALLOWED_VISIBILITY).toContain(RESOURCE_VISIBILITY.private);
+        // Test with all allowed visibility values
+        expect(_handleVisibility(ordExtensions, definition, RESOURCE_VISIBILITY.public)).toBe("public");
+        expect(_handleVisibility(ordExtensions, definition, RESOURCE_VISIBILITY.private)).toBe("private");
+        expect(_handleVisibility(ordExtensions, definition, RESOURCE_VISIBILITY.internal)).toBe("internal");
+    });
+});
 
 describe("templates", () => {
     let linkedModel;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -83,6 +83,8 @@ const RESOURCE_VISIBILITY = Object.freeze({
     private: "private",
 });
 
+const ALLOWED_VISIBILITY = Object.values(RESOURCE_VISIBILITY);
+
 const SHORT_DESCRIPTION_PREFIX = "Short description of ";
 
 const SEM_VERSION_REGEX =
@@ -111,6 +113,7 @@ module.exports = {
     ORD_RESOURCE_TYPE,
     ORD_SERVICE_NAME,
     RESOURCE_VISIBILITY,
+    ALLOWED_VISIBILITY,
     SHORT_DESCRIPTION_PREFIX,
     SEM_VERSION_REGEX,
 };

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -13,6 +13,7 @@ const {
     ORD_ODM_ENTITY_NAME_ANNOTATION,
     ORD_RESOURCE_TYPE,
     RESOURCE_VISIBILITY,
+    ALLOWED_VISIBILITY,
     SEM_VERSION_REGEX,
     SHORT_DESCRIPTION_PREFIX,
     CONTENT_MERGE_KEY,
@@ -242,6 +243,14 @@ const createEntityTypeTemplate = (appConfig, packageIds, entity) => {
 
 function _handleVisibility(ordExtensions, definition, defaultVisibility = RESOURCE_VISIBILITY.public) {
     let visibility;
+    //check for supported custom visibility value in defaultVisibility variable
+    if (!ALLOWED_VISIBILITY.includes(defaultVisibility)) {
+        Logger.warn(
+            `Default visibility "${defaultVisibility}" is not supported. Using "${RESOURCE_VISIBILITY.public}" as fallback.`,
+        );
+        defaultVisibility = RESOURCE_VISIBILITY.public;
+    }
+    // Determine visibility
     if (isPrimaryDataProductService(definition)) {
         visibility = RESOURCE_VISIBILITY.internal;
     } else if (ordExtensions.visibility) {
@@ -251,7 +260,7 @@ function _handleVisibility(ordExtensions, definition, defaultVisibility = RESOUR
     } else if (ordExtensions.implementationStandard === "sap:ord-document-api:v1") {
         // if the implementationStandard is sap:ord-document-api:v1, it should be public by default
         visibility = RESOURCE_VISIBILITY.public;
-    } else {
+    } else if (ALLOWED_VISIBILITY.includes(defaultVisibility)) {
         // Default visibility from config file
         visibility = defaultVisibility;
     }
@@ -486,4 +495,5 @@ module.exports = {
     _getPackageID,
     _getEntityTypeMappings,
     _propagateORDVisibility,
+    _handleVisibility,
 };

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -240,7 +240,7 @@ const createEntityTypeTemplate = (appConfig, packageIds, entity) => {
     };
 };
 
-function _handleVisibility(ordExtensions, definition) {
+function _handleVisibility(ordExtensions, definition, defaultVisibility = RESOURCE_VISIBILITY.public) {
     let visibility;
     if (isPrimaryDataProductService(definition)) {
         visibility = RESOURCE_VISIBILITY.internal;
@@ -248,8 +248,12 @@ function _handleVisibility(ordExtensions, definition) {
         visibility = ordExtensions.visibility;
     } else if (definition[ORD_EXTENSIONS_PREFIX + "visibility"]) {
         visibility = definition[ORD_EXTENSIONS_PREFIX + "visibility"];
-    } else {
+    } else if (ordExtensions.implementationStandard === "sap:ord-document-api:v1") {
+        // if the implementationStandard is sap:ord-document-api:v1, it should be public by default
         visibility = RESOURCE_VISIBILITY.public;
+    } else {
+        // Default visibility from config file
+        visibility = defaultVisibility;
     }
     return visibility;
 }
@@ -267,7 +271,7 @@ function _handleVisibility(ordExtensions, definition) {
  */
 const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, packageIds, accessStrategies) => {
     const ordExtensions = readORDExtensions(serviceDefinition);
-    const visibility = _handleVisibility(ordExtensions, serviceDefinition);
+    const visibility = _handleVisibility(ordExtensions, serviceDefinition, appConfig.env?.defaultVisibility);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.api, visibility);
 
     const paths = _generatePaths(serviceName, serviceDefinition);
@@ -349,7 +353,7 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
  */
 const createEventResourceTemplate = (serviceName, serviceDefinition, appConfig, packageIds, accessStrategies) => {
     const ordExtensions = readORDExtensions(serviceDefinition);
-    const visibility = _handleVisibility(ordExtensions, serviceDefinition);
+    const visibility = _handleVisibility(ordExtensions, serviceDefinition, appConfig.env?.defaultVisibility);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.event, visibility);
     const ordId = `${appConfig.ordNamespace}:eventResource:${_getGroupNameWithNestedNamespace(serviceDefinition, appConfig)}:v1`;
     const entityTypeMappings = _getEntityTypeMappings(serviceDefinition);

--- a/xmpl/.cdsrc.json
+++ b/xmpl/.cdsrc.json
@@ -15,6 +15,7 @@
         "description": "this is my custom description",
         "policyLevels": ["sap:core:v1"],
         "customOrdContentFile": "./ord/custom.ord.json",
+        "defaultVisibility": "internal",
         "existingProductORDId": "sap:product:SAPServiceCloudV2:",
         "products": [
             {


### PR DESCRIPTION
Tackling https://github.com/cap-js/ord/issues/189 

- Introducing new param `defaultVisibility ` which can be read from `.cdsrc.json`
- Introducing new constant `ALLOWED_VISIBILITY ` to verify input
- Adding tests

