### PR TITLE
chore: update node engines to >=20 <25

### DIFF
--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -53,8 +53,8 @@
 ### Prerequisites
 
 ```bash
-# Node.js (versions 18-22 currently supported)
-node --version  # Should be v18.x, v20.x, or v22.x
+# Node.js (versions 20-24 currently supported)
+node --version  # Should be v20.x, v22.x, or v24.x
 
 # CAP development kit
 npm install -g @sap/cds-dk

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "piscina": "^5.1.4"
     },
     "engines": {
-        "node": ">=18 <23"
+        "node": ">=20 <25"
     },
     "overrides": {
         "@sap/cds-compiler": "6.7.3"


### PR DESCRIPTION
## Summary

- Update `engines.node` from `>=18 <23` to `>=20 <25`
- Align with CAP's official Node.js support (v20, v22, v24)
- Drop EOL Node v18, add support for v24

Closes #400