### PR TITLE
chore: Introduce consistent handling for compile target registration

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -6,6 +6,7 @@ const cliProgress = require("cli-progress");
 
 const os = require("os");
 const { ord } = require("./index");
+const registerCompileTargets = require("./common/register-compile-targets");
 const { BUILD_DEFAULT_PATH, ORD_DOCUMENT_FILE_NAME } = require("./constants");
 
 module.exports = class OrdBuildPlugin extends cds.build.Plugin {
@@ -16,13 +17,7 @@ module.exports = class OrdBuildPlugin extends cds.build.Plugin {
     }
 
     async build() {
-        // @cap-js/graphql registers protocols and compile targets at runtime via cds-plugin.js,
-        // but cds build rebuilds cds.env afterward, losing both registrations.
-        // Re-apply so endpoints4() and cds.compile.to.graphql work during build.
-        if ("@cap-js/graphql" in cds.env.plugins && !cds.env.protocols?.graphql) {
-            cds.env.protocols.graphql = { path: "/graphql", impl: "@cap-js/graphql" };
-            require("@cap-js/graphql/lib/api").registerCompileTargets();
-        }
+        registerCompileTargets();
 
         return this.model()
             .then((model) => ({ model, document: ord(model) }))

--- a/lib/common/register-compile-targets.js
+++ b/lib/common/register-compile-targets.js
@@ -1,0 +1,31 @@
+const cds = require("@sap/cds");
+const Logger = require("../logger");
+
+const PROTOCOL_PROVIDERS = Object.freeze({
+    ["@cap-js/mcp"]: "mcp",
+    ["@cap-js/graphql"]: "graphql",
+});
+
+module.exports = () => {
+    // Plugins like @cap-js/mcp and @cap-js/graphql register protocols and compile targets
+    // at runtime via cds-plugin.js, but cds build rebuilds cds.env afterward, losing both
+    // registrations. Re-apply so that compilation works accordingly during build and runtime.
+
+    Object.keys(cds.env.plugins || {})
+        .filter((plugin) => plugin !== "@cap-js/ord")
+        .forEach((plugin) => {
+            try {
+                const protocol = PROTOCOL_PROVIDERS[plugin];
+
+                require(`${plugin}/lib/api`)?.registerCompileTargets?.();
+                cds.env.protocols = {
+                    ...cds.env.protocols,
+                    ...(!protocol || cds.env.protocols?.[protocol]
+                        ? {}
+                        : { [protocol]: { path: `/${protocol}`, impl: plugin } }),
+                };
+            } catch (error) {
+                Logger.warn(`Failed to register compile targets for ${plugin}: ${error}`);
+            }
+        });
+};

--- a/lib/threads/compile.js
+++ b/lib/threads/compile.js
@@ -1,19 +1,9 @@
-const cds = require("@sap/cds/lib");
 const { workerData } = require("piscina");
 
-const Logger = require("../logger");
 const compileMetadata = require("../meta-data");
+const registerCompileTargets = require("../common/register-compile-targets");
 
-// Worker threads skip cds-plugin.js — re-register compile targets
-Object.keys(cds.env.plugins || {})
-    .filter(plugin => plugin !== '@cap-js/ord')
-    .forEach((plugin) => {
-    try {
-        require(`${plugin}/lib/api`)?.registerCompileTargets?.();
-    } catch (error) {
-        Logger.warn(`Failed to register compile targets for ${plugin}: ${error}`);
-    }
-});
+registerCompileTargets(); // Worker threads skip cds-plugin.js — re-register compile targets
 
 module.exports = ({ url }) => {
     // JSON round-trip: CDS compiler output may contain Generator objects


### PR DESCRIPTION
# Introduce Consistent Handling for Compile Target Registration

### Refactor

♻️ Extracted the repeated compile target registration logic into a shared utility module, ensuring consistent behavior across both the build plugin and worker threads.

### Changes

* `lib/common/register-compile-targets.js` *(new)*: Introduces a reusable utility that iterates over all registered CDS plugins (excluding `@cap-js/ord`), calls `registerCompileTargets()` on each, and ensures the corresponding protocol is registered in `cds.env.protocols`. Errors are caught and logged as warnings.

* `lib/build.js`: Replaces the inline `@cap-js/graphql`-specific compile target re-registration block with a single call to the new shared `registerCompileTargets()` utility. The old logic only handled `@cap-js/graphql`; the new approach handles all plugins generically.

* `lib/threads/compile.js`: Replaces the inline loop that re-registered compile targets in worker threads (where `cds-plugin.js` is skipped) with a single call to the shared `registerCompileTargets()` utility. Also removes the previously required `cds` and `Logger` direct imports that are now encapsulated in the shared module.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.19.9` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Correlation ID: `8ffdf9c0-2dab-11f1-9ac1-86d32dfd6a3d`
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
