### PR TITLE
feat: ODMPLANNING-1151 - Correctly handle static / tenant-specific metadata

### DIFF
--- a/__tests__/integration/__snapshots__/basic-auth.test.js.snap
+++ b/__tests__/integration/__snapshots__/basic-auth.test.js.snap
@@ -1,219 +1,42 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customization should match snapshot 1`] = `
+exports[`ORD Integration Tests - Basic Authentication ORD Config Endpoint Tests should return ORD config with standard Authorization header 1`] = `
 {
-  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
-  "apiResources": [
-    {
-      "apiProtocol": "odata-v4",
-      "description": "Description for TestService",
-      "entryPoints": [
-        "/test",
-      ],
-      "extensible": {
-        "supported": "no",
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "basic-auth",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
       },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:TestService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.oas3.json",
-        },
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/xml",
-          "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.edmx",
-        },
-      ],
-      "shortDescription": "Minimal service for ORD integration tests",
-      "title": "Test Service for Integration Testing",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-    {
-      "apiProtocol": "odata-v4",
-      "description": "Description for SupplierService",
-      "entryPoints": [
-        "/odata/v4/supplier",
-      ],
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.oas3.json",
-        },
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/xml",
-          "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.edmx",
-        },
-      ],
-      "shortDescription": "Short description of SupplierService",
-      "title": "SupplierService",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
-  "describedSystemVersion": {
-    "version": "1.0.0",
+    ],
   },
-  "description": "this is an application description",
-  "eventResources": [
-    {
-      "description": "CAP Event resource describing events / messages.",
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:TestService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "asyncapi-v2",
-          "url": "customer.capireordintegrationtest_eventResource_TestService_v1/TestService.asyncapi2.json",
-        },
-      ],
-      "shortDescription": "Minimal service for ORD integration tests",
-      "title": "Test Service for Integration Testing",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-  ],
-  "groups": [
-    {
-      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
-      "groupTypeId": "sap.cds:service",
-      "title": "Test Service for Integration Testing",
-    },
-    {
-      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
-      "groupTypeId": "sap.cds:service",
-      "title": "Supplier Service",
-    },
-  ],
-  "integrationDependencies": [
-    {
-      "aspects": [
-        {
-          "apiResources": [
-            {
-              "minVersion": "1.0.0",
-              "ordId": "test.sai:apiResource:Supplier:v1",
-            },
-          ],
-          "description": "Integration with Test SAI Supplier Data Product",
-          "mandatory": false,
-          "title": "Test SAI Supplier API",
-        },
-        {
-          "apiResources": [
-            {
-              "minVersion": "1.0.0",
-              "ordId": "test.s4:apiResource:Supplier:v1",
-            },
-          ],
-          "description": "Integration with Test S4 Supplier Data Product",
-          "mandatory": false,
-          "title": "Test S4 Supplier API",
-        },
-      ],
-      "description": "Custom description from cdsrc",
-      "mandatory": false,
-      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "beta",
-      "title": "Custom External Dependencies",
-      "version": "2.0.0",
-      "visibility": "internal",
-    },
-  ],
-  "openResourceDiscovery": "1.14",
-  "packages": [
-    {
-      "description": "This package contains public General for capire ord integration test.",
-      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "partOfProducts": [
-        "customer:product:capire.ord.integration.test:",
-      ],
-      "shortDescription": "Package containing public General",
-      "title": "capire ord integration test",
-      "vendor": "customer:vendor:Customer:",
-      "version": "1.0.0",
-    },
-  ],
-  "perspective": "system-version",
-  "policyLevels": [
-    "none",
-  ],
-  "products": [
-    {
-      "ordId": "customer:product:capire.ord.integration.test:",
-      "shortDescription": "Short description of capire ord integration test",
-      "title": "capire ord integration test",
-      "vendor": "customer:vendor:Customer:",
-    },
-  ],
 }
 `;
 
-exports[`ORD Build Integration Tests IntegrationDependency with custom.ord.json merging should match snapshot 1`] = `
+exports[`ORD Integration Tests - Basic Authentication ORD Config Endpoint Tests should return ORD config without authentication 1`] = `
+{
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "basic-auth",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
+      },
+    ],
+  },
+}
+`;
+
+exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Tests should return ORD document with standard Authorization header 1`] = `
 {
   "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
   "apiResources": [
@@ -237,22 +60,22 @@ exports[`ORD Build Integration Tests IntegrationDependency with custom.ord.json 
         {
           "accessStrategies": [
             {
-              "type": "open",
+              "type": "basic-auth",
             },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.oas3.json",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json",
         },
         {
           "accessStrategies": [
             {
-              "type": "open",
+              "type": "basic-auth",
             },
           ],
           "mediaType": "application/xml",
           "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx",
         },
       ],
       "shortDescription": "Minimal service for ORD integration tests",
@@ -280,22 +103,22 @@ exports[`ORD Build Integration Tests IntegrationDependency with custom.ord.json 
         {
           "accessStrategies": [
             {
-              "type": "open",
+              "type": "basic-auth",
             },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.oas3.json",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.oas3.json",
         },
         {
           "accessStrategies": [
             {
-              "type": "open",
+              "type": "basic-auth",
             },
           ],
           "mediaType": "application/xml",
           "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
         },
       ],
       "shortDescription": "Short description of SupplierService",
@@ -335,225 +158,12 @@ exports[`ORD Build Integration Tests IntegrationDependency with custom.ord.json 
         {
           "accessStrategies": [
             {
-              "type": "open",
+              "type": "basic-auth",
             },
           ],
           "mediaType": "application/json",
           "type": "asyncapi-v2",
-          "url": "customer.capireordintegrationtest_eventResource_TestService_v1/TestService.asyncapi2.json",
-        },
-      ],
-      "shortDescription": "Minimal service for ORD integration tests",
-      "title": "Test Service for Integration Testing",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-  ],
-  "groups": [
-    {
-      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
-      "groupTypeId": "sap.cds:service",
-      "title": "Test Service for Integration Testing",
-    },
-    {
-      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
-      "groupTypeId": "sap.cds:service",
-      "title": "Supplier Service",
-    },
-  ],
-  "integrationDependencies": [
-    {
-      "aspects": [
-        {
-          "apiResources": [
-            {
-              "minVersion": "1.0.0",
-              "ordId": "test.sai:apiResource:Supplier:v1",
-            },
-          ],
-          "description": "Integration with Test SAI Supplier Data Product",
-          "mandatory": false,
-          "title": "Test SAI Supplier API",
-        },
-        {
-          "apiResources": [
-            {
-              "minVersion": "1.0.0",
-              "ordId": "test.s4:apiResource:Supplier:v1",
-            },
-          ],
-          "description": "Integration with Test S4 Supplier Data Product",
-          "mandatory": false,
-          "title": "Test S4 Supplier API",
-        },
-      ],
-      "mandatory": true,
-      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "shortDescription": "Patched via custom.ord.json",
-      "title": "Patched External Dependencies",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-  ],
-  "openResourceDiscovery": "1.14",
-  "packages": [
-    {
-      "description": "This package contains public General for capire ord integration test.",
-      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "partOfProducts": [
-        "customer:product:capire.ord.integration.test:",
-      ],
-      "shortDescription": "Package containing public General",
-      "title": "capire ord integration test",
-      "vendor": "customer:vendor:Customer:",
-      "version": "1.0.0",
-    },
-  ],
-  "perspective": "system-version",
-  "policyLevels": [
-    "none",
-  ],
-  "products": [
-    {
-      "ordId": "customer:product:capire.ord.integration.test:",
-      "shortDescription": "Short description of capire ord integration test",
-      "title": "capire ord integration test",
-      "vendor": "customer:vendor:Customer:",
-    },
-  ],
-}
-`;
-
-exports[`ORD Build Integration Tests Successful Build should generate ord-document.json 1`] = `
-{
-  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
-  "apiResources": [
-    {
-      "apiProtocol": "odata-v4",
-      "description": "Description for TestService",
-      "entryPoints": [
-        "/test",
-      ],
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:TestService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.oas3.json",
-        },
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/xml",
-          "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.edmx",
-        },
-      ],
-      "shortDescription": "Minimal service for ORD integration tests",
-      "title": "Test Service for Integration Testing",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-    {
-      "apiProtocol": "odata-v4",
-      "description": "Description for SupplierService",
-      "entryPoints": [
-        "/odata/v4/supplier",
-      ],
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.oas3.json",
-        },
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/xml",
-          "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.edmx",
-        },
-      ],
-      "shortDescription": "Short description of SupplierService",
-      "title": "SupplierService",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
-  "describedSystemVersion": {
-    "version": "0.1.0",
-  },
-  "description": "this is an application description",
-  "eventResources": [
-    {
-      "description": "CAP Event resource describing events / messages.",
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:TestService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "asyncapi-v2",
-          "url": "customer.capireordintegrationtest_eventResource_TestService_v1/TestService.asyncapi2.json",
+          "url": "/ord/v1/customer.capireordintegrationtest:eventResource:TestService:v1/TestService.asyncapi2.json",
         },
       ],
       "shortDescription": "Minimal service for ORD integration tests",
@@ -635,5 +245,730 @@ exports[`ORD Build Integration Tests Successful Build should generate ord-docume
       "vendor": "customer:vendor:Customer:",
     },
   ],
+}
+`;
+
+exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Tests should return ORD document with valid basic auth (lowercase header) 1`] = `
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "apiResources": [
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for TestService",
+      "entryPoints": [
+        "/test",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/odata/v4/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "consumptionBundles": [
+    {
+      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
+      "shortDescription": "If we have another protected API then it will be another object",
+      "title": "Unprotected resources",
+      "version": "1.0.0",
+    },
+  ],
+  "describedSystemVersion": {
+    "version": "0.1.0",
+  },
+  "description": "this is an application description",
+  "eventResources": [
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "/ord/v1/customer.capireordintegrationtest:eventResource:TestService:v1/TestService.asyncapi2.json",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "groups": [
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Test Service for Integration Testing",
+    },
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Supplier Service",
+    },
+  ],
+  "integrationDependencies": [
+    {
+      "aspects": [
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.sai:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test SAI Supplier Data Product",
+          "mandatory": false,
+          "title": "Test SAI Supplier API",
+        },
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.s4:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test S4 Supplier Data Product",
+          "mandatory": false,
+          "title": "Test S4 Supplier API",
+        },
+      ],
+      "mandatory": false,
+      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "title": "External Dependencies",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "openResourceDiscovery": "1.14",
+  "packages": [
+    {
+      "description": "This package contains public General for capire ord integration test.",
+      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "partOfProducts": [
+        "customer:product:capire.ord.integration.test:",
+      ],
+      "shortDescription": "Package containing public General",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+  ],
+  "perspective": "system-version",
+  "policyLevels": [
+    "none",
+  ],
+  "products": [
+    {
+      "ordId": "customer:product:capire.ord.integration.test:",
+      "shortDescription": "Short description of capire ord integration test",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+    },
+  ],
+}
+`;
+
+exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Tests should return ORD document with valid basic auth for system-instance perspective 1`] = `
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "apiResources": [
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for TestService",
+      "entryPoints": [
+        "/test",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json?perspective=system-instance",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx?perspective=system-instance",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/odata/v4/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.oas3.json?perspective=system-instance",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx?perspective=system-instance",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "consumptionBundles": [
+    {
+      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
+      "shortDescription": "If we have another protected API then it will be another object",
+      "title": "Unprotected resources",
+      "version": "1.0.0",
+    },
+  ],
+  "description": "this is an application description",
+  "eventResources": [
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "/ord/v1/customer.capireordintegrationtest:eventResource:TestService:v1/TestService.asyncapi2.json?perspective=system-instance",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "groups": [
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Test Service for Integration Testing",
+    },
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Supplier Service",
+    },
+  ],
+  "integrationDependencies": [
+    {
+      "aspects": [
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.sai:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test SAI Supplier Data Product",
+          "mandatory": false,
+          "title": "Test SAI Supplier API",
+        },
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.s4:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test S4 Supplier Data Product",
+          "mandatory": false,
+          "title": "Test S4 Supplier API",
+        },
+      ],
+      "mandatory": false,
+      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "title": "External Dependencies",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "openResourceDiscovery": "1.14",
+  "packages": [
+    {
+      "description": "This package contains public General for capire ord integration test.",
+      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "partOfProducts": [
+        "customer:product:capire.ord.integration.test:",
+      ],
+      "shortDescription": "Package containing public General",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+  ],
+  "perspective": "system-instance",
+  "policyLevels": [
+    "none",
+  ],
+  "products": [
+    {
+      "ordId": "customer:product:capire.ord.integration.test:",
+      "shortDescription": "Short description of capire ord integration test",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+    },
+  ],
+}
+`;
+
+exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Tests should return ORD document with valid basic auth for system-version perspective 1`] = `
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "apiResources": [
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for TestService",
+      "entryPoints": [
+        "/test",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/odata/v4/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "consumptionBundles": [
+    {
+      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
+      "shortDescription": "If we have another protected API then it will be another object",
+      "title": "Unprotected resources",
+      "version": "1.0.0",
+    },
+  ],
+  "describedSystemVersion": {
+    "version": "0.1.0",
+  },
+  "description": "this is an application description",
+  "eventResources": [
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "/ord/v1/customer.capireordintegrationtest:eventResource:TestService:v1/TestService.asyncapi2.json",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "groups": [
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Test Service for Integration Testing",
+    },
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Supplier Service",
+    },
+  ],
+  "integrationDependencies": [
+    {
+      "aspects": [
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.sai:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test SAI Supplier Data Product",
+          "mandatory": false,
+          "title": "Test SAI Supplier API",
+        },
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.s4:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test S4 Supplier Data Product",
+          "mandatory": false,
+          "title": "Test S4 Supplier API",
+        },
+      ],
+      "mandatory": false,
+      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "title": "External Dependencies",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "openResourceDiscovery": "1.14",
+  "packages": [
+    {
+      "description": "This package contains public General for capire ord integration test.",
+      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "partOfProducts": [
+        "customer:product:capire.ord.integration.test:",
+      ],
+      "shortDescription": "Package containing public General",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+  ],
+  "perspective": "system-version",
+  "policyLevels": [
+    "none",
+  ],
+  "products": [
+    {
+      "ordId": "customer:product:capire.ord.integration.test:",
+      "shortDescription": "Short description of capire ord integration test",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+    },
+  ],
+}
+`;
+
+exports[`ORD Integration Tests - Basic Authentication ORD Document Structure Validation for system-instance perspective should include TestService with correct properties 1`] = `
+{
+  "apiProtocol": "odata-v4",
+  "description": "Description for TestService",
+  "entryPoints": [
+    "/test",
+  ],
+  "extensible": {
+    "supported": "no",
+  },
+  "lastUpdate": "2026-05-04T13:45:01+01:00",
+  "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+  "partOfGroups": [
+    "sap.cds:service:customer.capireordintegrationtest:TestService",
+  ],
+  "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "basic-auth",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "openapi-v3",
+      "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json?perspective=system-instance",
+    },
+    {
+      "accessStrategies": [
+        {
+          "type": "basic-auth",
+        },
+      ],
+      "mediaType": "application/xml",
+      "type": "edmx",
+      "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx?perspective=system-instance",
+    },
+  ],
+  "shortDescription": "Minimal service for ORD integration tests",
+  "title": "Test Service for Integration Testing",
+  "version": "1.0.0",
+  "visibility": "public",
+}
+`;
+
+exports[`ORD Integration Tests - Basic Authentication ORD Document Structure Validation for system-version perspective should include TestService with correct properties 1`] = `
+{
+  "apiProtocol": "odata-v4",
+  "description": "Description for TestService",
+  "entryPoints": [
+    "/test",
+  ],
+  "extensible": {
+    "supported": "no",
+  },
+  "lastUpdate": "2026-05-04T13:45:01+01:00",
+  "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+  "partOfGroups": [
+    "sap.cds:service:customer.capireordintegrationtest:TestService",
+  ],
+  "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "basic-auth",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "openapi-v3",
+      "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json",
+    },
+    {
+      "accessStrategies": [
+        {
+          "type": "basic-auth",
+        },
+      ],
+      "mediaType": "application/xml",
+      "type": "edmx",
+      "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx",
+    },
+  ],
+  "shortDescription": "Minimal service for ORD integration tests",
+  "title": "Test Service for Integration Testing",
+  "version": "1.0.0",
+  "visibility": "public",
 }
 `;

--- a/__tests__/integration/__snapshots__/mtls-auth.test.js.snap
+++ b/__tests__/integration/__snapshots__/mtls-auth.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customization should match snapshot 1`] = `
+exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with configEndpoints) fetchMtlsCertInfo - Config Endpoint Fetch should use fetched cert info to validate mTLS requests 1`] = `
 {
   "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
   "apiResources": [
@@ -24,22 +24,22 @@ exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customizat
         {
           "accessStrategies": [
             {
-              "type": "open",
+              "type": "sap:cmp-mtls:v1",
             },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.oas3.json",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json",
         },
         {
           "accessStrategies": [
             {
-              "type": "open",
+              "type": "sap:cmp-mtls:v1",
             },
           ],
           "mediaType": "application/xml",
           "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx",
         },
       ],
       "shortDescription": "Minimal service for ORD integration tests",
@@ -67,22 +67,22 @@ exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customizat
         {
           "accessStrategies": [
             {
-              "type": "open",
+              "type": "sap:cmp-mtls:v1",
             },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.oas3.json",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.oas3.json",
         },
         {
           "accessStrategies": [
             {
-              "type": "open",
+              "type": "sap:cmp-mtls:v1",
             },
           ],
           "mediaType": "application/xml",
           "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
         },
       ],
       "shortDescription": "Short description of SupplierService",
@@ -102,7 +102,7 @@ exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customizat
     },
   ],
   "describedSystemVersion": {
-    "version": "1.0.0",
+    "version": "0.0.1",
   },
   "description": "this is an application description",
   "eventResources": [
@@ -122,438 +122,12 @@ exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customizat
         {
           "accessStrategies": [
             {
-              "type": "open",
+              "type": "sap:cmp-mtls:v1",
             },
           ],
           "mediaType": "application/json",
           "type": "asyncapi-v2",
-          "url": "customer.capireordintegrationtest_eventResource_TestService_v1/TestService.asyncapi2.json",
-        },
-      ],
-      "shortDescription": "Minimal service for ORD integration tests",
-      "title": "Test Service for Integration Testing",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-  ],
-  "groups": [
-    {
-      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
-      "groupTypeId": "sap.cds:service",
-      "title": "Test Service for Integration Testing",
-    },
-    {
-      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
-      "groupTypeId": "sap.cds:service",
-      "title": "Supplier Service",
-    },
-  ],
-  "integrationDependencies": [
-    {
-      "aspects": [
-        {
-          "apiResources": [
-            {
-              "minVersion": "1.0.0",
-              "ordId": "test.sai:apiResource:Supplier:v1",
-            },
-          ],
-          "description": "Integration with Test SAI Supplier Data Product",
-          "mandatory": false,
-          "title": "Test SAI Supplier API",
-        },
-        {
-          "apiResources": [
-            {
-              "minVersion": "1.0.0",
-              "ordId": "test.s4:apiResource:Supplier:v1",
-            },
-          ],
-          "description": "Integration with Test S4 Supplier Data Product",
-          "mandatory": false,
-          "title": "Test S4 Supplier API",
-        },
-      ],
-      "description": "Custom description from cdsrc",
-      "mandatory": false,
-      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "beta",
-      "title": "Custom External Dependencies",
-      "version": "2.0.0",
-      "visibility": "internal",
-    },
-  ],
-  "openResourceDiscovery": "1.14",
-  "packages": [
-    {
-      "description": "This package contains public General for capire ord integration test.",
-      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "partOfProducts": [
-        "customer:product:capire.ord.integration.test:",
-      ],
-      "shortDescription": "Package containing public General",
-      "title": "capire ord integration test",
-      "vendor": "customer:vendor:Customer:",
-      "version": "1.0.0",
-    },
-  ],
-  "perspective": "system-version",
-  "policyLevels": [
-    "none",
-  ],
-  "products": [
-    {
-      "ordId": "customer:product:capire.ord.integration.test:",
-      "shortDescription": "Short description of capire ord integration test",
-      "title": "capire ord integration test",
-      "vendor": "customer:vendor:Customer:",
-    },
-  ],
-}
-`;
-
-exports[`ORD Build Integration Tests IntegrationDependency with custom.ord.json merging should match snapshot 1`] = `
-{
-  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
-  "apiResources": [
-    {
-      "apiProtocol": "odata-v4",
-      "description": "Description for TestService",
-      "entryPoints": [
-        "/test",
-      ],
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:TestService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.oas3.json",
-        },
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/xml",
-          "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.edmx",
-        },
-      ],
-      "shortDescription": "Minimal service for ORD integration tests",
-      "title": "Test Service for Integration Testing",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-    {
-      "apiProtocol": "odata-v4",
-      "description": "Description for SupplierService",
-      "entryPoints": [
-        "/odata/v4/supplier",
-      ],
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.oas3.json",
-        },
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/xml",
-          "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.edmx",
-        },
-      ],
-      "shortDescription": "Short description of SupplierService",
-      "title": "SupplierService",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
-  "describedSystemVersion": {
-    "version": "0.1.0",
-  },
-  "description": "this is an application description",
-  "eventResources": [
-    {
-      "description": "CAP Event resource describing events / messages.",
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:TestService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "asyncapi-v2",
-          "url": "customer.capireordintegrationtest_eventResource_TestService_v1/TestService.asyncapi2.json",
-        },
-      ],
-      "shortDescription": "Minimal service for ORD integration tests",
-      "title": "Test Service for Integration Testing",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-  ],
-  "groups": [
-    {
-      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
-      "groupTypeId": "sap.cds:service",
-      "title": "Test Service for Integration Testing",
-    },
-    {
-      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
-      "groupTypeId": "sap.cds:service",
-      "title": "Supplier Service",
-    },
-  ],
-  "integrationDependencies": [
-    {
-      "aspects": [
-        {
-          "apiResources": [
-            {
-              "minVersion": "1.0.0",
-              "ordId": "test.sai:apiResource:Supplier:v1",
-            },
-          ],
-          "description": "Integration with Test SAI Supplier Data Product",
-          "mandatory": false,
-          "title": "Test SAI Supplier API",
-        },
-        {
-          "apiResources": [
-            {
-              "minVersion": "1.0.0",
-              "ordId": "test.s4:apiResource:Supplier:v1",
-            },
-          ],
-          "description": "Integration with Test S4 Supplier Data Product",
-          "mandatory": false,
-          "title": "Test S4 Supplier API",
-        },
-      ],
-      "mandatory": true,
-      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "shortDescription": "Patched via custom.ord.json",
-      "title": "Patched External Dependencies",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-  ],
-  "openResourceDiscovery": "1.14",
-  "packages": [
-    {
-      "description": "This package contains public General for capire ord integration test.",
-      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "partOfProducts": [
-        "customer:product:capire.ord.integration.test:",
-      ],
-      "shortDescription": "Package containing public General",
-      "title": "capire ord integration test",
-      "vendor": "customer:vendor:Customer:",
-      "version": "1.0.0",
-    },
-  ],
-  "perspective": "system-version",
-  "policyLevels": [
-    "none",
-  ],
-  "products": [
-    {
-      "ordId": "customer:product:capire.ord.integration.test:",
-      "shortDescription": "Short description of capire ord integration test",
-      "title": "capire ord integration test",
-      "vendor": "customer:vendor:Customer:",
-    },
-  ],
-}
-`;
-
-exports[`ORD Build Integration Tests Successful Build should generate ord-document.json 1`] = `
-{
-  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
-  "apiResources": [
-    {
-      "apiProtocol": "odata-v4",
-      "description": "Description for TestService",
-      "entryPoints": [
-        "/test",
-      ],
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:TestService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.oas3.json",
-        },
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/xml",
-          "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_TestService_v1/TestService.edmx",
-        },
-      ],
-      "shortDescription": "Minimal service for ORD integration tests",
-      "title": "Test Service for Integration Testing",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-    {
-      "apiProtocol": "odata-v4",
-      "description": "Description for SupplierService",
-      "entryPoints": [
-        "/odata/v4/supplier",
-      ],
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "openapi-v3",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.oas3.json",
-        },
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/xml",
-          "type": "edmx",
-          "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.edmx",
-        },
-      ],
-      "shortDescription": "Short description of SupplierService",
-      "title": "SupplierService",
-      "version": "1.0.0",
-      "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
-  "describedSystemVersion": {
-    "version": "0.1.0",
-  },
-  "description": "this is an application description",
-  "eventResources": [
-    {
-      "description": "CAP Event resource describing events / messages.",
-      "extensible": {
-        "supported": "no",
-      },
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
-      "partOfGroups": [
-        "sap.cds:service:customer.capireordintegrationtest:TestService",
-      ],
-      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
-      "releaseStatus": "active",
-      "resourceDefinitions": [
-        {
-          "accessStrategies": [
-            {
-              "type": "open",
-            },
-          ],
-          "mediaType": "application/json",
-          "type": "asyncapi-v2",
-          "url": "customer.capireordintegrationtest_eventResource_TestService_v1/TestService.asyncapi2.json",
+          "url": "/ord/v1/customer.capireordintegrationtest:eventResource:TestService:v1/TestService.asyncapi2.json",
         },
       ],
       "shortDescription": "Minimal service for ORD integration tests",
@@ -635,5 +209,796 @@ exports[`ORD Build Integration Tests Successful Build should generate ord-docume
       "vendor": "customer:vendor:Customer:",
     },
   ],
+}
+`;
+
+exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with configEndpoints) mTLS Authentication - Valid Scenarios should accept valid mTLS headers for ORD document endpoint 1`] = `
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "apiResources": [
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for TestService",
+      "entryPoints": [
+        "/test",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/odata/v4/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "consumptionBundles": [
+    {
+      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
+      "shortDescription": "If we have another protected API then it will be another object",
+      "title": "Unprotected resources",
+      "version": "1.0.0",
+    },
+  ],
+  "describedSystemVersion": {
+    "version": "0.0.1",
+  },
+  "description": "this is an application description",
+  "eventResources": [
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "/ord/v1/customer.capireordintegrationtest:eventResource:TestService:v1/TestService.asyncapi2.json",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "groups": [
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Test Service for Integration Testing",
+    },
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Supplier Service",
+    },
+  ],
+  "integrationDependencies": [
+    {
+      "aspects": [
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.sai:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test SAI Supplier Data Product",
+          "mandatory": false,
+          "title": "Test SAI Supplier API",
+        },
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.s4:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test S4 Supplier Data Product",
+          "mandatory": false,
+          "title": "Test S4 Supplier API",
+        },
+      ],
+      "mandatory": false,
+      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "title": "External Dependencies",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "openResourceDiscovery": "1.14",
+  "packages": [
+    {
+      "description": "This package contains public General for capire ord integration test.",
+      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "partOfProducts": [
+        "customer:product:capire.ord.integration.test:",
+      ],
+      "shortDescription": "Package containing public General",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+  ],
+  "perspective": "system-version",
+  "policyLevels": [
+    "none",
+  ],
+  "products": [
+    {
+      "ordId": "customer:product:capire.ord.integration.test:",
+      "shortDescription": "Short description of capire ord integration test",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+    },
+  ],
+}
+`;
+
+exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with configEndpoints) mTLS Authentication - Valid Scenarios should return ORD config without authentication (endpoint is always open) 1`] = `
+{
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "sap:cmp-mtls:v1",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
+      },
+    ],
+  },
+}
+`;
+
+exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) ORD Document Structure with mTLS and system-instance perspective should include TestService with correct properties 1`] = `
+{
+  "apiProtocol": "odata-v4",
+  "description": "Description for TestService",
+  "entryPoints": [
+    "/test",
+  ],
+  "extensible": {
+    "supported": "no",
+  },
+  "lastUpdate": "2026-05-04T13:45:01+01:00",
+  "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+  "partOfGroups": [
+    "sap.cds:service:customer.capireordintegrationtest:TestService",
+  ],
+  "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "sap:cmp-mtls:v1",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "openapi-v3",
+      "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json?perspective=system-instance",
+    },
+    {
+      "accessStrategies": [
+        {
+          "type": "sap:cmp-mtls:v1",
+        },
+      ],
+      "mediaType": "application/xml",
+      "type": "edmx",
+      "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx?perspective=system-instance",
+    },
+  ],
+  "shortDescription": "Minimal service for ORD integration tests",
+  "title": "Test Service for Integration Testing",
+  "version": "1.0.0",
+  "visibility": "public",
+}
+`;
+
+exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) ORD Document Structure with mTLS and system-version perspective should include TestService with correct properties 1`] = `
+{
+  "apiProtocol": "odata-v4",
+  "description": "Description for TestService",
+  "entryPoints": [
+    "/test",
+  ],
+  "extensible": {
+    "supported": "no",
+  },
+  "lastUpdate": "2026-05-04T13:45:01+01:00",
+  "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+  "partOfGroups": [
+    "sap.cds:service:customer.capireordintegrationtest:TestService",
+  ],
+  "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "sap:cmp-mtls:v1",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "openapi-v3",
+      "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json",
+    },
+    {
+      "accessStrategies": [
+        {
+          "type": "sap:cmp-mtls:v1",
+        },
+      ],
+      "mediaType": "application/xml",
+      "type": "edmx",
+      "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx",
+    },
+  ],
+  "shortDescription": "Minimal service for ORD integration tests",
+  "title": "Test Service for Integration Testing",
+  "version": "1.0.0",
+  "visibility": "public",
+}
+`;
+
+exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) Production Mode - cfMtls: true with CF_MTLS_TRUSTED_CERTS should work with cfMtls: true when CF_MTLS_TRUSTED_CERTS provides cert config 1`] = `
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "apiResources": [
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for TestService",
+      "entryPoints": [
+        "/test",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/odata/v4/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "consumptionBundles": [
+    {
+      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
+      "shortDescription": "If we have another protected API then it will be another object",
+      "title": "Unprotected resources",
+      "version": "1.0.0",
+    },
+  ],
+  "describedSystemVersion": {
+    "version": "0.0.1",
+  },
+  "description": "this is an application description",
+  "eventResources": [
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "/ord/v1/customer.capireordintegrationtest:eventResource:TestService:v1/TestService.asyncapi2.json",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "groups": [
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Test Service for Integration Testing",
+    },
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Supplier Service",
+    },
+  ],
+  "integrationDependencies": [
+    {
+      "aspects": [
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.sai:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test SAI Supplier Data Product",
+          "mandatory": false,
+          "title": "Test SAI Supplier API",
+        },
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.s4:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test S4 Supplier Data Product",
+          "mandatory": false,
+          "title": "Test S4 Supplier API",
+        },
+      ],
+      "mandatory": false,
+      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "title": "External Dependencies",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "openResourceDiscovery": "1.14",
+  "packages": [
+    {
+      "description": "This package contains public General for capire ord integration test.",
+      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "partOfProducts": [
+        "customer:product:capire.ord.integration.test:",
+      ],
+      "shortDescription": "Package containing public General",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+  ],
+  "perspective": "system-version",
+  "policyLevels": [
+    "none",
+  ],
+  "products": [
+    {
+      "ordId": "customer:product:capire.ord.integration.test:",
+      "shortDescription": "Short description of capire ord integration test",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+    },
+  ],
+}
+`;
+
+exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authentication - Valid Scenarios should accept valid mTLS headers for ORD document endpoint 1`] = `
+{
+  "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
+  "apiResources": [
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for TestService",
+      "entryPoints": [
+        "/test",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:TestService:v1/TestService.edmx",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "odata-v4",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/odata/v4/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.oas3.json",
+        },
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/xml",
+          "type": "edmx",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "consumptionBundles": [
+    {
+      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
+      "shortDescription": "If we have another protected API then it will be another object",
+      "title": "Unprotected resources",
+      "version": "1.0.0",
+    },
+  ],
+  "describedSystemVersion": {
+    "version": "0.0.1",
+  },
+  "description": "this is an application description",
+  "eventResources": [
+    {
+      "description": "CAP Event resource describing events / messages.",
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:eventResource:TestService:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:TestService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "asyncapi-v2",
+          "url": "/ord/v1/customer.capireordintegrationtest:eventResource:TestService:v1/TestService.asyncapi2.json",
+        },
+      ],
+      "shortDescription": "Minimal service for ORD integration tests",
+      "title": "Test Service for Integration Testing",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "groups": [
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:TestService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Test Service for Integration Testing",
+    },
+    {
+      "groupId": "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      "groupTypeId": "sap.cds:service",
+      "title": "Supplier Service",
+    },
+  ],
+  "integrationDependencies": [
+    {
+      "aspects": [
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.sai:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test SAI Supplier Data Product",
+          "mandatory": false,
+          "title": "Test SAI Supplier API",
+        },
+        {
+          "apiResources": [
+            {
+              "minVersion": "1.0.0",
+              "ordId": "test.s4:apiResource:Supplier:v1",
+            },
+          ],
+          "description": "Integration with Test S4 Supplier Data Product",
+          "mandatory": false,
+          "title": "Test S4 Supplier API",
+        },
+      ],
+      "mandatory": false,
+      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "title": "External Dependencies",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+  ],
+  "openResourceDiscovery": "1.14",
+  "packages": [
+    {
+      "description": "This package contains public General for capire ord integration test.",
+      "ordId": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "partOfProducts": [
+        "customer:product:capire.ord.integration.test:",
+      ],
+      "shortDescription": "Package containing public General",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+      "version": "1.0.0",
+    },
+  ],
+  "perspective": "system-version",
+  "policyLevels": [
+    "none",
+  ],
+  "products": [
+    {
+      "ordId": "customer:product:capire.ord.integration.test:",
+      "shortDescription": "Short description of capire ord integration test",
+      "title": "capire ord integration test",
+      "vendor": "customer:vendor:Customer:",
+    },
+  ],
+}
+`;
+
+exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authentication - Valid Scenarios should return ORD config for all perspectives without authentication (endpoint is always open) 1`] = `
+{
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "sap:cmp-mtls:v1",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "sap:cmp-mtls:v1",
+          },
+        ],
+        "perspective": "system-instance",
+        "url": "/ord/v1/documents/ord-document?perspective=system-instance",
+      },
+    ],
+  },
+}
+`;
+
+exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authentication - Valid Scenarios should return ORD config without authentication (endpoint is always open) 1`] = `
+{
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "sap:cmp-mtls:v1",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
+      },
+    ],
+  },
 }
 `;

--- a/__tests__/integration/basic-auth.test.js
+++ b/__tests__/integration/basic-auth.test.js
@@ -2,6 +2,8 @@ const request = require("supertest");
 const { spawn } = require("child_process");
 const path = require("path");
 
+const utils = require("../utils");
+
 const BASE_URL = "http://localhost:4004";
 const ORD_CONFIG_ENDPOINT = "/.well-known/open-resource-discovery";
 const ORD_DOCUMENT_ENDPOINT = "/ord/v1/documents/ord-document";
@@ -125,7 +127,17 @@ describe("ORD Integration Tests - Basic Authentication", () => {
                 .expect(200);
 
             expect(response.headers["content-type"]).toMatch(/application\/json/);
-            expect(response.body).toHaveProperty("openResourceDiscoveryV1");
+            expect(response.body).toEqual({
+                openResourceDiscoveryV1: {
+                    documents: [
+                        {
+                            url: "/ord/v1/documents/ord-document",
+                            accessStrategies: [{ type: "basic-auth" }],
+                            perspective: "system-version",
+                        },
+                    ],
+                },
+            });
         });
 
         test("should return ORD config with standard Authorization header", async () => {
@@ -134,14 +146,15 @@ describe("ORD Integration Tests - Basic Authentication", () => {
                 .set("Authorization", VALID_AUTH) // standard case
                 .expect(200);
 
-            expect(response.body).toHaveProperty("openResourceDiscoveryV1");
+            expect(response.headers["content-type"]).toMatch(/application\/json/);
+            expect(response.body).toMatchSnapshot();
         });
 
         test("should return ORD config without authentication", async () => {
             const response = await request(BASE_URL).get(ORD_CONFIG_ENDPOINT).expect(200);
 
             expect(response.headers["content-type"]).toMatch(/application\/json/);
-            expect(response.body).toHaveProperty("openResourceDiscoveryV1");
+            expect(response.body).toMatchSnapshot();
         });
     });
 
@@ -153,7 +166,7 @@ describe("ORD Integration Tests - Basic Authentication", () => {
                 .expect(200);
 
             expect(response.headers["content-type"]).toMatch(/application\/json/);
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
+            expect(utils.pinLastUpdateForStableTest(response.body)).toMatchSnapshot();
         });
 
         test("should return ORD document with standard Authorization header", async () => {
@@ -162,7 +175,8 @@ describe("ORD Integration Tests - Basic Authentication", () => {
                 .set("Authorization", VALID_AUTH) // standard case
                 .expect(200);
 
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
+            expect(response.headers["content-type"]).toMatch(/application\/json/);
+            expect(utils.pinLastUpdateForStableTest(response.body)).toMatchSnapshot();
         });
 
         test("should reject invalid password", async () => {
@@ -208,9 +222,44 @@ describe("ORD Integration Tests - Basic Authentication", () => {
 
             expect(response.text).toContain("Authentication required");
         });
+
+        test("should return bad request when requesting document with invalid perspective", async () => {
+            await request(BASE_URL)
+                .get(ORD_DOCUMENT_ENDPOINT + "?perspective=invalid")
+                .set("authorization", VALID_AUTH) // lowercase
+                .expect(400);
+        });
+
+        test("should return bad request when requesting document with system-instance perspective and no tenant", async () => {
+            await request(BASE_URL)
+                .get(ORD_DOCUMENT_ENDPOINT + "?perspective=system-instance")
+                .set("authorization", VALID_AUTH) // lowercase
+                .expect(400);
+        });
+
+        test("should return ORD document with valid basic auth for system-version perspective", async () => {
+            const response = await request(BASE_URL)
+                .get(ORD_DOCUMENT_ENDPOINT + "?perspective=system-version")
+                .set("authorization", VALID_AUTH) // lowercase
+                .expect(200);
+
+            expect(response.headers["content-type"]).toMatch(/application\/json/);
+            expect(utils.pinLastUpdateForStableTest(response.body)).toMatchSnapshot();
+        });
+
+        test("should return ORD document with valid basic auth for system-instance perspective", async () => {
+            const response = await request(BASE_URL)
+                .get(ORD_DOCUMENT_ENDPOINT + "?perspective=system-instance")
+                .set("Authorization", VALID_AUTH) // lowercase
+                .set("Local-Tenant-Id", "12-34-56") // lowercase
+                .expect(200);
+
+            expect(response.headers["content-type"]).toMatch(/application\/json/);
+            expect(utils.pinLastUpdateForStableTest(response.body)).toMatchSnapshot();
+        });
     });
 
-    describe("ORD Document Structure Validation", () => {
+    describe("ORD Document Structure Validation for system-version perspective", () => {
         let ordDocument;
 
         beforeAll(async () => {
@@ -219,7 +268,7 @@ describe("ORD Integration Tests - Basic Authentication", () => {
                 .set("Authorization", VALID_AUTH)
                 .expect(200);
 
-            ordDocument = response.body;
+            ordDocument = utils.pinLastUpdateForStableTest(response.body);
         });
 
         test("should have required ORD structure", () => {
@@ -227,23 +276,113 @@ describe("ORD Integration Tests - Basic Authentication", () => {
             expect(ordDocument).toHaveProperty("description");
             expect(Array.isArray(ordDocument.apiResources)).toBe(true);
             expect(Array.isArray(ordDocument.eventResources)).toBe(true);
+            expect(ordDocument.perspective).toBe("system-version");
+            expect(ordDocument.describedSystemVersion).toEqual({ version: "0.1.0" });
         });
 
         test("should include TestService with correct properties", () => {
             const testService = ordDocument.apiResources.find(
                 (api) => api.title === "Test Service for Integration Testing",
             );
-            expect(testService).toMatchObject({
-                shortDescription: "Minimal service for ORD integration tests",
-                version: "1.0.0",
-                visibility: "public",
-            });
+
+            expect(testService).toMatchSnapshot();
         });
 
         test("should contain expected resources", () => {
             expect(ordDocument.apiResources).toHaveLength(2);
             expect(ordDocument.eventResources).toHaveLength(1);
             expect(ordDocument.packages).toHaveLength(1);
+        });
+
+        test("should have correct query params for all resource definitions", () => {
+            ordDocument.apiResources.forEach((apiResource) => {
+                apiResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.url).toMatch(/(.*)\.(edmx|oas3\.json)$/);
+                });
+            });
+
+            ordDocument.eventResources.forEach((eventResource) => {
+                eventResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.url).toMatch(/(.*)\.asyncapi2\.json$/);
+                });
+            });
+        });
+
+        test("should have 'basic-auth' accessStrategies in all resources", () => {
+            // Verify API resources have 'basic-auth' accessStrategies
+            ordDocument.apiResources.forEach((apiResource) => {
+                apiResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "basic-auth" }]));
+                    expect(resDef.accessStrategies.some((s) => s.type === "basic-auth")).toBe(true);
+                });
+            });
+
+            // Verify Event resources have 'basic-auth' accessStrategies
+            ordDocument.eventResources.forEach((eventResource) => {
+                eventResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "basic-auth" }]));
+                    expect(resDef.accessStrategies.some((s) => s.type === "basic-auth")).toBe(true);
+                });
+            });
+
+            // Verify no resource has 'open' accessStrategy
+            [...ordDocument.apiResources, ...ordDocument.eventResources].forEach((resource) => {
+                resource.resourceDefinitions.forEach((resDef) => {
+                    const hasOpen = resDef.accessStrategies.some((s) => s.type === "open");
+                    expect(hasOpen).toBe(false);
+                });
+            });
+        });
+    });
+
+    describe("ORD Document Structure Validation for system-instance perspective", () => {
+        let ordDocument;
+
+        beforeAll(async () => {
+            const response = await request(BASE_URL)
+                .get("/ord/v1/documents/ord-document?perspective=system-instance")
+                .set("Authorization", VALID_AUTH)
+                .set("Local-Tenant-Id", "12-34-56")
+                .expect(200);
+
+            ordDocument = utils.pinLastUpdateForStableTest(response.body);
+        });
+
+        test("should have required ORD structure", () => {
+            expect(ordDocument).toHaveProperty("openResourceDiscovery", "1.14");
+            expect(ordDocument).toHaveProperty("description");
+            expect(Array.isArray(ordDocument.apiResources)).toBe(true);
+            expect(Array.isArray(ordDocument.eventResources)).toBe(true);
+            expect(ordDocument.perspective).toBe("system-instance");
+            expect(ordDocument.describedSystemVersion).toEqual(undefined);
+        });
+
+        test("should include TestService with correct properties", () => {
+            const testService = ordDocument.apiResources.find(
+                (api) => api.title === "Test Service for Integration Testing",
+            );
+
+            expect(testService).toMatchSnapshot();
+        });
+
+        test("should contain expected resources", () => {
+            expect(ordDocument.apiResources).toHaveLength(2);
+            expect(ordDocument.eventResources).toHaveLength(1);
+            expect(ordDocument.packages).toHaveLength(1);
+        });
+
+        test("should have correct query params for all resource definitions", () => {
+            ordDocument.apiResources.forEach((apiResource) => {
+                apiResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.url).toMatch(/(.*)\?perspective=system-instance$/);
+                });
+            });
+
+            ordDocument.eventResources.forEach((eventResource) => {
+                eventResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.url).toMatch(/(.*)\?perspective=system-instance$/);
+                });
+            });
         });
 
         test("should have 'basic-auth' accessStrategies in all resources", () => {

--- a/__tests__/integration/cds-build.test.js
+++ b/__tests__/integration/cds-build.test.js
@@ -3,24 +3,12 @@ const path = require("path");
 const fs = require("fs");
 const os = require("os");
 
+const utils = require("../utils");
+
 const TEST_APP_ROOT = path.join(__dirname, "integration-test-app");
 const GEN_DIR = path.join(TEST_APP_ROOT, "gen");
 const ORD_GEN_DIR = path.join(GEN_DIR, "srv");
 const ORD_DOC_PATH = path.join(ORD_GEN_DIR, "ord-document.json");
-
-function fixLastUpdateForStableTest(ord) {
-    (ord.consumptionBundles || []).find((cb) => {
-        cb.lastUpdate = "2026-05-04T13:45:01+01:00";
-    });
-    (ord.eventResources || []).find((er) => {
-        er.lastUpdate = "2026-05-04T13:45:01+01:00";
-    });
-    (ord.apiResources || []).find((ar) => {
-        ar.lastUpdate = "2026-05-04T13:45:01+01:00";
-    });
-
-    return ord;
-}
 
 /**
  * Execute cds build command and return result
@@ -90,7 +78,7 @@ describe("ORD Build Integration Tests", () => {
         test("should generate ord-document.json", () => {
             expect(fs.existsSync(ORD_DOC_PATH)).toBe(true);
             expect(fs.statSync(ORD_DOC_PATH).size).toBeGreaterThan(0);
-            expect(fixLastUpdateForStableTest(JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8")))).toMatchSnapshot();
+            expect(utils.pinLastUpdateForStableTest(JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8")))).toMatchSnapshot();
         });
 
         test("should have correct ORD document structure", () => {
@@ -110,7 +98,7 @@ describe("ORD Build Integration Tests", () => {
                 expect(apiResource.resourceDefinitions.length).toBeGreaterThan(0);
 
                 for (const resDef of apiResource.resourceDefinitions) {
-                    const filePath = path.join(ORD_GEN_DIR, resDef.url);
+                    const filePath = path.join(ORD_GEN_DIR, URL.parse(resDef.url, "http://localhost").pathname);
                     expect(fs.existsSync(filePath)).toBe(true);
                     expect(fs.statSync(filePath).size).toBeGreaterThan(0);
                 }
@@ -125,7 +113,7 @@ describe("ORD Build Integration Tests", () => {
                 expect(eventResource.resourceDefinitions.length).toBeGreaterThan(0);
 
                 for (const resDef of eventResource.resourceDefinitions) {
-                    const filePath = path.join(ORD_GEN_DIR, resDef.url);
+                    const filePath = path.join(ORD_GEN_DIR, URL.parse(resDef.url, "http://localhost").pathname);
                     expect(fs.existsSync(filePath)).toBe(true);
                     expect(fs.statSync(filePath).size).toBeGreaterThan(0);
                 }
@@ -136,10 +124,12 @@ describe("ORD Build Integration Tests", () => {
             const testServiceApi = ordDocument.apiResources.find((api) => api.ordId.includes("TestService"));
             expect(testServiceApi).toBeDefined();
 
-            const openApiDef = testServiceApi.resourceDefinitions.find((def) => def.url.endsWith(".oas3.json"));
+            const openApiDef = testServiceApi.resourceDefinitions.find((def) =>
+                URL.parse(def.url, "http://localhost").pathname.endsWith(".oas3.json"),
+            );
             expect(openApiDef).toBeDefined();
 
-            const openApiPath = path.join(ORD_GEN_DIR, openApiDef.url);
+            const openApiPath = path.join(ORD_GEN_DIR, URL.parse(openApiDef.url, "http://localhost").pathname);
             const openApiContent = JSON.parse(fs.readFileSync(openApiPath, "utf-8"));
 
             expect(openApiContent.servers).toBeDefined();
@@ -190,7 +180,7 @@ describe("ORD Build Integration Tests", () => {
             cleanupDir(GEN_DIR);
             buildResult = await runCdsBuild(TEST_APP_ROOT, CDSRC_CONFIG);
             if (fs.existsSync(ORD_DOC_PATH)) {
-                ordDocument = fixLastUpdateForStableTest(JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8")));
+                ordDocument = utils.pinLastUpdateForStableTest(JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8")));
             }
         }, 60000);
 
@@ -237,7 +227,7 @@ describe("ORD Build Integration Tests", () => {
             cleanupDir(GEN_DIR);
             buildResult = await runCdsBuild(TEST_APP_ROOT, CDSRC_CONFIG);
             if (fs.existsSync(ORD_DOC_PATH)) {
-                ordDocument = fixLastUpdateForStableTest(JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8")));
+                ordDocument = utils.pinLastUpdateForStableTest(JSON.parse(fs.readFileSync(ORD_DOC_PATH, "utf-8")));
             }
         }, 60000);
 

--- a/__tests__/integration/integration-test-app/.cdsrc.basic.json
+++ b/__tests__/integration/integration-test-app/.cdsrc.basic.json
@@ -1,4 +1,7 @@
 {
+    "requires": {
+        "toggles": true
+    },
     "ord": {
         "authentication": {
             "basic": {

--- a/__tests__/integration/integration-test-app/.cdsrc.mtls.json
+++ b/__tests__/integration/integration-test-app/.cdsrc.mtls.json
@@ -1,5 +1,11 @@
 {
+    "requires": {
+        "toggles": true
+    },
     "ord": {
+        "describedSystemVersion": {
+            "version": "0.0.1"
+        },
         "authentication": {
             "cfMtls": {
                 "certs": [],

--- a/__tests__/integration/integration-test-app/package.json
+++ b/__tests__/integration/integration-test-app/package.json
@@ -1,12 +1,13 @@
 {
     "name": "@capire/ord-integration-test",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "private": true,
     "scripts": {
         "start": "cds-serve"
     },
     "dependencies": {
         "@cap-js/ord": "*",
+        "@sap/cds-mtxs": "^3",
         "test-sai-supplier-v1": "file:./srv/imported/test-sai-supplier-v1",
         "test-s4-supplier-v1": "file:./srv/imported/test-s4-supplier-v1"
     },

--- a/__tests__/integration/mtls-auth.test.js
+++ b/__tests__/integration/mtls-auth.test.js
@@ -35,6 +35,8 @@ const path = require("path");
 const http = require("http");
 const net = require("net");
 const fs = require("fs");
+
+const utils = require("../utils");
 const { CF_MTLS_HEADERS } = require("../../lib/constants");
 
 const ORD_CONFIG_ENDPOINT = "/.well-known/open-resource-discovery";
@@ -182,7 +184,13 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
 
         // 1. Create production-style config file: cfMtls: true (requires env var)
         const productionConfig = {
+            requires: {
+                toggles: true,
+            },
             ord: {
+                describedSystemVersion: {
+                    version: "0.0.1"
+                },
                 authentication: {
                     cfMtls: true, // Production mode - requires CF_MTLS_TRUSTED_CERTS
                 },
@@ -289,7 +297,8 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
 
             const response = await request(BASE_URL).get(ORD_DOCUMENT_ENDPOINT).set(mtlsHeaders).expect(200);
 
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
+            expect(response.headers["content-type"]).toMatch(/application\/json/);
+            expect(utils.pinLastUpdateForStableTest(response.body)).toMatchSnapshot();
         });
     });
 
@@ -305,13 +314,22 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
             const response = await request(BASE_URL).get(ORD_DOCUMENT_ENDPOINT).set(mtlsHeaders).expect(200);
 
             expect(response.headers["content-type"]).toMatch(/application\/json/);
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
+            expect(utils.pinLastUpdateForStableTest(response.body)).toMatchSnapshot();
         });
 
         test("should return ORD config without authentication (endpoint is always open)", async () => {
             const response = await request(BASE_URL).get(ORD_CONFIG_ENDPOINT).expect(200);
 
-            expect(response.body).toHaveProperty("openResourceDiscoveryV1");
+            expect(response.body).toMatchSnapshot();
+        });
+
+        test("should return ORD config for all perspectives without authentication (endpoint is always open)", async () => {
+            const response = await request(BASE_URL)
+                .get(ORD_CONFIG_ENDPOINT)
+                .set("local-tenant-id", "12-34-56")
+                .expect(200);
+
+            expect(response.body).toMatchSnapshot();
         });
 
         test("should accept mTLS headers with DN components in different order", async () => {
@@ -402,7 +420,7 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
     });
 
     // ========== ORD document structure ==========
-    describe("ORD Document Structure with mTLS", () => {
+    describe("ORD Document Structure with mTLS and system-version perspective", () => {
         let ordDocument;
 
         beforeAll(async () => {
@@ -414,7 +432,7 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
 
             const response = await request(BASE_URL).get(ORD_DOCUMENT_ENDPOINT).set(mtlsHeaders).expect(200);
 
-            ordDocument = response.body;
+            ordDocument = utils.pinLastUpdateForStableTest(response.body);
         });
 
         test("should have required ORD structure", () => {
@@ -422,23 +440,119 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
             expect(ordDocument).toHaveProperty("description");
             expect(Array.isArray(ordDocument.apiResources)).toBe(true);
             expect(Array.isArray(ordDocument.eventResources)).toBe(true);
+            expect(ordDocument.perspective).toBe("system-version");
+            expect(ordDocument.describedSystemVersion).toEqual({version: "0.0.1"});
         });
 
         test("should include TestService with correct properties", () => {
             const testService = ordDocument.apiResources.find(
                 (api) => api.title === "Test Service for Integration Testing",
             );
-            expect(testService).toMatchObject({
-                shortDescription: "Minimal service for ORD integration tests",
-                version: "1.0.0",
-                visibility: "public",
-            });
+
+            expect(testService).toMatchSnapshot();
         });
 
         test("should contain expected resources", () => {
             expect(ordDocument.apiResources).toHaveLength(2);
             expect(ordDocument.eventResources).toHaveLength(1);
             expect(ordDocument.packages).toHaveLength(1);
+        });
+
+        test("should have correct query params for all resource definitions", () => {
+            ordDocument.apiResources.forEach((apiResource) => {
+                apiResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.url).toMatch(/(.*)\.(edmx|oas3\.json)$/);
+                });
+            });
+
+            ordDocument.eventResources.forEach((eventResource) => {
+                eventResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.url).toMatch(/(.*)\.asyncapi2.json$/);
+                });
+            });
+        });
+
+        test("should have 'sap:cmp-mtls:v1' accessStrategies in all resources", () => {
+            // Verify API resources have 'sap:cmp-mtls:v1' accessStrategies
+            ordDocument.apiResources.forEach((apiResource) => {
+                apiResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "sap:cmp-mtls:v1" }]));
+                    expect(resDef.accessStrategies.some((s) => s.type === "sap:cmp-mtls:v1")).toBe(true);
+                });
+            });
+
+            // Verify Event resources have 'sap:cmp-mtls:v1' accessStrategies
+            ordDocument.eventResources.forEach((eventResource) => {
+                eventResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "sap:cmp-mtls:v1" }]));
+                    expect(resDef.accessStrategies.some((s) => s.type === "sap:cmp-mtls:v1")).toBe(true);
+                });
+            });
+
+            // Verify no resource has 'open' accessStrategy
+            [...ordDocument.apiResources, ...ordDocument.eventResources].forEach((resource) => {
+                resource.resourceDefinitions.forEach((resDef) => {
+                    const hasOpen = resDef.accessStrategies.some((s) => s.type === "open");
+                    expect(hasOpen).toBe(false);
+                });
+            });
+        });
+    });
+
+    describe("ORD Document Structure with mTLS and system-instance perspective", () => {
+        let ordDocument;
+
+        beforeAll(async () => {
+            const mtlsHeaders = createMtlsHeaders(
+                MOCK_CERT_CONFIG_RESPONSE.certIssuer,
+                MOCK_CERT_CONFIG_RESPONSE.certSubject,
+                MOCK_ROOT_CA_DN,
+            );
+
+            const response = await request(BASE_URL)
+                .get("/ord/v1/documents/ord-document?perspective=system-instance")
+                .set(mtlsHeaders)
+                .set("Local-Tenant-Id", "12-34-56")
+                .expect(200);
+
+            ordDocument = utils.pinLastUpdateForStableTest(response.body);
+        });
+
+        test("should have required ORD structure", () => {
+            expect(ordDocument).toHaveProperty("openResourceDiscovery", "1.14");
+            expect(ordDocument).toHaveProperty("description");
+            expect(Array.isArray(ordDocument.apiResources)).toBe(true);
+            expect(Array.isArray(ordDocument.eventResources)).toBe(true);
+            expect(ordDocument.perspective).toBe("system-instance");
+            expect(ordDocument.describedSystemVersion).toEqual(undefined);
+        });
+
+        test("should include TestService with correct properties", () => {
+            const testService = ordDocument.apiResources.find(
+                (api) => api.title === "Test Service for Integration Testing",
+            );
+
+            expect(testService).toMatchSnapshot();
+        });
+
+        test("should contain expected resources", () => {
+            expect(ordDocument.apiResources).toHaveLength(2);
+            expect(ordDocument.eventResources).toHaveLength(1);
+            expect(ordDocument.packages).toHaveLength(1);
+        });
+
+        test("should have correct query params for all resource definitions", () => {
+            ordDocument.apiResources.forEach((apiResource) => {
+                apiResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.url).toMatch(/(.*)\?perspective=system-instance$/);
+                });
+            });
+
+            ordDocument.eventResources.forEach((eventResource) => {
+                eventResource.resourceDefinitions.forEach((resDef) => {
+                    expect(resDef.url).toMatch(/(.*)\?perspective=system-instance$/);
+                });
+            });
         });
 
         test("should have 'sap:cmp-mtls:v1' accessStrategies in all resources", () => {
@@ -587,7 +701,8 @@ describe("ORD Integration Tests - mTLS Development Mode (cfMtls object with conf
             const response = await request(BASE_URL).get(ORD_DOCUMENT_ENDPOINT).set(mtlsHeaders).expect(200);
 
             // Success means fetchMtlsCertInfo worked correctly
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
+            expect(response.headers["content-type"]).toMatch(/application\/json/);
+            expect(utils.pinLastUpdateForStableTest(response.body)).toMatchSnapshot();
         });
 
         test("should reject requests with cert info not matching fetched config", async () => {
@@ -624,13 +739,14 @@ describe("ORD Integration Tests - mTLS Development Mode (cfMtls object with conf
             const response = await request(BASE_URL).get(ORD_DOCUMENT_ENDPOINT).set(mtlsHeaders).expect(200);
 
             expect(response.headers["content-type"]).toMatch(/application\/json/);
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
+            expect(utils.pinLastUpdateForStableTest(response.body)).toMatchSnapshot();
         });
 
         test("should return ORD config without authentication (endpoint is always open)", async () => {
             const response = await request(BASE_URL).get(ORD_CONFIG_ENDPOINT).expect(200);
 
-            expect(response.body).toHaveProperty("openResourceDiscoveryV1");
+            expect(response.headers["content-type"]).toMatch(/application\/json/);
+            expect(response.body).toMatchSnapshot();
         });
 
         test("should accept mTLS headers with DN components in different order", async () => {

--- a/__tests__/unit/__snapshots__/defaults.test.js.snap
+++ b/__tests__/unit/__snapshots__/defaults.test.js.snap
@@ -2,7 +2,193 @@
 
 exports[`defaults $schema should return default value 1`] = `"https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json"`;
 
-exports[`defaults baseTemplate should return default value 1`] = `
+exports[`defaults adjustForPerspective should return correct value when system-instance-perspective is given 1`] = `
+{
+  "apiResources": [
+    {
+      "resourceDefinitions": [
+        {
+          "url": "dummy/dummy.oas3.json?perspective=system-instance",
+        },
+      ],
+    },
+  ],
+  "eventResources": [
+    {
+      "resourceDefinitions": [
+        {
+          "url": "dummy/dummy.asyncapi2.json?perspective=system-instance",
+        },
+      ],
+    },
+  ],
+  "perspective": "system-instance",
+}
+`;
+
+exports[`defaults adjustForPerspective should return correct value when system-instance-version is given 1`] = `
+{
+  "apiResources": [
+    {
+      "resourceDefinitions": [
+        {
+          "url": "dummy/dummy.oas3.json",
+        },
+      ],
+    },
+  ],
+  "describedSystemVersion": {
+    "version": "1.0",
+  },
+  "eventResources": [
+    {
+      "resourceDefinitions": [
+        {
+          "url": "dummy/dummy.asyncapi2.json",
+        },
+      ],
+    },
+  ],
+  "perspective": "system-version",
+}
+`;
+
+exports[`defaults baseTemplate should return correct value when no tenant is given and toggles & extensions are disabled 1`] = `
+{
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
+      },
+    ],
+  },
+}
+`;
+
+exports[`defaults baseTemplate should return correct value when no tenant is given and toggles & extensions are enabled 1`] = `
+{
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
+      },
+    ],
+  },
+}
+`;
+
+exports[`defaults baseTemplate should return correct value when tenant is given and extensions are enabled 1`] = `
+{
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "perspective": "system-instance",
+        "url": "/ord/v1/documents/ord-document?perspective=system-instance",
+      },
+    ],
+  },
+}
+`;
+
+exports[`defaults baseTemplate should return correct value when tenant is given and only toggles are enabled 1`] = `
+{
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "perspective": "system-instance",
+        "url": "/ord/v1/documents/ord-document?perspective=system-instance",
+      },
+    ],
+  },
+}
+`;
+
+exports[`defaults baseTemplate should return correct value when tenant is given and toggles & extensions are enabled 1`] = `
+{
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "perspective": "system-instance",
+        "url": "/ord/v1/documents/ord-document?perspective=system-instance",
+      },
+    ],
+  },
+}
+`;
+
+exports[`defaults baseTemplate should return correct value when tenant is not given and only extensions are enabled 1`] = `
+{
+  "openResourceDiscoveryV1": {
+    "documents": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "perspective": "system-version",
+        "url": "/ord/v1/documents/ord-document",
+      },
+    ],
+  },
+}
+`;
+
+exports[`defaults baseTemplate should return correct value when tenant is not given and only toggles are enabled 1`] = `
 {
   "openResourceDiscoveryV1": {
     "documents": [

--- a/__tests__/unit/build.test.js
+++ b/__tests__/unit/build.test.js
@@ -266,10 +266,16 @@ describe("Build", () => {
         expect(updatedOrdDocument.perspective).toBe(DOCUMENT_PERSPECTIVES.SystemVersion);
         expect(updatedOrdDocument.describedSystemVersion).toEqual({ version: "0.0.1" });
         expect(updatedOrdDocument.apiResources[0].resourceDefinitions[0].url).toBe(
-            path.join("customer.sample_apiResource_ProcessorService_v1", "ProcessorService.oas3.json"),
+            path.join(
+                "customer.sample_apiResource_ProcessorService_v1",
+                "ProcessorService.oas3.json",
+            ),
         );
         expect(updatedOrdDocument.eventResources[0].resourceDefinitions[0].url).toBe(
-            path.join("customer.sample_eventResource_ProcessorService_v1", "ProcessorService.asyncapi2.json"),
+            path.join(
+                "customer.sample_eventResource_ProcessorService_v1",
+                "ProcessorService.asyncapi2.json",
+            ),
         );
     });
 });

--- a/__tests__/unit/defaults.test.js
+++ b/__tests__/unit/defaults.test.js
@@ -169,37 +169,134 @@ describe("defaults", () => {
     });
 
     describe("baseTemplate", () => {
-        it("should return default value", () => {
+        it("should return correct value when no tenant is given and toggles & extensions are disabled", () => {
+            cds.env.requires.toggles = false;
+            cds.env.requires.extensibility = false;
             const authConfig = {
                 types: [AUTHENTICATION_TYPE.Open],
                 accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
             };
-            expect(defaults.baseTemplate(authConfig)).toMatchSnapshot();
+            expect(defaults.baseTemplate(authConfig, undefined)).toMatchSnapshot();
+        });
+
+        it("should return correct value when tenant is not given and only toggles are enabled", () => {
+            cds.env.requires.toggles = true;
+            cds.env.requires.extensibility = false;
+            const authConfig = {
+                types: [AUTHENTICATION_TYPE.Open],
+                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+            };
+            expect(defaults.baseTemplate(authConfig, undefined)).toMatchSnapshot();
+        });
+
+        it("should return correct value when tenant is not given and only extensions are enabled", () => {
+            cds.env.requires.toggles = false;
+            cds.env.requires.extensibility = true;
+            const authConfig = {
+                types: [AUTHENTICATION_TYPE.Open],
+                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+            };
+            expect(defaults.baseTemplate(authConfig, undefined)).toMatchSnapshot();
+        });
+
+        it("should return correct value when no tenant is given and toggles & extensions are enabled", () => {
+            cds.env.requires.toggles = true;
+            cds.env.requires.extensibility = true;
+            const authConfig = {
+                types: [AUTHENTICATION_TYPE.Open],
+                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+            };
+            expect(defaults.baseTemplate(authConfig, undefined)).toMatchSnapshot();
+        });
+
+        it("should return correct value when tenant is given and only toggles are enabled", () => {
+            cds.env.requires.toggles = true;
+            cds.env.requires.extensibility = false;
+            const authConfig = {
+                types: [AUTHENTICATION_TYPE.Open],
+                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+            };
+            expect(defaults.baseTemplate(authConfig, "dummy-tenant")).toMatchSnapshot();
+        });
+
+        it("should return correct value when tenant is given and extensions are enabled", () => {
+            cds.env.requires.toggles = false;
+            cds.env.requires.extensibility = true;
+            const authConfig = {
+                types: [AUTHENTICATION_TYPE.Open],
+                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+            };
+            expect(defaults.baseTemplate(authConfig, "dummy-tenant")).toMatchSnapshot();
+        });
+
+        it("should return correct value when tenant is given and toggles & extensions are enabled", () => {
+            cds.env.requires.toggles = true;
+            cds.env.requires.extensibility = true;
+            const authConfig = {
+                types: [AUTHENTICATION_TYPE.Open],
+                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+            };
+            expect(defaults.baseTemplate(authConfig, "dummy-tenant")).toMatchSnapshot();
         });
     });
 
-    describe("resolveDocumentPerspectiveExtension", () => {
-        it("should return correct value when loading version from .cdsrc.json", () => {
-            cds.env.ord = { describedSystemVersion: { version: "0.1.0" } };
-
-            expect(defaults.resolveDocumentPerspectiveExtension()).toEqual({
-                perspective: DOCUMENT_PERSPECTIVES.SystemVersion,
-                describedSystemVersion: {
-                    version: "0.1.0",
-                },
-            });
+    describe("adjustForPerspective", () => {
+        it("should return correct value when system-instance-perspective is given", () => {
+            expect(
+                defaults.adjustForPerspective(
+                    {
+                        apiResources: [
+                            {
+                                resourceDefinitions: [
+                                    {
+                                        url: "dummy/dummy.oas3.json",
+                                    },
+                                ],
+                            },
+                        ],
+                        eventResources: [
+                            {
+                                resourceDefinitions: [
+                                    {
+                                        url: "dummy/dummy.asyncapi2.json",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    DOCUMENT_PERSPECTIVES.SystemInstance,
+                ),
+            ).toMatchSnapshot();
         });
 
-        it("should return correct value when loading version from package.json", () => {
-            cds.env.ord = undefined;
-            cds.root = ".";
+        it("should return correct value when system-instance-version is given", () => {
+            cds.env.ord = { describedSystemVersion: { version: "1.0" } };
 
-            expect(defaults.resolveDocumentPerspectiveExtension()).toEqual({
-                perspective: DOCUMENT_PERSPECTIVES.SystemVersion,
-                describedSystemVersion: {
-                    version: "1.0.0",
-                },
-            });
+            expect(
+                defaults.adjustForPerspective(
+                    {
+                        apiResources: [
+                            {
+                                resourceDefinitions: [
+                                    {
+                                        url: "dummy/dummy.oas3.json",
+                                    },
+                                ],
+                            },
+                        ],
+                        eventResources: [
+                            {
+                                resourceDefinitions: [
+                                    {
+                                        url: "dummy/dummy.asyncapi2.json",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    DOCUMENT_PERSPECTIVES.SystemVersion,
+                ),
+            ).toMatchSnapshot();
         });
     });
 });

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,0 +1,13 @@
+module.exports = {
+    pinLastUpdateForStableTest: (ord, lastUpdate = "2026-05-04T13:45:01+01:00") => {
+        [
+            ...(ord.apiResources || []), //
+            ...(ord.eventResources || []), //
+            ...(ord.consumptionBundles || []), //
+        ].forEach((element) => {
+            element.lastUpdate = lastUpdate;
+        });
+
+        return ord;
+    },
+};

--- a/lib/build.js
+++ b/lib/build.js
@@ -8,7 +8,7 @@ const cliProgress = require("cli-progress");
 const defaults = require("./defaults.js");
 const { ord } = require("./index");
 const registerCompileTargets = require("./common/register-compile-targets");
-const { BUILD_DEFAULT_PATH, ORD_DOCUMENT_FILE_NAME  } = require("./constants");
+const { BUILD_DEFAULT_PATH, ORD_DOCUMENT_FILE_NAME, DOCUMENT_PERSPECTIVES } = require("./constants");
 
 module.exports = class OrdBuildPlugin extends cds.build.Plugin {
     static taskDefaults = { src: cds.env.folders.srv };
@@ -47,10 +47,6 @@ module.exports = class OrdBuildPlugin extends cds.build.Plugin {
 
     _postProcess(document) {
         const clone = _.cloneDeep(document);
-        const extension = defaults.resolveDocumentPerspectiveExtension();
-
-        clone.perspective = extension.perspective;
-        clone.describedSystemVersion = extension.describedSystemVersion;
 
         [...(clone.apiResources || []), ...(clone.eventResources || [])]
             .flatMap((resource) => resource.resourceDefinitions || [])
@@ -58,7 +54,7 @@ module.exports = class OrdBuildPlugin extends cds.build.Plugin {
                 resourceDefinition.url = this._createRelativePath(resourceDefinition.url);
             });
 
-        return clone;
+        return defaults.adjustForPerspective(clone, DOCUMENT_PERSPECTIVES.SystemVersion);
     }
 
     _createRelativePath(url) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -179,6 +179,8 @@ const DOCUMENT_PERSPECTIVES = Object.freeze({
     SystemInstance: "system-instance",
 });
 
+const LOCAL_TENANT_ID_HEADER_KEY = "local-tenant-id";
+
 module.exports = {
     AUTHENTICATION_TYPE,
     AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP,
@@ -220,4 +222,5 @@ module.exports = {
     HTTP_CONFIG,
     AUTH_STRINGS,
     DOCUMENT_PERSPECTIVES,
+    LOCAL_TENANT_ID_HEADER_KEY,
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,14 +1,13 @@
 const fs = require("fs");
-const { join } = require("path");
 const _ = require("lodash");
 const cds = require("@sap/cds");
+const { join } = require("path");
 
 const {
     SHORT_DESCRIPTION_PREFIX,
     RESOURCE_VISIBILITY,
     DOCUMENT_PERSPECTIVES,
 } = require("./constants");
-
 
 const packageTypes = [
     { tag: "-api", type: "APIs" },
@@ -142,10 +141,13 @@ module.exports = {
                 "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
         },
     ],
-    baseTemplate: (authConfig) => {
+    baseTemplate: (authConfig, tenant) => {
         // Get access strategies from the provided authConfig
         // If auth config is not available, fall back to empty array
+        const toggles = cds.env.requires.toggles;
+        const extensibility = cds.env.requires.extensibility;
         const accessStrategies = authConfig?.accessStrategies || [];
+
         return {
             openResourceDiscoveryV1: {
                 documents: [
@@ -154,16 +156,40 @@ module.exports = {
                         perspective: DOCUMENT_PERSPECTIVES.SystemVersion,
                         accessStrategies,
                     },
+                    ...(!tenant || !(toggles || extensibility)
+                        ? []
+                        : [
+                              {
+                                  url: `/ord/v1/documents/ord-document?perspective=${encodeURIComponent(DOCUMENT_PERSPECTIVES.SystemInstance)}`,
+                                  perspective: DOCUMENT_PERSPECTIVES.SystemInstance,
+                                  accessStrategies,
+                              },
+                          ]),
                 ],
             },
         };
     },
-    resolveDocumentPerspectiveExtension: () => {
-        return {
-            perspective: DOCUMENT_PERSPECTIVES.SystemVersion,
-            describedSystemVersion: cds.env["ord"]?.describedSystemVersion ?? {
+    adjustForPerspective: (document, perspective) => {
+        document.perspective = perspective;
+
+        if (perspective === DOCUMENT_PERSPECTIVES.SystemVersion) {
+            document.describedSystemVersion = cds.env["ord"]?.describedSystemVersion ?? {
                 version: JSON.parse(fs.readFileSync(join(cds.root, "package.json"), "utf-8")).version,
-            },
-        };
+            };
+        } else if (perspective === DOCUMENT_PERSPECTIVES.SystemInstance) {
+            (document.apiResources || []).forEach((apiResource) => {
+                (apiResource.resourceDefinitions || []).forEach((apiResourceDefinition) => {
+                    apiResourceDefinition.url += `?perspective=${encodeURIComponent(perspective)}`;
+                });
+            });
+
+            (document.eventResources || []).forEach((eventResource) => {
+                (eventResource.resourceDefinitions || []).forEach((eventResourceDefinition) => {
+                    eventResourceDefinition.url += `?perspective=${encodeURIComponent(perspective)}`;
+                });
+            });
+        }
+
+        return document;
     },
 };

--- a/lib/services/mtx-ord-provider-service.js
+++ b/lib/services/mtx-ord-provider-service.js
@@ -1,19 +1,24 @@
 const cds = require("@sap/cds/lib");
 const { ord, getMetadata } = require("@cap-js/ord/lib");
 
+const defaults = require("../defaults");
+const { DOCUMENT_PERSPECTIVES } = require("../constants");
+
 module.exports = class MtxOrdProviderService extends cds.ApplicationService {
     init() {
         this.on("getOrdDocument", async (req) => {
             req._?.res?.set("Content-Type", "application/json");
 
-            return ord(
-                await (
-                    await cds.connect.to("cds.xt.ModelProviderService")
-                ).getCsn({
-                    for: req.data.for,
-                    tenant: req.data.tenant,
-                    toggles: req.data.toggles,
-                }),
+            return defaults.adjustForPerspective(
+                ord(
+                    await (
+                        await cds.connect.to("cds.xt.ModelProviderService")
+                    ).getCsn({
+                        tenant: req.data.tenant,
+                        toggles: req.data.toggles,
+                    }),
+                ),
+                DOCUMENT_PERSPECTIVES.SystemInstance,
             );
         });
 
@@ -23,7 +28,6 @@ module.exports = class MtxOrdProviderService extends cds.ApplicationService {
                 await (
                     await cds.connect.to("cds.xt.ModelProviderService")
                 ).getCsn({
-                    for: req.data.for,
                     tenant: req.data.tenant,
                     toggles: req.data.toggles,
                 }),

--- a/lib/services/ord-service.js
+++ b/lib/services/ord-service.js
@@ -3,8 +3,60 @@ const cds = require("@sap/cds");
 const ord = require("../ord.js");
 const Logger = require("../logger.js");
 const defaults = require("../defaults.js");
+const { LOCAL_TENANT_ID_HEADER_KEY, DOCUMENT_PERSPECTIVES } = require("../constants");
 const compileMetadata = require("../meta-data.js");
 const { createAuthConfig, createAuthMiddleware } = require("../auth/authentication.js");
+
+const validationMiddleware = (req, res, next) => {
+    const toggles = cds.env.requires.toggles;
+    const perspective = req.query.perspective;
+    const extensibility = cds.env.requires.extensibility;
+    const tenant = req.headers[LOCAL_TENANT_ID_HEADER_KEY];
+
+    if (perspective && ![DOCUMENT_PERSPECTIVES.SystemVersion, DOCUMENT_PERSPECTIVES.SystemInstance].includes(perspective)) {
+        return res.status(400).send(`Required query parameter 'perspective' is invalid`);
+    }
+
+    if (perspective === DOCUMENT_PERSPECTIVES.SystemInstance && !(toggles || extensibility)) {
+        return res.status(400).send(`Unsupported query parameter 'perspective=${perspective}'`);
+    }
+
+    if (!tenant && perspective === DOCUMENT_PERSPECTIVES.SystemInstance) {
+        return res.status(400).send(`Missing required tenant context`);
+    }
+
+    return next();
+};
+
+const metadataResponseHandler = async (req, res) => {
+    try {
+        const perspective = req.query.perspective;
+        const tenant = req.headers[LOCAL_TENANT_ID_HEADER_KEY];
+        const model = await resolveCdsModel(perspective, tenant);
+        const { contentType, response } = await compileMetadata(req.path, model);
+
+        return res.status(200).contentType(contentType).send(response);
+    } catch (error) {
+        Logger.error(error, "Error while processing the resource definition document");
+        return res.status(500).send(error.message);
+    }
+};
+
+const resolveCdsModel = async (perspective, tenant) => {
+    if (!tenant || perspective !== DOCUMENT_PERSPECTIVES.SystemInstance) {
+        Logger.info("Retrieving static CDS model...");
+        return cds.model;
+    }
+
+    Logger.info(`Retrieving dynamic CDS model for tenant ${tenant}...`);
+
+    return await (
+        await cds.connect.to("cds.xt.ModelProviderService")
+    ).getCsn({
+        tenant: tenant,
+        toggles: OpenResourceDiscoveryService.resolveFeatureToggles(tenant),
+    });
+};
 
 class OpenResourceDiscoveryService extends cds.ApplicationService {
     async init() {
@@ -26,38 +78,37 @@ class OpenResourceDiscoveryService extends cds.ApplicationService {
         // Create authentication middleware
         const authMiddleware = createAuthMiddleware(authConfig);
 
-        cds.app.get(`${this.path}`, (_, res) => {
-            return res.status(200).send(defaults.baseTemplate(authConfig));
+        // Default: /.well-known/open-resource-discovery
+        cds.app.get(`${this.path}`, (req, res) => {
+            const tenant = req.headers[LOCAL_TENANT_ID_HEADER_KEY];
+
+            return res.status(200).send(defaults.baseTemplate(authConfig, tenant));
         });
 
-        cds.app.get(`/ord/v1/documents/ord-document`, authMiddleware, async (_, res) => {
-            const csn = cds.context?.model || cds.model;
-            const document = ord(csn, Array.from(Object.values(this.extensions)));
+        cds.app.get(`/ord/v1/documents/ord-document`, [authMiddleware, validationMiddleware], async (req, res) => {
+            const perspective = req.query.perspective || DOCUMENT_PERSPECTIVES.SystemVersion;
+            const tenant = req.headers[LOCAL_TENANT_ID_HEADER_KEY];
+            const model = await resolveCdsModel(perspective, tenant);
+            const extensions = Array.from(Object.values(this.extensions));
 
-            return res.status(200).send(Object.assign(document, defaults.resolveDocumentPerspectiveExtension()));
+            return res.status(200).send(defaults.adjustForPerspective(ord(model, extensions), perspective));
         });
 
-        cds.app.get(`/ord/v1/documents/:id`, authMiddleware, async (_, res) => {
+        cds.app.get(`/ord/v1/documents/:id`, [authMiddleware, validationMiddleware], async (_, res) => {
             return res.status(404).send("404 Not Found");
         });
 
-        // Handler for metadata requests (oas3, edmx, csn, etc.)
-        const metadataHandler = async (req, res) => {
-            try {
-                const { contentType, response } = await compileMetadata(req.url);
-                return res.status(200).contentType(contentType).send(response);
-            } catch (error) {
-                Logger.error(error, "Error while processing the resource definition document");
-                return res.status(500).send(error.message);
-            }
-        };
-
         // Use separate routes instead of optional parameters for path-to-regexp v8 compatibility
-        cds.app.get(`/ord/v1/:ordId/:service`, authMiddleware, metadataHandler);
-        cds.app.get(`/ord/v1/:ordId`, authMiddleware, metadataHandler);
-        cds.app.get(`/ord/v1`, authMiddleware, metadataHandler);
+        cds.app.get(`/ord/v1/:ordId/:service`, [authMiddleware, validationMiddleware], metadataResponseHandler);
+        cds.app.get(`/ord/v1/:ordId`, [authMiddleware, validationMiddleware], metadataResponseHandler);
+        cds.app.get(`/ord/v1`, [authMiddleware, validationMiddleware], metadataResponseHandler);
 
         return super.init();
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    static resolveFeatureToggles(tenant) {
+        return ["*"];
     }
 }
 


### PR DESCRIPTION
# Correctly Handle Static / Tenant-Specific Metadata for ORD Documents

### New Feature

✨ Introduced tenant-aware model resolution and perspective-based routing for ORD document and metadata endpoints. The service now correctly differentiates between `system-version` (static) and `system-instance` (tenant-specific) perspectives, fetching tenant-specific CDS models via `cds.xt.ModelProviderService` when configured, or falling back to the static global model.

### Changes

* `lib/constants.js`: Added `LOCAL_TENANT_ID_HEADER_KEY` constant (`"local-tenant-id"`) for reading tenant from request headers.

* `lib/defaults.js`: Refactored `baseTemplate` to accept a `tenant` parameter and conditionally include a `system-instance` document link when tenant and toggles/extensibility are configured. Replaced `resolveDocumentPerspectiveExtension` with a new `adjustForPerspective(document, perspective)` method that sets perspective, `describedSystemVersion` (for `system-version`), and appends `?perspective=...` query params to resource definition URLs (for `system-instance`).

* `lib/services/ord-service.js`: Added `validationMiddleware` to validate the `perspective` query param and enforce tenant context for `system-instance` requests. Added `resolveCdsModel(perspective, tenant)` helper to fetch tenant-specific CSN or fall back to `cds.model`. Updated ORD config and document handlers to use tenant/perspective-aware logic. Refactored inline metadata handler into `metadataResponseHandler`. Added `static resolveFeatureToggles(tenant)` method.

* `lib/build.js`: Updated `_postProcess` to use `defaults.adjustForPerspective` with `system-version` perspective, including `perspective` and `describedSystemVersion` fields.

* `lib/ord.js`: Minor cleanup — uses `defaults.$schema` instead of a hardcoded schema string.

* `lib/services/mtx-ord-provider-service.js`: Removed `for` parameter from `getCsn` calls; now wraps result with `defaults.adjustForPerspective` for `system-instance` perspective.

* `__tests__/integration/basic-auth.test.js` & `mtls-auth.test.js`: Expanded integration tests to cover both `system-version` and `system-instance` perspectives, with snapshot-based assertions, query parameter validation, and access strategy verification.

* `__tests__/integration/cds-build.test.js`: Fixed file path resolution using `URL.parse` to handle query params in resource definition URLs.

* `__tests__/integration/integration-test-app/.cdsrc.basic.json` & `.cdsrc.mtls.json`: Added `requires.toggles: true` and `describedSystemVersion` settings.

* `__tests__/integration/integration-test-app/package.json`: Bumped version to `0.1.0` and added `@sap/cds-mtxs` dependency.

* New snapshot files added for `basic-auth` and `mtls-auth` integration test suites; unit test snapshots updated to reflect new `baseTemplate` and `adjustForPerspective` behavior.

### Jira Issues

* ODMPLANNING-1151

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.37`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `383eb9f5-a1c7-4fe1-a9fb-f73a252d0c49`
</details>
