### PR TITLE
fix: path-to-regexp v8 compatibility for CDS 9.7.0

### DIFF
--- a/lib/ord-service.js
+++ b/lib/ord-service.js
@@ -31,7 +31,8 @@ class OpenResourceDiscoveryService extends cds.ApplicationService {
             return res.status(404).send("404 Not Found");
         });
 
-        cds.app.get(`/ord/v1/:ordId?/:service?`, authMiddleware, async (req, res) => {
+        // Handler for metadata requests (oas3, edmx, csn, etc.)
+        const metadataHandler = async (req, res) => {
             try {
                 const { contentType, response } = await getMetadata(req.url);
                 return res.status(200).contentType(contentType).send(response);
@@ -39,7 +40,12 @@ class OpenResourceDiscoveryService extends cds.ApplicationService {
                 Logger.error(error, "Error while processing the resource definition document");
                 return res.status(500).send(error.message);
             }
-        });
+        };
+
+        // Use separate routes instead of optional parameters for path-to-regexp v8 compatibility
+        cds.app.get(`/ord/v1/:ordId/:service`, authMiddleware, metadataHandler);
+        cds.app.get(`/ord/v1/:ordId`, authMiddleware, metadataHandler);
+        cds.app.get(`/ord/v1`, authMiddleware, metadataHandler);
 
         return super.init();
     }


### PR DESCRIPTION
## Summary

- CDS 9.7.0 upgraded its dependency chain which includes `path-to-regexp` v8.x
- This version no longer supports the `?` suffix syntax for optional route parameters (e.g., `:ordId?`)
- The change caused runtime crashes when starting CAP applications with `@sap/cds@9.7.0`

## Solution

Replace the single route with optional parameters:
```javascript
`/ord/v1/:ordId?/:service?`
```

With three separate routes using only required parameters:
```javascript
`/ord/v1/:ordId/:service`
`/ord/v1/:ordId`
`/ord/v1`
```

This approach uses only the basic `:param` syntax which is compatible with both old (`path-to-regexp` v0.1.x) and new (`path-to-regexp` v8.x) versions.

Fixes #356