### PR TITLE
feat: support ORD document perspective configuration

### DIFF
--- a/__tests__/unit/defaults.test.js
+++ b/__tests__/unit/defaults.test.js
@@ -179,5 +179,30 @@ describe("defaults", () => {
             };
             expect(defaults.baseTemplate(authConfig)).toMatchSnapshot();
         });
+
+        it("should include perspective when configured", () => {
+            const authConfig = {
+                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+            };
+            const ordConfig = { perspective: "system-version" };
+            const result = defaults.baseTemplate(authConfig, ordConfig);
+            expect(result.openResourceDiscoveryV1.documents[0].perspective).toBe("system-version");
+        });
+
+        it("should not include perspective when not configured", () => {
+            const authConfig = {
+                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+            };
+            const result = defaults.baseTemplate(authConfig);
+            expect(result.openResourceDiscoveryV1.documents[0].perspective).toBeUndefined();
+        });
+
+        it("should not include perspective when ordConfig is empty", () => {
+            const authConfig = {
+                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+            };
+            const result = defaults.baseTemplate(authConfig, {});
+            expect(result.openResourceDiscoveryV1.documents[0].perspective).toBeUndefined();
+        });
     });
 });

--- a/__tests__/unit/ord.e2e.test.js
+++ b/__tests__/unit/ord.e2e.test.js
@@ -556,3 +556,48 @@ describe("Tests for eventResource and apiResource", () => {
         expect(document).toMatchSnapshot();
     });
 });
+
+describe("Tests for ORD document perspective", () => {
+    let csn, ord;
+
+    beforeAll(async () => {
+        cds.root = path.join(__dirname, "../bookshop");
+        csn = await cds.load(path.join(cds.root, "srv"));
+        ord = require("../../lib/ord");
+    });
+
+    afterEach(() => {
+        delete cds.env.ord.perspective;
+        delete cds.env.ord.describedSystemVersion;
+        delete cds.env.ord.describedSystemInstance;
+        delete cds.env.ord.describedSystemType;
+    });
+
+    test("ORD document includes perspective when configured", () => {
+        cds.env.ord.perspective = "system-version";
+        cds.env.ord.describedSystemVersion = { version: "1.2.0" };
+        const document = ord(csn);
+        expect(document.perspective).toBe("system-version");
+        expect(document.describedSystemVersion).toEqual({ version: "1.2.0" });
+    });
+
+    test("ORD document includes describedSystemInstance when configured", () => {
+        cds.env.ord.perspective = "system-instance";
+        cds.env.ord.describedSystemInstance = { baseUrl: "https://my-app.example.com" };
+        const document = ord(csn);
+        expect(document.perspective).toBe("system-instance");
+        expect(document.describedSystemInstance).toEqual({ baseUrl: "https://my-app.example.com" });
+    });
+
+    test("ORD document omits perspective when not configured", () => {
+        const document = ord(csn);
+        expect(document.perspective).toBeUndefined();
+        expect(document.describedSystemVersion).toBeUndefined();
+    });
+
+    test("Invalid perspective value is dropped with warning", () => {
+        cds.env.ord.perspective = "invalid-value";
+        const document = ord(csn);
+        expect(document.perspective).toBeUndefined();
+    });
+});

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -118,6 +118,15 @@ const SEM_VERSION_REGEX =
 
 const MCP_RESOURCE_DEFINITION_TYPE = "sap:mcp-server-card:v0";
 
+const ORD_PERSPECTIVE = Object.freeze({
+    SystemType: "system-type",
+    SystemVersion: "system-version",
+    SystemInstance: "system-instance",
+    SystemIndependent: "system-independent",
+});
+
+const ALLOWED_PERSPECTIVES = Object.values(ORD_PERSPECTIVE);
+
 const EXTERNAL_DP_ORD_ID_ANNOTATION = "@cds.dp.ordId";
 
 const EXTERNAL_SERVICE_ANNOTATION = "@cds.external";
@@ -202,6 +211,8 @@ module.exports = {
     INTEGRATION_DEPENDENCY_RESOURCE_NAME,
     LEVEL,
     MCP_RESOURCE_DEFINITION_TYPE,
+    ORD_PERSPECTIVE,
+    ALLOWED_PERSPECTIVES,
     OPEN_RESOURCE_DISCOVERY_VERSION,
     OPENAPI_SERVERS_ANNOTATION,
     ORD_ACCESS_STRATEGY,

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -138,18 +138,18 @@ module.exports = {
     apiResources: [],
     eventResources: [],
     entityTypes: [],
-    baseTemplate: (authConfig) => {
-        // Get access strategies from the provided authConfig
-        // If auth config is not available, fall back to empty array
+    baseTemplate: (authConfig, ordConfig) => {
         const accessStrategies = authConfig?.accessStrategies || [];
+        const documentEntry = {
+            url: "/ord/v1/documents/ord-document",
+            accessStrategies,
+        };
+        if (ordConfig?.perspective) {
+            documentEntry.perspective = ordConfig.perspective;
+        }
         return {
             openResourceDiscoveryV1: {
-                documents: [
-                    {
-                        url: "/ord/v1/documents/ord-document",
-                        accessStrategies,
-                    },
-                ],
+                documents: [documentEntry],
             },
         };
     },

--- a/lib/ord-service.js
+++ b/lib/ord-service.js
@@ -17,8 +17,11 @@ class OpenResourceDiscoveryService extends cds.ApplicationService {
         // Create authentication middleware
         const authMiddleware = createAuthMiddleware(authConfig);
 
+        const ordConfig = cds.env["ord"] || {};
+
+        // ORD config endpoint does NOT need tenant context per ORD spec
         cds.app.get(`${this.path}`, (_, res) => {
-            return res.status(200).send(defaults.baseTemplate(authConfig));
+            return res.status(200).send(defaults.baseTemplate(authConfig, ordConfig));
         });
 
         cds.app.get(`/ord/v1/documents/ord-document`, authMiddleware, async (_, res) => {

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -1,4 +1,5 @@
 const {
+    ALLOWED_PERSPECTIVES,
     BLOCKED_SERVICE_NAME,
     CDS_ELEMENT_KIND,
     CONTENT_MERGE_KEY,
@@ -274,11 +275,37 @@ const _getProducts = (appConfig) => {
     return productsObj;
 };
 
+const _getPerspectiveFields = (appConfig) => {
+    const result = {};
+    const perspective = appConfig.env?.perspective;
+
+    if (perspective) {
+        if (ALLOWED_PERSPECTIVES.includes(perspective)) {
+            result.perspective = perspective;
+        } else {
+            Logger.warn(`Invalid perspective "${perspective}". Allowed: ${ALLOWED_PERSPECTIVES.join(", ")}`);
+        }
+    }
+
+    if (appConfig.env?.describedSystemVersion) {
+        result.describedSystemVersion = appConfig.env.describedSystemVersion;
+    }
+    if (appConfig.env?.describedSystemInstance) {
+        result.describedSystemInstance = appConfig.env.describedSystemInstance;
+    }
+    if (appConfig.env?.describedSystemType) {
+        result.describedSystemType = appConfig.env.describedSystemType;
+    }
+
+    return result;
+};
+
 function createDefaultORDDocument(linkedCsn, appConfig) {
     appConfig.policyLevels = _getPolicyLevels(appConfig);
     let ordDocument = {
         $schema: "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
         openResourceDiscovery: _getOpenResourceDiscovery(appConfig),
+        ..._getPerspectiveFields(appConfig),
         policyLevels: appConfig.policyLevels,
         description: _getDescription(appConfig),
         consumptionBundles: _getConsumptionBundles(appConfig),


### PR DESCRIPTION
## Summary

- Add `perspective` field to ORD config endpoint and ORD document
- Support `describedSystemVersion`, `describedSystemInstance`, `describedSystemType` passthrough from `.cdsrc.json`
- Invalid perspective values are dropped with a warning log
- Backward compatible: no changes when perspective is not configured

### Configuration example (.cdsrc.json)

```json
{
  "ord": {
    "perspective": "system-version",
    "describedSystemVersion": { "version": "1.2.0" }
  }
}
```

Closes #272
Closes #185