### PR TITLE
chore: Simplify file generation logic

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -5,9 +5,8 @@ const Piscina = require("piscina");
 const cliProgress = require("cli-progress");
 
 const os = require("os");
-const compileMetadata = require("./metaData");
 const { ord } = require("./index");
-const { BUILD_DEFAULT_PATH, ORD_SERVICE_NAME, ORD_DOCUMENT_FILE_NAME } = require("./constants");
+const { BUILD_DEFAULT_PATH, ORD_DOCUMENT_FILE_NAME } = require("./constants");
 
 module.exports = class OrdBuildPlugin extends cds.build.Plugin {
     static taskDefaults = { src: cds.env.folders.srv };
@@ -68,55 +67,42 @@ module.exports = class OrdBuildPlugin extends cds.build.Plugin {
         return path.join(...relative.replace(/:/g, "_").split("/"));
     }
 
-    _getCompileTasksCount(resources) {
-        return resources
-            .filter((resource) => !resource.ordId.includes(ORD_SERVICE_NAME))
-            .map(({ resourceDefinitions }) => resourceDefinitions?.length || 0)
-            .reduce((a, b) => a + b, 0);
-    }
-
     _createWorkerPool(tasks, model) {
-        if (tasks.length < 2) {
-            // No need for worker pool if only one task - run in-process to avoid overhead of worker thread communication
-            return {
-                close: () => Promise.resolve(),
-                run: ({ url }) => compileMetadata(url, model).then(({ response }) => response),
-            };
-        }
-
         const size = cds.cli?.options?.taskOptions?.workers || os.availableParallelism();
         const maxThreads = Math.ceil(Number(size) || os.availableParallelism() * Number(size.replace(/C$/i, "")));
 
         return new Piscina({
-            minThreads: Math.min(tasks, maxThreads),
             filename: path.join(__dirname, "threads", "compile.js"),
             workerData: { model: JSON.parse(JSON.stringify(model)) },
+            minThreads: Math.min(tasks, maxThreads, Math.ceil(os.availableParallelism() * 1.5)),
             maxThreads: Math.min(tasks, maxThreads, Math.ceil(os.availableParallelism() * 1.5)),
         });
     }
 
-    _generateResourcesFiles(model, resources) {
-        const tasks = this._getCompileTasksCount(resources);
-        const progressBar = this._createProgressBar();
-        const pool = this._createWorkerPool(tasks, model);
+    _extractCompileTasks(resources) {
+        return resources
+            .filter(({ resourceDefinitions }) => !!resourceDefinitions)
+            .flatMap(({ ordId, resourceDefinitions }) => resourceDefinitions.map(({ url }) => ({ url, ordId })));
+    }
 
-        progressBar.start(tasks, 0);
+    _generateResourcesFiles(model, resources) {
+        const progressBar = this._createProgressBar();
+        const tasks = this._extractCompileTasks(resources);
+        const pool = !tasks.length ? null : this._createWorkerPool(tasks.length, model);
+
+        progressBar.start(tasks.length, 0);
 
         return Promise.all(
-            resources
-                .filter(({ resourceDefinitions }) => !!resourceDefinitions)
-                .flatMap(({ ordId, resourceDefinitions }) =>
-                    resourceDefinitions.map(({ url }) =>
-                        pool.run({ url }).then((response) =>
-                            this.write(response)
-                                .to(path.join(ordId, url.split("/").pop()).replace(/:/g, "_"))
-                                .then(() => progressBar.increment()),
-                        ),
-                    ),
+            tasks.map(({ url, ordId }) =>
+                pool.run({ url }).then((response) =>
+                    this.write(response)
+                        .to(path.join(ordId, url.split("/").pop()).replace(/:/g, "_"))
+                        .then(() => progressBar.increment()),
                 ),
+            ),
         ).finally(() => {
             progressBar.stop();
-            return pool.close({ force: true });
+            return pool?.close({ force: true });
         });
     }
 };


### PR DESCRIPTION
# Simplify File Generation Logic in ORD Build Plugin

### Refactor

♻️ Simplified and cleaned up the file generation logic in the ORD build plugin to reduce redundancy, improve clarity, and prevent potential thread over-allocation.

### Changes

* `lib/build.js`:
  - Removed unused `compileMetadata` import and `ORD_SERVICE_NAME` constant.
  - Removed `_getCompileTasksCount` method, replaced by the new `_extractCompileTasks` helper.
  - Added `_extractCompileTasks` as a unified helper that extracts and returns compile tasks, eliminating repeated `flatMap`/`filter` chains.
  - Removed the single-task short-circuit path in `_createWorkerPool` that previously ran compilation in-process instead of a worker thread.
  - Updated `_generateResourcesFiles` to use `_extractCompileTasks` for both the task list and count.
  - Added a cap on `minThreads` and `maxThreads` using `Math.ceil(os.availableParallelism() * 1.5)` to prevent thread over-allocation.
  - Worker pool is now conditionally created only when tasks exist (`!tasks.length ? null : this._createWorkerPool(...)`).
  - Updated `pool.close()` to use optional chaining (`pool?.close()`) to safely handle the case where no pool is created.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.17.99` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Correlation ID: `b5b11c60-1be5-11f1-87d9-18d1ec31bb52`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.edited`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
