### PR TITLE
fix: include service name in error messages

### DIFF
--- a/lib/metaData.js
+++ b/lib/metaData.js
@@ -46,7 +46,7 @@ const getMetadata = async (url, model = null) => {
 
                 responseFile = openapi(csn, openapiOptions);
             } catch (error) {
-                Logger.error("OpenApi error for service", serviceName, "-", error.message);
+                Logger.error(`OpenApi error for service ${serviceName} - ${error.message}`);
                 throw error;
             }
             break;
@@ -54,7 +54,7 @@ const getMetadata = async (url, model = null) => {
             try {
                 responseFile = asyncapi(csn, { ...options, ...(compileOptions?.asyncapi || {}) });
             } catch (error) {
-                Logger.error("AsyncApi error for service", serviceName, "-", error.message);
+                Logger.error(`AsyncApi error for service ${serviceName} - ${error.message}`);
                 throw error;
             }
             break;
@@ -64,7 +64,7 @@ const getMetadata = async (url, model = null) => {
                 let effCsn = cdsc.for.effective(csn, opt_eff);
                 responseFile = interopCSN(effCsn);
             } catch (error) {
-                Logger.error("Csn error for service", serviceName, "-", error.message);
+                Logger.error(`Csn error for service ${serviceName} - ${error.message}`);
                 throw error;
             }
             break;
@@ -72,7 +72,7 @@ const getMetadata = async (url, model = null) => {
             try {
                 responseFile = await cds.compile(csn).to["edmx"]({ ...options, ...(compileOptions?.edmx || {}) });
             } catch (error) {
-                Logger.error("Edmx error for service", serviceName, "-", error.message);
+                Logger.error(`Edmx error for service ${serviceName} - ${error.message}`);
                 throw error;
             }
             break;
@@ -88,7 +88,7 @@ const getMetadata = async (url, model = null) => {
                 // Extract only the MCP content, not the ORD metadata
                 responseFile = mcpResult.mcp;
             } catch (error) {
-                Logger.error("MCP server definition error:", error.message);
+                Logger.error(`MCP server definition error - ${error.message}`);
                 throw error;
             }
             break;


### PR DESCRIPTION
## Summary

- Adds service name to error messages in `lib/metaData.js` for all compiler types (OpenApi, AsyncApi, Csn, Edmx)
- Makes debugging easier in large projects with many services by identifying which service triggered the error

Closes #364