### PR TITLE
feat: Allow for custom ORD document extensions

### DIFF
--- a/__tests__/unit/__snapshots__/extend-ord-with-custom.test.js.snap
+++ b/__tests__/unit/__snapshots__/extend-ord-with-custom.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`extendOrdWithCustom extendCustomORDContentIfExists should add new ord resources that are not supported by cap framework 1`] = `
+exports[`extendOrdWithCustom extend-ord-with-custom should add new ord resources that are not supported by cap framework 1`] = `
 {
   "dataProducts": [
     {
@@ -31,7 +31,7 @@ exports[`extendOrdWithCustom extendCustomORDContentIfExists should add new ord r
 }
 `;
 
-exports[`extendOrdWithCustom extendCustomORDContentIfExists should enhance the list of generated ord resources 1`] = `
+exports[`extendOrdWithCustom extend-ord-with-custom should enhance the list of generated ord resources 1`] = `
 {
   "packages": [
     {
@@ -46,7 +46,7 @@ exports[`extendOrdWithCustom extendCustomORDContentIfExists should enhance the l
 }
 `;
 
-exports[`extendOrdWithCustom extendCustomORDContentIfExists should ignore and log warn if found ord top-level primitive property in customOrdFile 1`] = `
+exports[`extendOrdWithCustom extend-ord-with-custom should ignore and log warn if found ord top-level primitive property in customOrdFile 1`] = `
 {
   "packages": [
     {
@@ -57,7 +57,7 @@ exports[`extendOrdWithCustom extendCustomORDContentIfExists should ignore and lo
 }
 `;
 
-exports[`extendOrdWithCustom extendCustomORDContentIfExists should should patch the existing generated ord resources 1`] = `
+exports[`extendOrdWithCustom extend-ord-with-custom should should patch the existing generated ord resources 1`] = `
 {
   "apiResources": [
     {

--- a/__tests__/unit/extend-ord-with-custom.test.js
+++ b/__tests__/unit/extend-ord-with-custom.test.js
@@ -1,6 +1,9 @@
 const cds = require("@sap/cds");
 const path = require("path");
-const { extendCustomORDContentIfExists } = require("../../lib/extend-ord-with-custom");
+const {
+    getCustomORDContent,
+    compareAndHandleCustomORDContentWithExistingContent,
+} = require("../../lib/extend-ord-with-custom");
 
 describe("extendOrdWithCustom", () => {
     let appConfig = {};
@@ -24,25 +27,27 @@ describe("extendOrdWithCustom", () => {
         jest.clearAllMocks();
     });
 
-    describe("extendCustomORDContentIfExists", () => {
-        it("should skip if there is no customOrdContentFile property in the .cdsrc.json", () => {
-            const ordContent = {};
+    describe("extend-ord-with-custom", () => {
+        it("should return undefined if there is no customOrdContentFile property in the .cdsrc.json", () => {
             appConfig.env.customOrdContentFile = undefined;
-            const result = extendCustomORDContentIfExists(appConfig, ordContent);
-            expect(result).toEqual(ordContent);
+
+            const result = getCustomORDContent(appConfig);
+
+            expect(result).toEqual(undefined);
         });
 
-        it("should skip if customOrdContentFile property in the .cdsrc.json points to NON-EXISTING custom ord file", () => {
-            const ordContent = {};
+        it("should return undefined if customOrdContentFile property in the .cdsrc.json points to NON-EXISTING custom ord file", () => {
             appConfig.env.customOrdContentFile = "./ord/NotExistingCustom.ord.json";
-            const result = extendCustomORDContentIfExists(appConfig, ordContent);
-            expect(result).toEqual(ordContent);
+
+            const result = getCustomORDContent(appConfig);
+
+            expect(result).toEqual(undefined);
         });
 
         it("should ignore and log warn if found ord top-level primitive property in customOrdFile", () => {
-            const ordContent = {};
             prepareTestEnvironment({ namespace: "sap.sample" }, appConfig, "testCustomORDContentFileThrowErrors.json");
-            const result = extendCustomORDContentIfExists(appConfig, ordContent);
+
+            const result = compareAndHandleCustomORDContentWithExistingContent({}, getCustomORDContent(appConfig));
 
             expect(warningSpy).toHaveBeenCalledTimes(3);
             expect(warningSpy).toHaveBeenCalledWith(
@@ -55,138 +60,163 @@ describe("extendOrdWithCustom", () => {
         });
 
         it("should add new ord resources that are not supported by cap framework", () => {
-            const ordContent = {};
             prepareTestEnvironment({}, appConfig, "testCustomORDContentFileWithNewResources.json");
-            const result = extendCustomORDContentIfExists(appConfig, ordContent);
+
+            const result = compareAndHandleCustomORDContentWithExistingContent({}, getCustomORDContent(appConfig));
+
             expect(result).toMatchSnapshot();
         });
 
         it("should enhance the list of generated ord resources", () => {
-            const ordContent = {
-                packages: [
-                    {
-                        ordId: "sap.sm:package:smDataProducts:v1",
-                        localId: "smDataProductsV1",
-                    },
-                ],
-            };
             prepareTestEnvironment({}, appConfig, "testCustomORDContentFileWithEnhanced.json");
-            const result = extendCustomORDContentIfExists(appConfig, ordContent);
+
+            const result = compareAndHandleCustomORDContentWithExistingContent(
+                {
+                    packages: [
+                        {
+                            ordId: "sap.sm:package:smDataProducts:v1",
+                            localId: "smDataProductsV1",
+                        },
+                    ],
+                },
+                getCustomORDContent(appConfig),
+            );
+
             expect(result).toMatchSnapshot();
         });
 
         it("should should patch the existing generated ord resources", () => {
-            const ordContent = {
-                packages: [
-                    {
-                        ordId: "sap.sm:package:smDataProducts:v1",
-                        localId: "smDataProductsV1",
-                    },
-                ],
-                apiResources: [
-                    {
-                        ordId: "sap.sm:apiResource:SupplierService:v1",
-                        title: "should be removed",
-                        partOfGroups: ["sap.cds:service:sap.test.cdsrc.sample:originalService"],
-                        partOfPackage: "sap.sm:package:smDataProducts:v2",
-                        extensible: {
-                            supported: "no",
-                        },
-                        entityTypeMappings: [
-                            {
-                                entityTypeTargets: [
-                                    {
-                                        ordId: "sap.odm:entityType:BusinessPartner:v2",
-                                    },
-                                    {
-                                        ordId: "sap.odm:entityType:BusinessPartner:v3",
-                                    },
-                                ],
-                            },
-                        ],
-                    },
-                    {
-                        ordId: "sap.sm:apiResource:orginalService:v2",
-                        partOfGroups: ["sap.cds:service:sap.test.cdsrc.sample:originalService"],
-                        partOfPackage: "sap.sm:package:smDataProducts:v2",
-                        entityTypeMappings: [
-                            {
-                                entityTypeTargets: [],
-                            },
-                        ],
-                    },
-                ],
-            };
             prepareTestEnvironment({}, appConfig, "testCustomORDContentFileWithPatch.json");
-            const result = extendCustomORDContentIfExists(appConfig, ordContent);
+
+            const result = compareAndHandleCustomORDContentWithExistingContent(
+                {
+                    packages: [
+                        {
+                            ordId: "sap.sm:package:smDataProducts:v1",
+                            localId: "smDataProductsV1",
+                        },
+                    ],
+                    apiResources: [
+                        {
+                            ordId: "sap.sm:apiResource:SupplierService:v1",
+                            title: "should be removed",
+                            partOfGroups: ["sap.cds:service:sap.test.cdsrc.sample:originalService"],
+                            partOfPackage: "sap.sm:package:smDataProducts:v2",
+                            extensible: {
+                                supported: "no",
+                            },
+                            entityTypeMappings: [
+                                {
+                                    entityTypeTargets: [
+                                        {
+                                            ordId: "sap.odm:entityType:BusinessPartner:v2",
+                                        },
+                                        {
+                                            ordId: "sap.odm:entityType:BusinessPartner:v3",
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        {
+                            ordId: "sap.sm:apiResource:orginalService:v2",
+                            partOfGroups: ["sap.cds:service:sap.test.cdsrc.sample:originalService"],
+                            partOfPackage: "sap.sm:package:smDataProducts:v2",
+                            entityTypeMappings: [
+                                {
+                                    entityTypeTargets: [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                getCustomORDContent(appConfig),
+            );
+
             expect(result).toMatchSnapshot();
         });
 
         it("should patch MCP API resources via custom.ord.json", () => {
-            const ordContent = {
-                apiResources: [
-                    {
-                        ordId: "customer.test:apiResource:mcp-server:v1",
-                        title: "MCP Server for test-app",
-                        shortDescription: "This is the MCP server to interact with the test-app",
-                        version: "1.0.0",
-                        visibility: "public",
-                        releaseStatus: "active",
-                        entryPoints: [],
-                        apiProtocol: "mcp",
-                    },
-                ],
-            };
             prepareTestEnvironment({}, appConfig, "testCustomORDContentFileWithMCPOverride.json");
-            const result = extendCustomORDContentIfExists(appConfig, ordContent);
 
-            expect(result.apiResources).toHaveLength(1);
-            const mcpResource = result.apiResources[0];
-            expect(mcpResource.ordId).toBe("customer.test:apiResource:mcp-server:v1");
-            expect(mcpResource.visibility).toBe("internal");
-            expect(mcpResource.title).toBe("Internal MCP Server for CAP Project");
-            expect(mcpResource.shortDescription).toBe("Custom MCP server description");
-            expect(mcpResource.version).toBe("2.1.0");
-            expect(mcpResource.entryPoints).toEqual(["/mcp-server"]);
-            expect(mcpResource.releaseStatus).toBe("beta");
-            expect(mcpResource.apiProtocol).toBe("mcp"); // Should remain unchanged
+            const result = compareAndHandleCustomORDContentWithExistingContent(
+                {
+                    apiResources: [
+                        {
+                            ordId: "customer.test:apiResource:mcp-server:v1",
+                            title: "MCP Server for test-app",
+                            shortDescription: "This is the MCP server to interact with the test-app",
+                            version: "1.0.0",
+                            visibility: "public",
+                            releaseStatus: "active",
+                            entryPoints: [],
+                            apiProtocol: "mcp",
+                        },
+                    ],
+                },
+                getCustomORDContent(appConfig),
+            );
+
+            expect(result.apiResources).toEqual([
+                {
+                    ordId: "customer.test:apiResource:mcp-server:v1",
+                    visibility: "internal",
+                    title: "Internal MCP Server for CAP Project",
+                    shortDescription: "Custom MCP server description",
+                    version: "2.1.0",
+                    entryPoints: ["/mcp-server"],
+                    releaseStatus: "beta",
+                    apiProtocol: "mcp",
+                },
+            ]);
         });
 
         it("should patch IntegrationDependency via custom.ord.json", () => {
-            const ordContent = {
-                integrationDependencies: [
-                    {
-                        ordId: "customer.testapp:integrationDependency:externalDependencies:v1",
-                        title: "External Dependencies",
-                        version: "1.0.0",
-                        releaseStatus: "active",
-                        visibility: "public",
-                        mandatory: false,
-                        partOfPackage: "customer.testapp:package:testapp-integrationDependency:v1",
-                        aspects: [
-                            {
-                                title: "sap.sai.Supplier.v1",
-                                mandatory: false,
-                                apiResources: [{ ordId: "sap.sai:apiResource:Supplier:v1", minVersion: "1.0.0" }],
-                            },
-                        ],
-                    },
-                ],
-            };
             prepareTestEnvironment({}, appConfig, "testCustomORDContentFileWithIntegrationDependency.json");
-            const result = extendCustomORDContentIfExists(appConfig, ordContent);
 
-            expect(result.integrationDependencies).toHaveLength(1);
-            const integrationDep = result.integrationDependencies[0];
-            expect(integrationDep.ordId).toBe("customer.testapp:integrationDependency:externalDependencies:v1");
-            expect(integrationDep.version).toBe("2.0.0");
-            expect(integrationDep.title).toBe("Custom External Dependencies");
-            expect(integrationDep.description).toBe("Patched via custom.ord.json");
-            // Should preserve original values not in patch
-            expect(integrationDep.releaseStatus).toBe("active");
-            expect(integrationDep.visibility).toBe("public");
-            expect(integrationDep.mandatory).toBe(false);
-            expect(integrationDep.aspects).toHaveLength(1);
+            const result = compareAndHandleCustomORDContentWithExistingContent(
+                {
+                    integrationDependencies: [
+                        {
+                            ordId: "customer.testapp:integrationDependency:externalDependencies:v1",
+                            title: "External Dependencies",
+                            version: "1.0.0",
+                            releaseStatus: "active",
+                            visibility: "public",
+                            mandatory: false,
+                            partOfPackage: "customer.testapp:package:testapp-integrationDependency:v1",
+                            aspects: [
+                                {
+                                    title: "sap.sai.Supplier.v1",
+                                    mandatory: false,
+                                    apiResources: [{ ordId: "sap.sai:apiResource:Supplier:v1", minVersion: "1.0.0" }],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                getCustomORDContent(appConfig),
+            );
+
+            expect(result.integrationDependencies).toEqual([
+                {
+                    ordId: "customer.testapp:integrationDependency:externalDependencies:v1",
+                    title: "Custom External Dependencies",
+                    version: "2.0.0",
+                    releaseStatus: "active",
+                    visibility: "public",
+                    mandatory: false,
+                    partOfPackage: "customer.testapp:package:testapp-integrationDependency:v1",
+                    aspects: [
+                        {
+                            title: "sap.sai.Supplier.v1",
+                            mandatory: false,
+                            apiResources: [{ ordId: "sap.sai:apiResource:Supplier:v1", minVersion: "1.0.0" }],
+                        },
+                    ],
+                    description: "Patched via custom.ord.json",
+                },
+            ]);
         });
     });
 });

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -4,17 +4,7 @@ if (cds.cli.command === "build") {
     cds.build?.register?.("ord", require("./lib/build"));
 }
 
-function _lazyRegisterCompileTarget() {
-    const ord = require("./lib/index").ord;
-    Object.defineProperty(this, "ord", { ord });
-    return ord;
-}
-
-const registerORDCompileTarget = () => {
-    Object.defineProperty(cds.compile.to, "ord", {
-        get: _lazyRegisterCompileTarget,
-        configurable: true,
-    });
-};
-
-registerORDCompileTarget();
+Object.defineProperty(cds.compile.to, "ord", {
+    configurable: true,
+    get: () => (model) => require("./lib/index").ord(model, []),
+});

--- a/lib/auth/mtls-endpoint-service.js
+++ b/lib/auth/mtls-endpoint-service.js
@@ -5,7 +5,7 @@
  * from external configuration endpoints and merge with static configuration.
  */
 
-/* global AbortController */
+/* global AbortController */ // eslint-disable-line no-redeclare
 
 const { HTTP_CONFIG } = require("../constants");
 

--- a/lib/extend-ord-with-custom.js
+++ b/lib/extend-ord-with-custom.js
@@ -62,13 +62,7 @@ function getCustomORDContent(appConfig) {
     return require(pathToCustomORDContent);
 }
 
-function extendCustomORDContentIfExists(appConfig, ordContent) {
-    const customORDContent = getCustomORDContent(appConfig);
-    return customORDContent
-        ? compareAndHandleCustomORDContentWithExistingContent(ordContent, customORDContent)
-        : ordContent;
-}
-
 module.exports = {
-    extendCustomORDContentIfExists,
+    getCustomORDContent,
+    compareAndHandleCustomORDContentWithExistingContent,
 };

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -14,7 +14,10 @@ const {
     _propagateORDVisibility,
 } = require("./templates");
 const { getIntegrationDependencies } = require("./integration-dependency");
-const { extendCustomORDContentIfExists } = require("./extend-ord-with-custom");
+const {
+    getCustomORDContent,
+    compareAndHandleCustomORDContentWithExistingContent,
+} = require("./extend-ord-with-custom");
 const { getRFC3339Date } = require("./date");
 const { createAuthConfig } = require("./auth/authentication");
 
@@ -321,7 +324,7 @@ function _filterUnusedPackages(ordDocument) {
     return ordDocument.packages.filter((pkg) => usedPackageIds.has(pkg.ordId));
 }
 
-module.exports = (csn) => {
+module.exports = (csn, extensions = []) => {
     const linkedCsn = _propagateORDVisibility(cds.linked(csn));
     const appConfig = initializeAppConfig(linkedCsn);
 
@@ -358,7 +361,12 @@ module.exports = (csn) => {
         ordDocument.integrationDependencies = integrationDependencies;
     }
 
-    ordDocument = extendCustomORDContentIfExists(appConfig, ordDocument);
+    [...(extensions || []), getCustomORDContent(appConfig)]
+        .filter((extension) => !!extension)
+        .forEach((extension) => {
+            ordDocument = compareAndHandleCustomORDContentWithExistingContent(ordDocument, extension);
+        });
+
     ordDocument.packages = _filterUnusedPackages(ordDocument);
 
     return ordDocument;

--- a/lib/services/ord-service.js
+++ b/lib/services/ord-service.js
@@ -8,6 +8,14 @@ const { createAuthConfig, createAuthMiddleware } = require("../auth/authenticati
 
 class OpenResourceDiscoveryService extends cds.ApplicationService {
     async init() {
+        this.extensions = {};
+
+        cds.on("ord.extension.publish", ({ id, data }) => {
+            Logger.info(`Registering extension with id ${id}...`);
+
+            this.extensions[id] = data;
+        });
+
         // Initialize authentication configuration from .cdsrc.json or environment variables
         // CF mTLS validator is lazily initialized on first mTLS request
         const authConfig = createAuthConfig();
@@ -24,7 +32,7 @@ class OpenResourceDiscoveryService extends cds.ApplicationService {
 
         cds.app.get(`/ord/v1/documents/ord-document`, authMiddleware, async (_, res) => {
             const csn = cds.context?.model || cds.model;
-            const data = ord(csn);
+            const data = ord(csn, Array.from(Object.values(this.extensions)));
             return res.status(200).send(data);
         });
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -114,7 +114,10 @@ A detailed code review of `lib/ord.js`, `lib/templates.js`, `lib/extendOrdWithCu
 
 **Custom ORD Content Merge**:
 
-- `extendCustomORDContentIfExists()` in `lib/extendOrdWithCustom.js` merges by `ordId`.
+- `extendCustomORDContentIfExists()` was removed. Responsibility split into two focused functions in `lib/extend-ord-with-custom.js`:
+  - `getCustomORDContent(appConfig)` — loads custom ORD JSON from `env.ord.customOrdContentFile`; returns `undefined` if absent.
+  - `compareAndHandleCustomORDContentWithExistingContent(ordContent, customORDContent)` — merges by `ordId`.
+- In `lib/ord.js`, runtime extensions (from `cds.on("ord.extension.publish")`) and the config-based custom file are merged sequentially via a single `forEach` loop, with `undefined` entries filtered out.
 - `patchGeneratedOrdResources()` uses `_.assign` (structuredClone) to overlay custom properties.
 - Null properties in custom content delete the corresponding generated property.
 - ⚠️ Known issue: `require()` caches the custom file — to be replaced with `JSON.parse(fs.readFileSync(...))`.
@@ -238,7 +241,7 @@ lib/
 ### Immediate Priorities
 
 - **`ord-service.js` hardening**: Wrap `ord(csn)` call in try/catch and log errors; remove or implement `/ord/v1/documents/:id` placeholder; unify hard-coded `/ord/v1` prefix with `this.path`.
-- Fix high-priority code review issues: `cleanNullProperties` array handling, `_propagateORDVisibility` object iteration, `typeof "array"` dead branch in `extendOrdWithCustom`.
+- Fix high-priority code review issues: `cleanNullProperties` array handling, `_propagateORDVisibility` object iteration, `typeof "array"` dead branch.
 - Replace `require(pathToCustomORDContent)` with `JSON.parse(fs.readFileSync(...))` to fix caching.
 - Fix `...(exposedEntityTypes ? { exposedEntityTypes } : [])` spread-into-object typo.
 - Rename `_shouldNotSkipIfServiceProtocolIsNone` → `_isProtocolEnabled`.
@@ -247,6 +250,7 @@ lib/
 
 ### Recently Completed
 
+- ✅ Removed `extendCustomORDContentIfExists()` — split into `getCustomORDContent()` + `compareAndHandleCustomORDContentWithExistingContent()` for cleaner separation and runtime extension support
 - ✅ v1.5.0: Parallel resource file generation, MCP migration fix, interop CSN meta cleanup
 - ✅ v1.4.5: GraphQL support, auto IntegrationDependencies, INA protocol, multi-protocol detection
 - ✅ v1.4.4: INA protocol null entryPoints fix, cds-compiler lock

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -57,7 +57,7 @@ CSN Model → _propagateORDVisibility → Triage Definitions → Generate Resour
 2. **CSN Analysis**: `_triageCsnDefinitions()` categorizes services, entities, events, actions/functions.
 3. **Resource Generation**: Creates API resources, event resources, entity types, integration dependencies.
 4. **Template Application**: `lib/templates.js` applies ORD-compliant formatting.
-5. **Custom Merge**: `extendCustomORDContentIfExists()` overlays `custom.ord.json` by `ordId`.
+5. **Custom Merge**: `getCustomORDContent()` loads the custom file, then `compareAndHandleCustomORDContentWithExistingContent()` overlays it by `ordId`. Runtime extensions (via `cds.on("ord.extension.publish")`) are merged first, followed by the config-based custom file.
 6. **Package Pruning**: `_filterUnusedPackages()` removes packages not referenced by any resource.
 
 ### 3. Protocol Resolution Pattern
@@ -265,7 +265,7 @@ Resource Generation
     ↓
 ORD Document Assembly (createDefaultORDDocument)
     ↓
-Custom Content Overlay (extendCustomORDContentIfExists)
+Custom Content Overlay (getCustomORDContent + compareAndHandleCustomORDContentWithExistingContent)
     ↓
 Package Pruning (_filterUnusedPackages)
     ↓


### PR DESCRIPTION
# Allow Custom ORD Document Extensions via Event-Based Registration

### New Feature

✨ Introduces support for dynamically registering custom ORD document extensions at runtime via a CDS event mechanism (`ord.extension.publish`), in addition to the existing file-based custom ORD content approach.

### Changes

* `lib/extend-ord-with-custom.js`: Exported `getCustomORDContent` and `compareAndHandleCustomORDContentWithExistingContent` individually from the module. Added a `// TODO - To be deleted` comment marking `extendCustomORDContentIfExists` for future removal.

* `lib/ord.js`: Updated the main ORD document builder to accept an optional `extensions` array as a second parameter. Replaced the single `extendCustomORDContentIfExists` call with an iteration over all provided extensions (plus the file-based custom ORD content), applying `compareAndHandleCustomORDContentWithExistingContent` for each.

* `lib/services/ord-service.js`: Added a constructor to `OpenResourceDiscoveryService` that initializes an `extensions` map and registers a listener for the `ord.extension.publish` CDS event. Incoming extensions are stored by ID, and when serving the ORD document, all registered extensions are passed to the `ord()` builder as an array.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.19.9` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.edited`
- Correlation ID: `8251b270-2c3f-11f1-9367-315d92ec01eb`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
