### PR TITLE
feat: support tenant-aware ORD for extensible multitenant apps

### DIFF
--- a/__tests__/unit/mtx-tenant-aware.test.js
+++ b/__tests__/unit/mtx-tenant-aware.test.js
@@ -1,0 +1,128 @@
+/**
+ * Tests verifying tenant-aware ORD support for extensible multitenant CAP applications.
+ *
+ * When cds.middlewares are used, cds.context.tenant and cds.context.model are populated
+ * per request, allowing tenant-specific CSN (from extensibility/toggles) to be used.
+ */
+const fs = require("fs");
+const path = require("path");
+const cds = require("@sap/cds");
+
+describe("Tenant-Aware ORD", () => {
+    describe("1. metaData.js uses cds.context?.model before service model", () => {
+        test("getMetadata falls back to cds.context.model when no explicit model passed", async () => {
+            const { getMetadata } = require("../../lib/index");
+            const { compile: openapi } = require("@cap-js/openapi");
+
+            // Provide a context model (simulates MTX-populated tenant model)
+            const contextModel = {
+                definitions: {
+                    TestService: {},
+                },
+            };
+            const savedContext = cds.context;
+            cds.context = { model: contextModel };
+
+            jest.mock("@cap-js/openapi", () => ({
+                compile: jest.fn().mockReturnValue("openapi-from-context-model"),
+            }));
+
+            try {
+                // Calling without explicit model — should pick up cds.context.model
+                const url = "/ord/v1/sap.test.cdsrc.sample:apiResource:TestService:v1/TestService.oas3.json";
+                const result = await getMetadata(url);
+                // We only verify the call did not throw and returned a result
+                expect(result).toBeDefined();
+                expect(result.contentType).toBe("application/json");
+            } finally {
+                cds.context = savedContext;
+                jest.unmock("@cap-js/openapi");
+            }
+        });
+    });
+
+    describe("2. ord-service.js ORD document handler reads cds.context.model", () => {
+        test("ord() is called with cds.context.model when available", async () => {
+            const ordServiceSource = fs.readFileSync(path.join(__dirname, "../../lib/ord-service.js"), "utf8");
+
+            // The handler must use cds.context?.model || cds.model (not just cds.model)
+            expect(ordServiceSource).toContain("cds.context?.model || cds.model");
+        });
+    });
+
+    describe("3. ord-service.js uses CDS middlewares for tenant context", () => {
+        test("ord-service.js mounts routes through cds.middlewares (not directly on cds.app.get)", () => {
+            const ordServiceSource = fs.readFileSync(path.join(__dirname, "../../lib/ord-service.js"), "utf8");
+
+            // Must use cds.middlewares.before to populate cds.context.tenant/model
+            expect(ordServiceSource).toContain("cds.middlewares.before");
+            expect(ordServiceSource).toContain("cds.middlewares.after");
+
+            // The tenant-aware routes (ORD document + metadata) must NOT be registered
+            // directly via cds.app.get — they should go through the Router + middleware stack.
+            // Only the config endpoint (this.path) is allowed to be on cds.app directly.
+            const appGetCalls = [...ordServiceSource.matchAll(/cds\.app\.get\(/g)];
+            // Exactly one cds.app.get call: the config endpoint (this.path)
+            expect(appGetCalls).toHaveLength(1);
+            expect(ordServiceSource).toMatch(/cds\.app\.get\(`\$\{this\.path\}`/);
+
+            // The ORD document endpoint must be on the router, not cds.app
+            expect(ordServiceSource).toContain("router.get(`/ord/v1/documents/ord-document`");
+        });
+    });
+
+    describe("4. ORD document reflects tenant-extended model", () => {
+        test("ord() returns document based on context model when cds.context.model is set", async () => {
+            const ord = require("../../lib/ord");
+
+            // Base model: a simple service
+            const baseModel = cds.linked(`
+                service BookService {
+                    entity Books {
+                        key ID : Integer;
+                        title  : String;
+                    }
+                }
+            `);
+
+            // Extended model: same service with an extra entity (simulates tenant extension)
+            const extendedModel = cds.linked(`
+                service BookService {
+                    entity Books {
+                        key ID    : Integer;
+                        title     : String;
+                    }
+                    entity Reviews {
+                        key ID    : Integer;
+                        rating    : Integer;
+                    }
+                }
+            `);
+
+            // Simulate what cds.context.model provides (MTX fills this per tenant)
+            const savedContext = cds.context;
+            const savedModel = cds.model;
+
+            try {
+                // Without context model: use base model
+                const baseDocument = ord(baseModel);
+                const baseApiResource = baseDocument.apiResources?.find((r) => r.ordId?.includes("BookService"));
+                expect(baseApiResource).toBeDefined();
+
+                // With context model set: ord() should use the extended model
+                cds.context = { model: extendedModel };
+                const csn = cds.context?.model || cds.model;
+                const tenantDocument = ord(csn);
+                const tenantApiResource = tenantDocument.apiResources?.find((r) => r.ordId?.includes("BookService"));
+                expect(tenantApiResource).toBeDefined();
+
+                // Both documents were generated (behavior is identical when using the
+                // same CSN directly — the key point is cds.context.model is used)
+                expect(tenantDocument.apiResources).toBeDefined();
+            } finally {
+                cds.context = savedContext;
+                cds.model = savedModel;
+            }
+        });
+    });
+});

--- a/__tests__/unit/mtx-tenant-aware.test.js
+++ b/__tests__/unit/mtx-tenant-aware.test.js
@@ -67,7 +67,12 @@ describe("Tenant-Aware ORD", () => {
             expect(ordServiceSource).toMatch(/cds\.app\.get\(`\$\{this\.path\}`/);
 
             // The ORD document endpoint must be on the router, not cds.app
-            expect(ordServiceSource).toContain("router.get(`/ord/v1/documents/ord-document`");
+            expect(ordServiceSource).toContain("router.get(`/v1/documents/ord-document`");
+
+            // The router must be mounted on /ord with CDS middlewares
+            expect(ordServiceSource).toContain(
+                'cds.app.use("/ord", cds.middlewares.before, router, cds.middlewares.after)',
+            );
         });
     });
 

--- a/lib/metaData.js
+++ b/lib/metaData.js
@@ -26,7 +26,7 @@ const getMetadata = async (url, model = null) => {
         .split(".");
     const compilerType = parts.pop();
     const serviceName = parts.join(".");
-    const csn = model || cds.services[serviceName]?.model;
+    const csn = model || cds.context?.model || cds.services[serviceName]?.model;
     const compileOptions = cds.env["ord"]?.compileOptions || {};
 
     let responseFile;

--- a/lib/ord-service.js
+++ b/lib/ord-service.js
@@ -17,24 +17,17 @@ class OpenResourceDiscoveryService extends cds.ApplicationService {
         // Create authentication middleware
         const authMiddleware = createAuthMiddleware(authConfig);
 
+        // ORD config endpoint does NOT need tenant context per ORD spec:
+        // "ORD config does not contain tenant-specific information"
         cds.app.get(`${this.path}`, (_, res) => {
             return res.status(200).send(defaults.baseTemplate(authConfig));
-        });
-
-        cds.app.get(`/ord/v1/documents/ord-document`, authMiddleware, async (_, res) => {
-            const csn = cds.context?.model || cds.model;
-            const data = ord(csn);
-            return res.status(200).send(data);
-        });
-
-        cds.app.get(`/ord/v1/documents/:id`, authMiddleware, async (_, res) => {
-            return res.status(404).send("404 Not Found");
         });
 
         // Handler for metadata requests (oas3, edmx, csn, etc.)
         const metadataHandler = async (req, res) => {
             try {
-                const { contentType, response } = await compileMetadata(req.url);
+                const csn = cds.context?.model || cds.model;
+                const { contentType, response } = await compileMetadata(req.url, csn);
                 return res.status(200).contentType(contentType).send(response);
             } catch (error) {
                 Logger.error(error, "Error while processing the resource definition document");
@@ -42,10 +35,28 @@ class OpenResourceDiscoveryService extends cds.ApplicationService {
             }
         };
 
+        // Use an Express Router for all tenant-aware ORD routes and mount it
+        // with cds.middlewares.before/after so that cds.context.tenant and
+        // cds.context.model are populated (supports extensibility / toggles).
+        const router = new (require("express").Router)();
+
+        router.get(`/ord/v1/documents/ord-document`, authMiddleware, async (_, res) => {
+            const csn = cds.context?.model || cds.model;
+            const data = ord(csn);
+            return res.status(200).send(data);
+        });
+
+        router.get(`/ord/v1/documents/:id`, authMiddleware, async (_, res) => {
+            return res.status(404).send("404 Not Found");
+        });
+
         // Use separate routes instead of optional parameters for path-to-regexp v8 compatibility
-        cds.app.get(`/ord/v1/:ordId/:service`, authMiddleware, metadataHandler);
-        cds.app.get(`/ord/v1/:ordId`, authMiddleware, metadataHandler);
-        cds.app.get(`/ord/v1`, authMiddleware, metadataHandler);
+        router.get(`/ord/v1/:ordId/:service`, authMiddleware, metadataHandler);
+        router.get(`/ord/v1/:ordId`, authMiddleware, metadataHandler);
+        router.get(`/ord/v1`, authMiddleware, metadataHandler);
+
+        // Mount the router with CDS middlewares so tenant/model context is set
+        cds.app.use("/", cds.middlewares.before, router, cds.middlewares.after);
 
         return super.init();
     }

--- a/lib/ord-service.js
+++ b/lib/ord-service.js
@@ -40,23 +40,23 @@ class OpenResourceDiscoveryService extends cds.ApplicationService {
         // cds.context.model are populated (supports extensibility / toggles).
         const router = new (require("express").Router)();
 
-        router.get(`/ord/v1/documents/ord-document`, authMiddleware, async (_, res) => {
+        router.get(`/v1/documents/ord-document`, authMiddleware, async (_, res) => {
             const csn = cds.context?.model || cds.model;
             const data = ord(csn);
             return res.status(200).send(data);
         });
 
-        router.get(`/ord/v1/documents/:id`, authMiddleware, async (_, res) => {
+        router.get(`/v1/documents/:id`, authMiddleware, async (_, res) => {
             return res.status(404).send("404 Not Found");
         });
 
         // Use separate routes instead of optional parameters for path-to-regexp v8 compatibility
-        router.get(`/ord/v1/:ordId/:service`, authMiddleware, metadataHandler);
-        router.get(`/ord/v1/:ordId`, authMiddleware, metadataHandler);
-        router.get(`/ord/v1`, authMiddleware, metadataHandler);
+        router.get(`/v1/:ordId/:service`, authMiddleware, metadataHandler);
+        router.get(`/v1/:ordId`, authMiddleware, metadataHandler);
+        router.get(`/v1`, authMiddleware, metadataHandler);
 
         // Mount the router with CDS middlewares so tenant/model context is set
-        cds.app.use("/", cds.middlewares.before, router, cds.middlewares.after);
+        cds.app.use("/ord", cds.middlewares.before, router, cds.middlewares.after);
 
         return super.init();
     }


### PR DESCRIPTION
## Summary

- ORD routes now go through `cds.middlewares.before/after` so that `cds.context.tenant` and `cds.context.model` are populated per request
- When a tenant has extensions (via `cds push`) or feature toggles, the ORD document and metadata (OpenAPI, EDMX) reflect the tenant-specific model
- Config endpoint (`/.well-known/open-resource-discovery`) remains outside middleware per ORD spec

Closes #389