### PR TITLE
feat: ODMPLANNING-1151 - Introduce 'perspective: system-version' for static files

### DIFF
--- a/__tests__/integration/__snapshots__/cds-build.test.js.snap
+++ b/__tests__/integration/__snapshots__/cds-build.test.js.snap
@@ -1,0 +1,639 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customization should match snapshot 1`] = `
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "apiResources": [
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for TestService",
+      "entryPoints": [
+        "/test",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.edmx",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/odata/v4/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "consumptionBundles": [
+    {
+      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
+      "shortDescription": "If we have another protected API then it will be another object",
+      "title": "Unprotected resources",
+      "version": "1.0.0",
+    },
+  ],
+  "describedSystemVersion": {
+    "version": "1.0.0",
+  },
+  "description": "this is an application description",
+  "eventResources": [
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "customer.capireordintegrationtest_eventResource_TestService_v1/TestService.asyncapi2.json",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "groups": [
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Test Service for Integration Testing",
+    },
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Supplier Service",
+    },
+  ],
+  "integrationDependencies": [
+    {
+      "aspects": [
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.sai:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test SAI Supplier Data Product",
+          "mandatory": false,
+          "title": "Test SAI Supplier API",
+        },
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.s4:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test S4 Supplier Data Product",
+          "mandatory": false,
+          "title": "Test S4 Supplier API",
+        },
+      ],
+      "description": "Custom description from cdsrc",
+      "mandatory": false,
+      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "beta",
+      "title": "Custom External Dependencies",
+      "version": "2.0.0",
+      "visibility": "internal",
+    },
+  ],
+  "openResourceDiscovery": "1.12",
+  "packages": [
+    {
+      "description": "This package contains public General for capire ord integration test.",
+      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "partOfProducts": [
+        "customer:product:capire.ord.integration.test:",
+      ],
+      "shortDescription": "Package containing public General",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+  ],
+  "perspective": "system-version",
+  "policyLevels": [
+    "none",
+  ],
+  "products": [
+    {
+      "ordId": "customer:product:capire.ord.integration.test:",
+      "shortDescription": "Short description of capire ord integration test",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+    },
+  ],
+}
+`;
+
+exports[`ORD Build Integration Tests IntegrationDependency with custom.ord.json merging should match snapshot 1`] = `
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "apiResources": [
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for TestService",
+      "entryPoints": [
+        "/test",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.edmx",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/odata/v4/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "consumptionBundles": [
+    {
+      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
+      "shortDescription": "If we have another protected API then it will be another object",
+      "title": "Unprotected resources",
+      "version": "1.0.0",
+    },
+  ],
+  "describedSystemVersion": {
+    "version": "0.0.1",
+  },
+  "description": "this is an application description",
+  "eventResources": [
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "customer.capireordintegrationtest_eventResource_TestService_v1/TestService.asyncapi2.json",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "groups": [
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Test Service for Integration Testing",
+    },
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Supplier Service",
+    },
+  ],
+  "integrationDependencies": [
+    {
+      "aspects": [
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.sai:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test SAI Supplier Data Product",
+          "mandatory": false,
+          "title": "Test SAI Supplier API",
+        },
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.s4:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test S4 Supplier Data Product",
+          "mandatory": false,
+          "title": "Test S4 Supplier API",
+        },
+      ],
+      "mandatory": true,
+      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "shortDescription": "Patched via custom.ord.json",
+      "title": "Patched External Dependencies",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "openResourceDiscovery": "1.12",
+  "packages": [
+    {
+      "description": "This package contains public General for capire ord integration test.",
+      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "partOfProducts": [
+        "customer:product:capire.ord.integration.test:",
+      ],
+      "shortDescription": "Package containing public General",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+  ],
+  "perspective": "system-version",
+  "policyLevels": [
+    "none",
+  ],
+  "products": [
+    {
+      "ordId": "customer:product:capire.ord.integration.test:",
+      "shortDescription": "Short description of capire ord integration test",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+    },
+  ],
+}
+`;
+
+exports[`ORD Build Integration Tests Successful Build should generate ord-document.json 1`] = `
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "apiResources": [
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for TestService",
+      "entryPoints": [
+        "/test",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.edmx",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/odata/v4/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "consumptionBundles": [
+    {
+      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
+      "shortDescription": "If we have another protected API then it will be another object",
+      "title": "Unprotected resources",
+      "version": "1.0.0",
+    },
+  ],
+  "describedSystemVersion": {
+    "version": "0.0.1",
+  },
+  "description": "this is an application description",
+  "eventResources": [
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "customer.capireordintegrationtest_eventResource_TestService_v1/TestService.asyncapi2.json",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "groups": [
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Test Service for Integration Testing",
+    },
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Supplier Service",
+    },
+  ],
+  "integrationDependencies": [
+    {
+      "aspects": [
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.sai:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test SAI Supplier Data Product",
+          "mandatory": false,
+          "title": "Test SAI Supplier API",
+        },
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.s4:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test S4 Supplier Data Product",
+          "mandatory": false,
+          "title": "Test S4 Supplier API",
+        },
+      ],
+      "mandatory": false,
+      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "title": "External Dependencies",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "openResourceDiscovery": "1.12",
+  "packages": [
+    {
+      "description": "This package contains public General for capire ord integration test.",
+      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "partOfProducts": [
+        "customer:product:capire.ord.integration.test:",
+      ],
+      "shortDescription": "Package containing public General",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+  ],
+  "perspective": "system-version",
+  "policyLevels": [
+    "none",
+  ],
+  "products": [
+    {
+      "ordId": "customer:product:capire.ord.integration.test:",
+      "shortDescription": "Short description of capire ord integration test",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+    },
+  ],
+}
+`;

--- a/__tests__/integration/cds-build.test.js
+++ b/__tests__/integration/cds-build.test.js
@@ -8,6 +8,20 @@ const GEN_DIR = path.join(TEST_APP_ROOT, "gen");
 const ORD_GEN_DIR = path.join(GEN_DIR, "srv");
 const ORD_DOC_PATH = path.join(ORD_GEN_DIR, "ord-document.json");
 
+function fixLastUpdateForStableTest(ord) {
+    (ord.consumptionBundles || []).find((cb) => {
+        cb.lastUpdate = "2026-05-04T13:45:01+01:00";
+    });
+    (ord.eventResources || []).find((er) => {
+        er.lastUpdate = "2026-05-04T13:45:01+01:00";
+    });
+    (ord.apiResources || []).find((ar) => {
+        ar.lastUpdate = "2026-05-04T13:45:01+01:00";
+    });
+
+    return ord;
+}
+
 /**
  * Execute cds build command and return result
  * @param {string} cwd - Working directory
@@ -76,6 +90,7 @@ describe("ORD Build Integration Tests", () => {
         test("should generate ord-document.json", () => {
             expect(fs.existsSync(ORD_DOC_PATH)).toBe(true);
             expect(fs.statSync(ORD_DOC_PATH).size).toBeGreaterThan(0);
+            expect(fixLastUpdateForStableTest(JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8")))).toMatchSnapshot();
         });
 
         test("should have correct ORD document structure", () => {
@@ -83,6 +98,8 @@ describe("ORD Build Integration Tests", () => {
             expect(ordDocument).toHaveProperty("apiResources");
             expect(ordDocument).toHaveProperty("eventResources");
             expect(ordDocument).toHaveProperty("packages");
+            expect(ordDocument).toHaveProperty("perspective");
+            expect(ordDocument).toHaveProperty("describedSystemVersion");
         });
 
         test("should generate API resource definition files with non-zero size", () => {
@@ -173,7 +190,7 @@ describe("ORD Build Integration Tests", () => {
             cleanupDir(GEN_DIR);
             buildResult = await runCdsBuild(TEST_APP_ROOT, CDSRC_CONFIG);
             if (fs.existsSync(ORD_DOC_PATH)) {
-                ordDocument = JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8"));
+                ordDocument = fixLastUpdateForStableTest(JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8")));
             }
         }, 60000);
 
@@ -183,6 +200,10 @@ describe("ORD Build Integration Tests", () => {
 
         test("should exit with code 0", () => {
             expect(buildResult.code).toBe(0);
+        });
+
+        test("should match snapshot", () => {
+            expect(ordDocument).toMatchSnapshot();
         });
 
         test("should apply cdsrc customization to IntegrationDependency", () => {
@@ -216,7 +237,7 @@ describe("ORD Build Integration Tests", () => {
             cleanupDir(GEN_DIR);
             buildResult = await runCdsBuild(TEST_APP_ROOT, CDSRC_CONFIG);
             if (fs.existsSync(ORD_DOC_PATH)) {
-                ordDocument = JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8"));
+                ordDocument = fixLastUpdateForStableTest(JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8")));
             }
         }, 60000);
 
@@ -226,6 +247,10 @@ describe("ORD Build Integration Tests", () => {
 
         test("should exit with code 0", () => {
             expect(buildResult.code).toBe(0);
+        });
+
+        test("should match snapshot", () => {
+            expect(ordDocument).toMatchSnapshot();
         });
 
         test("should merge custom.ord.json patches to IntegrationDependency", () => {

--- a/__tests__/integration/integration-test-app/.cdsrc.integrationDep.json
+++ b/__tests__/integration/integration-test-app/.cdsrc.integrationDep.json
@@ -1,5 +1,8 @@
 {
     "ord": {
+        "describedSystemVersion": {
+            "version": "1.0.0"
+        },
         "integrationDependency": {
             "title": "Custom External Dependencies",
             "version": "2.0.0",

--- a/__tests__/integration/integration-test-app/package.json
+++ b/__tests__/integration/integration-test-app/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@capire/ord-integration-test",
+    "version": "0.0.1",
     "private": true,
     "scripts": {
         "start": "cds-serve"

--- a/__tests__/unit/__snapshots__/defaults.test.js.snap
+++ b/__tests__/unit/__snapshots__/defaults.test.js.snap
@@ -12,6 +12,7 @@ exports[`defaults baseTemplate should return default value 1`] = `
             "type": "open",
           },
         ],
+        "perspective": "system-version",
         "url": "/ord/v1/documents/ord-document",
       },
     ],

--- a/__tests__/unit/build.test.js
+++ b/__tests__/unit/build.test.js
@@ -1,6 +1,6 @@
 const path = require("path");
-const { BUILD_DEFAULT_PATH } = require("../../lib/constants");
 const index = require("../../lib/index");
+const { BUILD_DEFAULT_PATH, DOCUMENT_PERSPECTIVES } = require("../../lib/constants");
 
 // Setup cds.build.Plugin mock BEFORE requiring build.js
 const cds = require("@sap/cds");
@@ -84,6 +84,7 @@ jest.mock("cli-progress", () => {
 describe("Build", () => {
     beforeAll(() => {
         process.env.DEBUG = "true";
+        cds.env.ord = { describedSystemVersion: { version: "0.0.1" } };
     });
 
     afterEach(() => {
@@ -213,7 +214,9 @@ describe("Build", () => {
         jest.spyOn(OrdBuildPlugin.prototype, "_createWorkerPool").mockImplementation(() => {
             return new (class {
                 close() {}
-                run() { return Promise.reject(new Error()) }
+                run() {
+                    return Promise.reject(new Error());
+                }
             })();
         });
 
@@ -257,7 +260,11 @@ describe("Build", () => {
                 },
             ],
         };
+
         const updatedOrdDocument = buildClass._postProcess(ordDocument);
+
+        expect(updatedOrdDocument.perspective).toBe(DOCUMENT_PERSPECTIVES.SystemVersion);
+        expect(updatedOrdDocument.describedSystemVersion).toEqual({ version: "0.0.1" });
         expect(updatedOrdDocument.apiResources[0].resourceDefinitions[0].url).toBe(
             path.join("customer.sample_apiResource_ProcessorService_v1", "ProcessorService.oas3.json"),
         );

--- a/__tests__/unit/defaults.test.js
+++ b/__tests__/unit/defaults.test.js
@@ -1,5 +1,12 @@
 const defaults = require("../../lib/defaults");
-const { AUTHENTICATION_TYPE } = require("../../lib/constants");
+const { AUTHENTICATION_TYPE, DOCUMENT_PERSPECTIVES } = require("../../lib/constants");
+const cds = require("@sap/cds");
+
+jest.mock("fs", () => {
+    return {
+        readFileSync: () => (JSON.stringify({version:  "1.0.0"})),
+    };
+});
 
 describe("defaults", () => {
     describe("$schema", () => {
@@ -171,6 +178,7 @@ describe("defaults", () => {
             expect(defaults.consumptionBundles(testAppConfig)).toMatchSnapshot();
         });
     });
+
     describe("baseTemplate", () => {
         it("should return default value", () => {
             const authConfig = {
@@ -178,6 +186,31 @@ describe("defaults", () => {
                 accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
             };
             expect(defaults.baseTemplate(authConfig)).toMatchSnapshot();
+        });
+    });
+
+    describe("resolveDocumentPerspectiveExtension", () => {
+        it("should return correct value when loading version from .cdsrc.json", () => {
+            cds.env.ord = { describedSystemVersion: { version: "0.1.0" } };
+
+            expect(defaults.resolveDocumentPerspectiveExtension()).toEqual({
+                perspective: DOCUMENT_PERSPECTIVES.SystemVersion,
+                describedSystemVersion: {
+                    version: "0.1.0",
+                },
+            });
+        });
+
+        it("should return correct value when loading version from package.json", () => {
+            cds.env.ord = undefined;
+            cds.root = "."
+
+            expect(defaults.resolveDocumentPerspectiveExtension()).toEqual({
+                perspective: DOCUMENT_PERSPECTIVES.SystemVersion,
+                describedSystemVersion: {
+                    version: "1.0.0",
+                },
+            });
         });
     });
 });

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,13 +1,14 @@
+const os = require("os");
 const path = require("path");
 const cds = require("@sap/cds");
 const _ = require("lodash");
 const Piscina = require("piscina");
 const cliProgress = require("cli-progress");
 
-const os = require("os");
+const defaults = require("./defaults.js");
 const { ord } = require("./index");
 const registerCompileTargets = require("./common/register-compile-targets");
-const { BUILD_DEFAULT_PATH, ORD_DOCUMENT_FILE_NAME } = require("./constants");
+const { BUILD_DEFAULT_PATH, ORD_DOCUMENT_FILE_NAME  } = require("./constants");
 
 module.exports = class OrdBuildPlugin extends cds.build.Plugin {
     static taskDefaults = { src: cds.env.folders.srv };
@@ -46,6 +47,10 @@ module.exports = class OrdBuildPlugin extends cds.build.Plugin {
 
     _postProcess(document) {
         const clone = _.cloneDeep(document);
+        const extension = defaults.resolveDocumentPerspectiveExtension();
+
+        clone.perspective = extension.perspective;
+        clone.describedSystemVersion = extension.describedSystemVersion;
 
         [...(clone.apiResources || []), ...(clone.eventResources || [])]
             .flatMap((resource) => resource.resourceDefinitions || [])

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -181,6 +181,11 @@ const AUTH_STRINGS = Object.freeze({
     WWW_AUTHENTICATE_REALM: 'Basic realm="401"',
 });
 
+const DOCUMENT_PERSPECTIVES = Object.freeze({
+    SystemVersion: "system-version",
+    SystemInstance: "system-instance",
+});
+
 module.exports = {
     AUTHENTICATION_TYPE,
     AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP,
@@ -223,4 +228,5 @@ module.exports = {
     CF_MTLS_ERROR_REASON,
     HTTP_CONFIG,
     AUTH_STRINGS,
+    DOCUMENT_PERSPECTIVES,
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,6 +1,16 @@
-const { OPEN_RESOURCE_DISCOVERY_VERSION, SHORT_DESCRIPTION_PREFIX, RESOURCE_VISIBILITY } = require("./constants");
-const { hasSAPPolicyLevel } = require("./utils");
+const fs = require("fs");
+const { join } = require("path");
 const _ = require("lodash");
+const cds = require("@sap/cds");
+
+const { hasSAPPolicyLevel } = require("./utils");
+const {
+    OPEN_RESOURCE_DISCOVERY_VERSION,
+    SHORT_DESCRIPTION_PREFIX,
+    RESOURCE_VISIBILITY,
+    DOCUMENT_PERSPECTIVES,
+} = require("./constants");
+
 
 const packageTypes = [
     { tag: "-api", type: "APIs" },
@@ -134,7 +144,6 @@ module.exports = {
                 "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
         },
     ],
-
     apiResources: [],
     eventResources: [],
     entityTypes: [],
@@ -147,9 +156,18 @@ module.exports = {
                 documents: [
                     {
                         url: "/ord/v1/documents/ord-document",
+                        perspective: DOCUMENT_PERSPECTIVES.SystemVersion,
                         accessStrategies,
                     },
                 ],
+            },
+        };
+    },
+    resolveDocumentPerspectiveExtension: () => {
+        return {
+            perspective: DOCUMENT_PERSPECTIVES.SystemVersion,
+            describedSystemVersion: cds.env["ord"]?.describedSystemVersion ?? {
+                version: JSON.parse(fs.readFileSync(join(cds.root, "package.json"), 'utf-8')).version,
             },
         };
     },

--- a/lib/services/ord-service.js
+++ b/lib/services/ord-service.js
@@ -32,8 +32,9 @@ class OpenResourceDiscoveryService extends cds.ApplicationService {
 
         cds.app.get(`/ord/v1/documents/ord-document`, authMiddleware, async (_, res) => {
             const csn = cds.context?.model || cds.model;
-            const data = ord(csn, Array.from(Object.values(this.extensions)));
-            return res.status(200).send(data);
+            const document = ord(csn, Array.from(Object.values(this.extensions)));
+
+            return res.status(200).send(Object.assign(document, defaults.resolveDocumentPerspectiveExtension()));
         });
 
         cds.app.get(`/ord/v1/documents/:id`, authMiddleware, async (_, res) => {


### PR DESCRIPTION
# Introduce `perspective: system-version` for Static Files and ORD Service

### New Feature

✨ Adds `perspective: "system-version"` and `describedSystemVersion` fields to the ORD document output for both static file builds and the ORD service's runtime document endpoint. The `describedSystemVersion` is resolved from `cds.env["ord"]?.describedSystemVersion` if configured, or falls back to the `version` field in `package.json`. This ensures generated ORD artifacts are correctly tagged with the system-version perspective, enabling downstream consumers to properly identify and handle scoped resources.

Additionally, the `baseTemplate` helper now includes `perspective: "system-version"` in the ORD document entry, and custom ORD content merging is now restricted to a defined allow-list of properties, removing the previous primitive-property warning logic.

### Changes

* `lib/constants.js`: Added `DOCUMENT_PERSPECTIVES` constant with `SystemVersion` and `SystemInstance` values.
* `lib/defaults.js`: Added `resolveDocumentPerspectiveExtension()` helper that returns `perspective` and `describedSystemVersion` (from `cds.env.ord` config or `package.json`). Added `perspective: "system-version"` to the `baseTemplate` document entry.
* `lib/build.js`: Updated `_postProcess` to apply `perspective` and `describedSystemVersion` to the generated ORD document using the new `resolveDocumentPerspectiveExtension()` helper.
* `lib/services/ord-service.js`: Updated the ORD document endpoint to merge perspective extension into the response via `resolveDocumentPerspectiveExtension()`.
* `lib/extend-ord-with-custom.js`: Refactored `compareAndHandleCustomORDContentWithExistingContent` to use an explicit `CUSTOMIZABLE_PROPERTIES` allow-list with `Object.keys().filter().forEach()`, replacing the old `for...in` loop and removing primitive-property warning logic.
* `__tests__/unit/build.test.js`: Added assertions verifying `_postProcess` sets `perspective` to `"system-version"` and populates `describedSystemVersion` from config.
* `__tests__/unit/defaults.test.js`: Added tests for `resolveDocumentPerspectiveExtension()` covering both config-driven and `package.json` fallback scenarios.
* `__tests__/unit/extend-ord-with-custom.test.js`: Removed `warningSpy` and related warning assertions for primitive properties.
* `__tests__/unit/utils/testCustomORDContentFileThrowErrors.json`: Updated test fixture to use known ORD top-level string properties instead of boolean/number primitives.
* `__tests__/integration/cds-build.test.js`: Added snapshot tests and assertions verifying `perspective` and `describedSystemVersion` are present in generated ORD documents; added `fixLastUpdateForStableTest` helper for deterministic snapshots.
* `__tests__/integration/integration-test-app/package.json`: Added `"version": "0.0.1"` to support `describedSystemVersion` derivation from `package.json`.
* `__tests__/integration/integration-test-app/.cdsrc.integrationDep.json`: Added `describedSystemVersion` config entry to test config-driven version resolution.
* `__tests__/integration/__snapshots__/cds-build.test.js.snap`: New snapshot file capturing full ORD document output including `perspective` and `describedSystemVersion`.
* `__tests__/unit/__snapshots__/defaults.test.js.snap`: Updated snapshot to include `perspective: "system-version"` in the `baseTemplate` output.

### Jira Issues

* ODMPLANNING-1151

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.37`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `8de144e9-7bdd-4fef-82dc-dde19d597605`
- Event Trigger: `pull_request.edited`
</details>
