### PR TITLE
Fix: use @sap/cds instead of @sap/cds-dk for build plugin

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,6 +19,7 @@ jobs:
 
             - name: Install dependencies
               run: |
+                  npm install -g @sap/cds-dk@latest
                   npm install
 
             - name: Run basic auth integration tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,9 @@ jobs:
 
             - name: Install dependencies and prepare documents
               run: |
+                  npm install -g @sap/cds-dk@latest
                   npm install @sap/cds@latest
-                  npx cds version
+                  cds version
 
             - name: Node.js Test
               run: |
@@ -37,5 +38,5 @@ jobs:
               run: |
                   cd xmpl_java
                   npm i
-                  npx cds build --for ord
+                  cds build --for ord
                   mvn clean test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ npm i
 For testing an example app is available in the `xmpl` folder:
 
 ```bash
+#If not already globally installed, install cds-dk
+npm install -g @sap/cds-dk
 cds w xmpl
 ```
 

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -13,6 +13,7 @@
 **CAP Framework Integration**:
 
 - **@sap/cds**: Core CAP framework (>=8.9.4)
+- **@sap/cds-dk**: CAP development kit (>=8.9.5)
 - **CSN (Core Schema Notation)**: CAP's internal model representation
 
 **Key Dependencies**:
@@ -54,6 +55,9 @@
 ```bash
 # Node.js (versions 18-22 currently supported)
 node --version  # Should be v18.x, v20.x, or v22.x
+
+# CAP development kit
+npm install -g @sap/cds-dk
 
 # Clone with submodules (if using calesi)
 git clone --recursive https://github.com/cap-js/calesi.git

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "jest": "^30.0.0",
         "prettier": "3.7.4",
         "supertest": "^7.0.0",
-        "@cap-js/sqlite": "^2"
+        "@cap-js/sqlite": "^2",
+        "@sap/cds-dk": ">=8.9.5"
     },
     "peerDependencies": {
         "@sap/cds": ">=8.9.4"


### PR DESCRIPTION
- Change build plugin to extend cds.build.Plugin from @sap/cds
- Remove @sap/cds-dk from peerDependencies
- Update tests to mock cds.build.Plugin before requiring build.js
- Aligns with other CAP plugins (notifications, captivator) pattern
- cds.build.Plugin is injected by cds-dk at build time