### PR TITLE
fix: resolve AbortController no-redeclare lint error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,25 +1,33 @@
 import cds from "@sap/cds/eslint.config.mjs";
 
 export default [
-  ...cds.recommended,
-  {
-    // Allow console statements in test files and add jest globals
-    files: ['__tests__/**/*.js', '__tests__/**/*.mjs', '**/*.test.js', '**/*.spec.js'],
-    languageOptions: {
-      globals: {
-        jest: 'readonly',
-        describe: 'readonly',
-        it: 'readonly',
-        expect: 'readonly',
-        beforeAll: 'readonly',
-        afterAll: 'readonly',
-        beforeEach: 'readonly',
-        afterEach: 'readonly',
-        test: 'readonly'
-      }
+    ...cds.recommended,
+    {
+        languageOptions: {
+            globals: {
+                AbortController: "readonly",
+                AbortSignal: "readonly",
+            },
+        },
     },
-    rules: {
-      'no-console': 'off'
-    }
-  }
+    {
+        // Allow console statements in test files and add jest globals
+        files: ["__tests__/**/*.js", "__tests__/**/*.mjs", "**/*.test.js", "**/*.spec.js"],
+        languageOptions: {
+            globals: {
+                jest: "readonly",
+                describe: "readonly",
+                it: "readonly",
+                expect: "readonly",
+                beforeAll: "readonly",
+                afterAll: "readonly",
+                beforeEach: "readonly",
+                afterEach: "readonly",
+                test: "readonly",
+            },
+        },
+        rules: {
+            "no-console": "off",
+        },
+    },
 ];

--- a/lib/auth/mtls-endpoint-service.js
+++ b/lib/auth/mtls-endpoint-service.js
@@ -5,8 +5,6 @@
  * from external configuration endpoints and merge with static configuration.
  */
 
-/* global AbortController */ // eslint-disable-line no-redeclare
-
 const { HTTP_CONFIG } = require("../constants");
 
 /**


### PR DESCRIPTION
## Summary

- Remove obsolete `/* global AbortController */` directive from `lib/auth/mtls-endpoint-service.js` that now conflicts with `@sap/cds@9.9.0`'s eslint config
- Add `AbortController` and `AbortSignal` to project eslint globals for compatibility across `@sap/cds` versions

This fixes the lint failures on PRs #408, #409, and #411.