### PR TITLE
chore: prepare for trusted publishing, enable provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,4 @@ jobs:
               with:
                   tag: "v${{ steps.package-version.outputs.current-version }}"
                   body: "${{ steps.parse-changelog.outputs.body }}"
-            - run: npm publish --access public
-              env:
-                  NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+            - run: npm publish --access public --provenance


### PR DESCRIPTION
Allows token-less publishing.
See https://docs.npmjs.com/trusted-publishers