### PR TITLE
chore: release v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.4.3 (2026-01-29)
+
+## What's Changed
+
+- feat: support @OpenAPI.servers annotation for service-level server URLs by @swennemers in https://github.com/cap-js/ord/pull/339
+- fix: throw BuildError during cds build to terminate build on errors by @zongqichen in https://github.com/cap-js/ord/pull/334
+- fix: finalize CF mTLS configuration documentation by @zongqichen in https://github.com/cap-js/ord/pull/331
+
+**Full Changelog**: https://github.com/cap-js/ord/compare/v1.4.2...v1.4.3
+
 ## 1.4.2 (2026-01-14)
 
 ## What's Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cap-js/ord",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "CAP Plugin for generating ORD document.",
     "repository": "cap-js/ord",
     "author": "SAP SE (https://www.sap.com)",


### PR DESCRIPTION
## Summary

- Bump version to 1.4.3
- Update CHANGELOG.md with release notes

## What's Changed in v1.4.3

- feat: support @OpenAPI.servers annotation for service-level server URLs (#339)
- fix: throw BuildError during cds build to terminate build on errors (#334)
- fix: finalize CF mTLS configuration documentation (#331)

**Full Changelog**: https://github.com/cap-js/ord/compare/v1.4.2...v1.4.3