### PR TITLE
FIX: Adjust API apiProtocol for primary data product services

### DIFF
--- a/__tests__/unit/__snapshots__/ord.e2e.test.js.snap
+++ b/__tests__/unit/__snapshots__/ord.e2e.test.js.snap
@@ -105,7 +105,7 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "visibility": "internal",
     },
     {
-      "apiProtocol": "rest",
+      "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
       "entityTypeMappings": [
@@ -132,7 +132,6 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "extensible": {
         "supported": "no",
       },
-      "implementationStandard": "sap.dp:data-subscription-api:v1",
       "lastUpdate": "2024-11-04T14:33:25+01:00",
       "ordId": "sap.test.cdsrc.sample:apiResource:sap.capdpprod.DPBooks:v1",
       "partOfGroups": [
@@ -452,7 +451,7 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "visibility": "internal",
     },
     {
-      "apiProtocol": "rest",
+      "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
       "entityTypeMappings": [
@@ -479,7 +478,6 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "extensible": {
         "supported": "no",
       },
-      "implementationStandard": "sap.dp:data-subscription-api:v1",
       "lastUpdate": "2024-11-04T14:33:25+01:00",
       "ordId": "sap.test.cdsrc.sample:apiResource:sap.capdpprod.DPBooks:v1",
       "partOfGroups": [
@@ -799,7 +797,7 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "visibility": "internal",
     },
     {
-      "apiProtocol": "rest",
+      "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
       "entityTypeMappings": [
@@ -826,7 +824,6 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "extensible": {
         "supported": "no",
       },
-      "implementationStandard": "sap.dp:data-subscription-api:v1",
       "lastUpdate": "2024-11-04T14:33:25+01:00",
       "ordId": "sap.test.cdsrc.sample:apiResource:sap.capdpprod.DPBooks:v1",
       "partOfGroups": [
@@ -2479,7 +2476,7 @@ exports[`Tests for eventResource and apiResource should allow MCP API resource c
       "visibility": "internal",
     },
     {
-      "apiProtocol": "rest",
+      "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
       "entityTypeMappings": [
@@ -2506,7 +2503,6 @@ exports[`Tests for eventResource and apiResource should allow MCP API resource c
       "extensible": {
         "supported": "no",
       },
-      "implementationStandard": "sap.dp:data-subscription-api:v1",
       "lastUpdate": "2024-11-04T14:33:25+01:00",
       "ordId": "sap.test.cdsrc.sample:apiResource:sap.capdpprod.DPBooks:v1",
       "partOfGroups": [
@@ -3426,7 +3422,7 @@ exports[`Tests for products and packages should not contain products property if
       "visibility": "internal",
     },
     {
-      "apiProtocol": "rest",
+      "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
       "entityTypeMappings": [
@@ -3453,7 +3449,6 @@ exports[`Tests for products and packages should not contain products property if
       "extensible": {
         "supported": "no",
       },
-      "implementationStandard": "sap.dp:data-subscription-api:v1",
       "lastUpdate": "2024-11-04T14:33:25+01:00",
       "ordId": "customer.capirebookshopordsample:apiResource:sap.capdpprod.DPBooks:v1",
       "partOfGroups": [
@@ -3726,7 +3721,7 @@ exports[`Tests for products and packages should raise error log when custom prod
       "visibility": "internal",
     },
     {
-      "apiProtocol": "rest",
+      "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
       "entityTypeMappings": [
@@ -3753,7 +3748,6 @@ exports[`Tests for products and packages should raise error log when custom prod
       "extensible": {
         "supported": "no",
       },
-      "implementationStandard": "sap.dp:data-subscription-api:v1",
       "lastUpdate": "2024-11-04T14:33:25+01:00",
       "ordId": "customer.capirebookshopordsample:apiResource:sap.capdpprod.DPBooks:v1",
       "partOfGroups": [
@@ -4034,7 +4028,7 @@ exports[`Tests for products and packages should use valid custom products ordId 
       "visibility": "internal",
     },
     {
-      "apiProtocol": "rest",
+      "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
       "entityTypeMappings": [
@@ -4061,7 +4055,6 @@ exports[`Tests for products and packages should use valid custom products ordId 
       "extensible": {
         "supported": "no",
       },
-      "implementationStandard": "sap.dp:data-subscription-api:v1",
       "lastUpdate": "2024-11-04T14:33:25+01:00",
       "ordId": "customer.capirebookshopordsample:apiResource:sap.capdpprod.DPBooks:v1",
       "partOfGroups": [

--- a/__tests__/unit/mockedCsn.test.js
+++ b/__tests__/unit/mockedCsn.test.js
@@ -133,7 +133,7 @@ describe("Tests for ORD document generated out of mocked csn files", () => {
 
             expect(document.apiResources).toHaveLength(1);
             const dataProductApiResources = document.apiResources.filter(
-                (resource) => resource.implementationStandard === "sap.dp:data-subscription-api:v1",
+                (resource) => resource.apiProtocol === "sap.dp:data-subscription-api:v1",
             );
             expect(dataProductApiResources).toHaveLength(1);
             expect(dataProductApiResources[0].resourceDefinitions).toHaveLength(1);
@@ -157,7 +157,7 @@ describe("Tests for ORD document generated out of mocked csn files", () => {
 
             expect(document.apiResources).toHaveLength(1);
             const dataProductApiResources = document.apiResources.filter(
-                (resource) => resource.implementationStandard === "sap.dp:data-subscription-api:v1",
+                (resource) => resource.apiProtocol === "sap.dp:data-subscription-api:v1",
             );
             expect(dataProductApiResources).toHaveLength(1);
             expect(dataProductApiResources[0].resourceDefinitions).toHaveLength(1);
@@ -166,7 +166,6 @@ describe("Tests for ORD document generated out of mocked csn files", () => {
                 "sap.test.cdsrc.sample:package:capirebookshopordsample-api-internal:v1",
             );
             expect(dataProductApiResources[0].visibility).toEqual("internal");
-            expect(dataProductApiResources[0].apiProtocol).toEqual("rest");
             expect(dataProductApiResources[0].direction).toEqual("outbound");
         });
 

--- a/__tests__/unit/versionSuffixExtraction.test.js
+++ b/__tests__/unit/versionSuffixExtraction.test.js
@@ -295,9 +295,8 @@ describe("Version Suffix Extraction for Data Product Services", () => {
             );
 
             expect(result).toHaveLength(1);
-            expect(result[0].apiProtocol).toBe("rest");
             expect(result[0].direction).toBe("outbound");
-            expect(result[0].implementationStandard).toBe("sap.dp:data-subscription-api:v1");
+            expect(result[0].apiProtocol).toBe("sap.dp:data-subscription-api:v1");
             expect(result[0].entryPoints).toEqual([]);
             expect(result[0].resourceDefinitions).toHaveLength(1);
             expect(result[0].resourceDefinitions[0].type).toBe("sap-csn-interop-effective-v1");
@@ -325,9 +324,8 @@ describe("Version Suffix Extraction for Data Product Services", () => {
             expect(result[0].ordId).toBe("sap.test:apiResource:DataService:v1");
             expect(result[0].version).toBe("1.0.0");
             expect(result[0].partOfGroups[0]).toBe("sap.cds:service:sap.test:DataService");
-            expect(result[0].apiProtocol).toBe("rest");
             expect(result[0].direction).toBe("outbound");
-            expect(result[0].implementationStandard).toBe("sap.dp:data-subscription-api:v1");
+            expect(result[0].apiProtocol).toBe("sap.dp:data-subscription-api:v1");
         });
 
         test("should handle .v2 suffix correctly with @data.product annotation", () => {

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -390,9 +390,8 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
         };
 
         if (isPrimaryDataProductService(serviceDefinition)) {
-            obj.apiProtocol = "rest";
+            obj.apiProtocol = "sap.dp:data-subscription-api:v1";
             obj.direction = "outbound";
-            obj.implementationStandard = "sap.dp:data-subscription-api:v1";
             obj.entryPoints = [];
             if (extracted) {
                 // Overwrite partOfGroups


### PR DESCRIPTION
Set apiProtocol to "sap.dp:data-subscription-api:v1" instead of "rest" to avoid validation errors with regards to rest APIs expecting OpenAPI definitions.