### PR TITLE
fix: re-register MCP protocol during cds build

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -24,6 +24,14 @@ module.exports = class OrdBuildPlugin extends cds.build.Plugin {
             require("@cap-js/graphql/lib/api").registerCompileTargets();
         }
 
+        // @cap-js/mcp registers protocols and compile targets at runtime via cds-plugin.js,
+        // but cds build rebuilds cds.env afterward, losing both registrations.
+        // Re-apply so endpoints4() and cds.compile.to.mcp work during build.
+        if ("@cap-js/mcp" in cds.env.plugins && !cds.env.protocols?.mcp) {
+            cds.env.protocols.mcp = { path: "/mcp", impl: "@cap-js/mcp" };
+            require("@cap-js/mcp/lib/api").registerCompileTargets();
+        }
+
         return this.model()
             .then((model) => ({ model, document: ord(model) }))
             .then(({ model, document }) =>

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -143,6 +143,7 @@ const CAP_TO_ORD_PROTOCOL_MAP = Object.freeze({
     "odata-v2": ORD_API_PROTOCOL.ODATA_V2,
     "rest": ORD_API_PROTOCOL.REST,
     "graphql": ORD_API_PROTOCOL.GRAPHQL,
+    "mcp": ORD_API_PROTOCOL.MCP,
 });
 
 // Protocols that ORD supports but CAP may not recognize (endpoints4 returns [])


### PR DESCRIPTION
- Re-register `@cap-js/mcp` protocol in `build.js` before ORD document generation (same pattern as the existing `@cap-js/graphql` workaround)
- Add `"mcp"` to `CAP_TO_ORD_PROTOCOL_MAP` in `constants.js`

## Problem

During `cds build --for ord`, CDS rebuilds `cds.env`, which wipes out the protocol registration that `@cap-js/mcp` makes in its `cds-plugin.js`. As a result, `endpoints4()` never returns `kind: "mcp"` for MCP-exposed services, they fall back to `odata-v4` instead. The MCP server card is then neither referenced in the ORD document nor generated as a `.mcp.json` resource file.

This primarily affects Java projects, which serve ORD from static files generated at build time. Node.js projects typically serve ORD dynamically at runtime where the protocol registration is intact.