### PR TITLE
chore: Exclude deprecated property 'entityTypeMappings' from ORD document generation

### DIFF
--- a/__tests__/__mocks__/internalResourcesCsn.json
+++ b/__tests__/__mocks__/internalResourcesCsn.json
@@ -8,7 +8,7 @@
             "@ORD.Extensions.visibility": "internal",
             "@ORD.Extensions.version": "2.0.0",
             "@ORD.Extensions.extensible.supported": "yes",
-            "@ORD.Extensions.entityTypeMappings.entityTypeTargets": [
+            "@ORD.Extensions.exposedEntityTypes": [
                 {
                     "ordId": "sap.odm:entityType:test-from-extension:v1"
                 }

--- a/__tests__/__mocks__/privateResourcesCsn.json
+++ b/__tests__/__mocks__/privateResourcesCsn.json
@@ -8,7 +8,7 @@
             "@ORD.Extensions.visibility": "private",
             "@ORD.Extensions.version": "2.0.0",
             "@ORD.Extensions.extensible.supported": "yes",
-            "@ORD.Extensions.entityTypeMappings.entityTypeTargets": [
+            "@ORD.Extensions.exposedEntityTypes": [
                 {
                     "ordId": "sap.odm:entityType:test-from-extension:v1"
                 }

--- a/__tests__/__mocks__/publicResourcesCsn.json
+++ b/__tests__/__mocks__/publicResourcesCsn.json
@@ -8,7 +8,7 @@
             "@ORD.Extensions.visibility": "public",
             "@ORD.Extensions.version": "2.0.0",
             "@ORD.Extensions.extensible.supported": "yes",
-            "@ORD.Extensions.entityTypeMappings.entityTypeTargets": [
+            "@ORD.Extensions.exposedEntityTypes": [
                 {
                     "ordId": "sap.odm:entityType:test-from-extension:v1"
                 }

--- a/__tests__/bookshop/ord/custom.ord.json
+++ b/__tests__/bookshop/ord/custom.ord.json
@@ -21,13 +21,9 @@
         {
             "partOfGroups": null,
             "ordId": "sap.test.cdsrc.sample:apiResource:AdminService:v1",
-            "entityTypeMappings": [
+            "exposedEntityTypes": [
                 {
-                    "entityTypeTargets": [
-                        {
-                            "ordId": "sap.odm:entityType:BusinessPartner:v1"
-                        }
-                    ]
+                    "ordId": "sap.odm:entityType:BusinessPartner:v1"
                 }
             ],
             "extensible": {

--- a/__tests__/bookshop/srv/admin-service.cds
+++ b/__tests__/bookshop/srv/admin-service.cds
@@ -28,5 +28,5 @@ annotate AdminService with @ORD.Extensions: {
     visibility        : 'public',
     version           : '2.0.0',
     extensible        : {supported: 'yes'},
-    entityTypeMappings: {entityTypeTargets: [{ordId: 'sap.odm:entityType:test-from-extension:v1'}]},
+    exposedEntityTypes: [{ordId: 'sap.odm:entityType:test-from-extension:v1'}],
 };

--- a/__tests__/unit/__snapshots__/extend-ord-with-custom.test.js.snap
+++ b/__tests__/unit/__snapshots__/extend-ord-with-custom.test.js.snap
@@ -61,17 +61,13 @@ exports[`extendOrdWithCustom extend-ord-with-custom should should patch the exis
 {
   "apiResources": [
     {
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [
-            {
-              "ordId": "sap.odm:entityType:BusinessPartner:v1",
-            },
-          ],
-        },
-      ],
       "entryPoints": [
         "/odata/v4/admin",
+      ],
+      "exposedEntityTypes": [
+        {
+          "ordId": "sap.odm:entityType:BusinessPartner:v1",
+        },
       ],
       "ordId": "sap.sm:apiResource:SupplierService:v1",
       "partOfGroups": [
@@ -80,11 +76,7 @@ exports[`extendOrdWithCustom extend-ord-with-custom should should patch the exis
       "partOfPackage": "sap.sm:package:smDataProducts:v1",
     },
     {
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [],
-        },
-      ],
+      "exposedEntityTypes": [],
       "ordId": "sap.sm:apiResource:orginalService:v2",
       "partOfGroups": [
         "sap.cds:service:sap.test.cdsrc.sample:originalService",

--- a/__tests__/unit/__snapshots__/mocked-csn.test.js.snap
+++ b/__tests__/unit/__snapshots__/mocked-csn.test.js.snap
@@ -7,19 +7,12 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
     {
       "apiProtocol": "odata-v4",
       "description": "Description for AdminService",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "entryPoints": [
         "/odata/v4/admin",
       ],
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {
@@ -160,16 +153,9 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
   "eventResources": [
     {
       "description": "CAP Event resource describing events / messages.",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {
@@ -303,7 +289,7 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
 }
 `;
 
-exports[`Tests for ORD document generated out of mocked csn files Tests for ORD document when there no events or entities in service definitions Successfully create ORD Document: no entityTypeMappings field in apiResource 1`] = `
+exports[`Tests for ORD document generated out of mocked csn files Tests for ORD document when there no events or entities in service definitions Successfully create ORD Document: no exposedEntityTypes field in apiResource 1`] = `
 {
   "$schema": "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
   "apiResources": [

--- a/__tests__/unit/__snapshots__/ord.e2e.test.js.snap
+++ b/__tests__/unit/__snapshots__/ord.e2e.test.js.snap
@@ -7,24 +7,12 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
     {
       "apiProtocol": "odata-v4",
       "description": "Description for AdminService",
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [
-            {
-              "ordId": "sap.odm:entityType:BusinessPartner:v1",
-            },
-          ],
-        },
-      ],
       "entryPoints": [
         "/odata/v4/admin",
       ],
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:BusinessPartner:v1",
         },
       ],
       "extensible": {
@@ -108,18 +96,6 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [
-            {
-              "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-            },
-            {
-              "ordId": "customer.foo:entityType:Authors:v1",
-            },
-          ],
-        },
-      ],
       "entryPoints": [],
       "exposedEntityTypes": [
         {
@@ -197,19 +173,9 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
   "eventResources": [
     {
       "description": "CAP Event resource describing events / messages.",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {
@@ -353,24 +319,12 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
     {
       "apiProtocol": "odata-v4",
       "description": "Description for AdminService",
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [
-            {
-              "ordId": "sap.odm:entityType:BusinessPartner:v1",
-            },
-          ],
-        },
-      ],
       "entryPoints": [
         "/odata/v4/admin",
       ],
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:BusinessPartner:v1",
         },
       ],
       "extensible": {
@@ -454,18 +408,6 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [
-            {
-              "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-            },
-            {
-              "ordId": "customer.foo:entityType:Authors:v1",
-            },
-          ],
-        },
-      ],
       "entryPoints": [],
       "exposedEntityTypes": [
         {
@@ -543,19 +485,9 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
   "eventResources": [
     {
       "description": "CAP Event resource describing events / messages.",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {
@@ -699,24 +631,12 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
     {
       "apiProtocol": "odata-v4",
       "description": "Description for AdminService",
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [
-            {
-              "ordId": "sap.odm:entityType:BusinessPartner:v1",
-            },
-          ],
-        },
-      ],
       "entryPoints": [
         "/odata/v4/admin",
       ],
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:BusinessPartner:v1",
         },
       ],
       "extensible": {
@@ -800,18 +720,6 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [
-            {
-              "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-            },
-            {
-              "ordId": "customer.foo:entityType:Authors:v1",
-            },
-          ],
-        },
-      ],
       "entryPoints": [],
       "exposedEntityTypes": [
         {
@@ -889,19 +797,9 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
   "eventResources": [
     {
       "description": "CAP Event resource describing events / messages.",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {
@@ -2896,22 +2794,12 @@ exports[`Tests for products and packages should not contain products property if
     {
       "apiProtocol": "odata-v4",
       "description": "Description for AdminService",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "entryPoints": [
         "/odata/v4/admin",
       ],
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {
@@ -2998,18 +2886,6 @@ exports[`Tests for products and packages should not contain products property if
       "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [
-            {
-              "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-            },
-            {
-              "ordId": "customer.foo:entityType:Authors:v1",
-            },
-          ],
-        },
-      ],
       "entryPoints": [],
       "exposedEntityTypes": [
         {
@@ -3079,19 +2955,9 @@ exports[`Tests for products and packages should not contain products property if
   "eventResources": [
     {
       "description": "CAP Event resource describing events / messages.",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {
@@ -3195,22 +3061,12 @@ exports[`Tests for products and packages should raise error log when custom prod
     {
       "apiProtocol": "odata-v4",
       "description": "Description for AdminService",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "entryPoints": [
         "/odata/v4/admin",
       ],
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {
@@ -3297,18 +3153,6 @@ exports[`Tests for products and packages should raise error log when custom prod
       "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [
-            {
-              "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-            },
-            {
-              "ordId": "customer.foo:entityType:Authors:v1",
-            },
-          ],
-        },
-      ],
       "entryPoints": [],
       "exposedEntityTypes": [
         {
@@ -3378,19 +3222,9 @@ exports[`Tests for products and packages should raise error log when custom prod
   "eventResources": [
     {
       "description": "CAP Event resource describing events / messages.",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {
@@ -3502,22 +3336,12 @@ exports[`Tests for products and packages should use valid custom products ordId 
     {
       "apiProtocol": "odata-v4",
       "description": "Description for AdminService",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "entryPoints": [
         "/odata/v4/admin",
       ],
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {
@@ -3604,18 +3428,6 @@ exports[`Tests for products and packages should use valid custom products ordId 
       "apiProtocol": "sap.dp:data-subscription-api:v1",
       "description": "Description for sap.capdpprod.DPBooks.v1",
       "direction": "outbound",
-      "entityTypeMappings": [
-        {
-          "entityTypeTargets": [
-            {
-              "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-            },
-            {
-              "ordId": "customer.foo:entityType:Authors:v1",
-            },
-          ],
-        },
-      ],
       "entryPoints": [],
       "exposedEntityTypes": [
         {
@@ -3685,19 +3497,9 @@ exports[`Tests for products and packages should use valid custom products ordId 
   "eventResources": [
     {
       "description": "CAP Event resource describing events / messages.",
-      "entityTypeMappings": {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:test-from-extension:v1",
-          },
-        ],
-      },
       "exposedEntityTypes": [
         {
-          "ordId": "sap.odm:entityType:odm.bookshop.Authors:v1",
-        },
-        {
-          "ordId": "customer.foo:entityType:Authors:v1",
+          "ordId": "sap.odm:entityType:test-from-extension:v1",
         },
       ],
       "extensible": {

--- a/__tests__/unit/__snapshots__/templates.test.js.snap
+++ b/__tests__/unit/__snapshots__/templates.test.js.snap
@@ -154,21 +154,6 @@ exports[`templates createEventResourceTemplate should create event resource temp
 ]
 `;
 
-exports[`templates getEntityTypeMappings should clean up duplicates 1`] = `
-[
-  {
-    "entityTypeTargets": [
-      {
-        "ordId": "sap.odm:entityType:Something:v1",
-      },
-      {
-        "ordId": "sap.sm:entityType:Else:v2",
-      },
-    ],
-  },
-]
-`;
-
 exports[`templates getExposedEntityTypes should clean up duplicates 1`] = `
 [
   {
@@ -185,15 +170,6 @@ exports[`templates ordExtension should add apiResources with ORD Extension "visi
   {
     "apiProtocol": "odata-v4",
     "description": "Description for MyService",
-    "entityTypeMappings": [
-      {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:testOdmEntity:v1",
-          },
-        ],
-      },
-    ],
     "entryPoints": [
       "/odata/v4/my",
     ],
@@ -281,18 +257,6 @@ exports[`templates ordExtension should find association on nested entities for r
   {
     "apiProtocol": "odata-v4",
     "description": "Description for MyService",
-    "entityTypeMappings": [
-      {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:DirectAssociationOdmEntity:v1",
-          },
-          {
-            "ordId": "sap.odm:entityType:NestedAssociationOdmEntity:v1",
-          },
-        ],
-      },
-    ],
     "entryPoints": [
       "/odata/v4/my",
     ],
@@ -349,18 +313,6 @@ exports[`templates ordExtension should find composition and association entities
   {
     "apiProtocol": "odata-v4",
     "description": "Description for MyService",
-    "entityTypeMappings": [
-      {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:CompositionOdmEntity:v1",
-          },
-          {
-            "ordId": "sap.odm:entityType:AssociationOdmEntity:v1",
-          },
-        ],
-      },
-    ],
     "entryPoints": [
       "/odata/v4/my",
     ],
@@ -417,18 +369,6 @@ exports[`templates ordExtension should find composition on nested entities for r
   {
     "apiProtocol": "odata-v4",
     "description": "Description for MyService",
-    "entityTypeMappings": [
-      {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:DirectCompositionOdmEntity:v1",
-          },
-          {
-            "ordId": "sap.odm:entityType:NestedCompositionOdmEntity:v1",
-          },
-        ],
-      },
-    ],
     "entryPoints": [
       "/odata/v4/my",
     ],
@@ -485,18 +425,6 @@ exports[`templates ordExtension should find ordId on circular relations 1`] = `
   {
     "apiProtocol": "odata-v4",
     "description": "Description for MyService",
-    "entityTypeMappings": [
-      {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:DirectCompositionOdmEntity:v1",
-          },
-          {
-            "ordId": "sap.odm:entityType:NestedCompositionOdmEntity:v1",
-          },
-        ],
-      },
-    ],
     "entryPoints": [
       "/odata/v4/my",
     ],
@@ -553,15 +481,6 @@ exports[`templates ordExtension should include internal API resources but ensure
   {
     "apiProtocol": "odata-v4",
     "description": "Description for MyService",
-    "entityTypeMappings": [
-      {
-        "entityTypeTargets": [
-          {
-            "ordId": "sap.odm:entityType:testOdmEntity:v1",
-          },
-        ],
-      },
-    ],
     "entryPoints": [
       "/odata/v4/my",
     ],

--- a/__tests__/unit/extend-ord-with-custom.test.js
+++ b/__tests__/unit/extend-ord-with-custom.test.js
@@ -105,16 +105,12 @@ describe("extendOrdWithCustom", () => {
                             extensible: {
                                 supported: "no",
                             },
-                            entityTypeMappings: [
+                            exposedEntityTypes: [
                                 {
-                                    entityTypeTargets: [
-                                        {
-                                            ordId: "sap.odm:entityType:BusinessPartner:v2",
-                                        },
-                                        {
-                                            ordId: "sap.odm:entityType:BusinessPartner:v3",
-                                        },
-                                    ],
+                                    ordId: "sap.odm:entityType:BusinessPartner:v2",
+                                },
+                                {
+                                    ordId: "sap.odm:entityType:BusinessPartner:v3",
                                 },
                             ],
                         },
@@ -122,11 +118,7 @@ describe("extendOrdWithCustom", () => {
                             ordId: "sap.sm:apiResource:orginalService:v2",
                             partOfGroups: ["sap.cds:service:sap.test.cdsrc.sample:originalService"],
                             partOfPackage: "sap.sm:package:smDataProducts:v2",
-                            entityTypeMappings: [
-                                {
-                                    entityTypeTargets: [],
-                                },
-                            ],
+                            exposedEntityTypes: [],
                         },
                     ],
                 },

--- a/__tests__/unit/mocked-csn.test.js
+++ b/__tests__/unit/mocked-csn.test.js
@@ -41,7 +41,7 @@ describe("Tests for ORD document generated out of mocked csn files", () => {
     });
 
     describe("Tests for ORD document when there no events or entities in service definitions", () => {
-        test("Successfully create ORD Document: no entityTypeMappings field in apiResource", () => {
+        test("Successfully create ORD Document: no exposedEntityTypes field in apiResource", () => {
             cds.env = {};
             const csn = require("../__mocks__/noEntitiesInServiceDefinitionCsn.json");
             const document = ord(csn);
@@ -53,8 +53,8 @@ describe("Tests for ORD document generated out of mocked csn files", () => {
         });
     });
 
-    describe("Tests for ORD document checking if entityTypes and entityTypeMappings are generated correctly", () => {
-        test("Successfully create ORD Document: entityTypes with local entities and entityTypeMappings containing referenced entities", () => {
+    describe("Tests for ORD document checking if entityTypes and exposedEntityTypes are generated correctly", () => {
+        test("Successfully create ORD Document: entityTypes with local entities and exposedEntityTypes containing referenced entities", () => {
             cds.env.ord.policyLevels = ["none"];
             const csn = require("../__mocks__/localAndNonODMReferencedEntitiesCsn.json");
             const document = ord(csn);
@@ -65,7 +65,7 @@ describe("Tests for ORD document generated out of mocked csn files", () => {
             );
             expect(document.entityTypes[0].ordId).toEqual("sap.sm:entityType:SomeAribaDummyEntity:v1");
             expect(document.entityTypes[0].level).toEqual(expect.stringContaining("root-entity"));
-            expect(document.apiResources[0].entityTypeMappings[0].entityTypeTargets).toEqual(
+            expect(document.apiResources[0].exposedEntityTypes).toEqual(
                 expect.arrayContaining([
                     { ordId: "sap.odm:entityType:SomeODMEntity:v1" },
                     { ordId: "sap.sm:entityType:SomeAribaDummyEntity:v1" },

--- a/__tests__/unit/ord-visibility-split.test.js
+++ b/__tests__/unit/ord-visibility-split.test.js
@@ -31,7 +31,7 @@ describe("templates", () => {
                     {
                         ordId: "sap.sm:apiResource:SomeAPI:v1",
                         visibility: "private",
-                        entityTypeMappings: [{ entityTypeTargets: [{ ordId: entity.ordId }] }],
+                        exposedEntityTypes: [{ ordId: entity.ordId }],
                     },
                 ],
             };
@@ -55,7 +55,7 @@ describe("templates", () => {
                     {
                         ordId: "sap.sm:apiResource:SomeAPI:v1",
                         visibility: "public",
-                        entityTypeMappings: [{ entityTypeTargets: [{ ordId: entity.ordId }] }],
+                        exposedEntityTypes: [{ ordId: entity.ordId }],
                     },
                 ],
             };

--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -12,7 +12,6 @@ const {
     createGroupsTemplateForService,
     createAPIResourceTemplate,
     createEventResourceTemplate,
-    _getEntityTypeMappings,
     _getExposedEntityTypes,
     _propagateORDVisibility,
     _handleVisibility,
@@ -248,35 +247,6 @@ describe("templates", () => {
             const local = mappings.find((m) => !m.isODMMapping);
             expect(odm && odm.ordId).toBe("sap.odm:entityType:DualEntity:v1");
             expect(local && local.ordId).toBe("customer.dual:entityType:DualEntity:v1");
-        });
-
-        it("_getEntityTypeMappings collects both; only local becomes entityType", () => {
-            const model = cds.linked(`
-                    namespace customer.dualmapping;
-                    @ODM.entityName: 'DualAuthors'
-                    @EntityRelationship.entityType: 'customer.dualmapping:DualAuthors'
-                    entity DualAuthors { key ID: UUID; title: String; }
-                    service DualService { entity Authors as projection on DualAuthors; }
-                `);
-            const serviceDef = model.definitions["customer.dualmapping.DualService"];
-            const mappingsWrapper = _getEntityTypeMappings(serviceDef);
-            const targets = mappingsWrapper[0].entityTypeTargets.map((t) => t.ordId);
-            expect(targets).toEqual(
-                expect.arrayContaining([
-                    "sap.odm:entityType:DualAuthors:v1",
-                    "customer.dualmapping:entityType:DualAuthors:v1",
-                ]),
-            );
-
-            const mappingItems = createEntityTypeMappingsItemTemplate(
-                model.definitions["customer.dualmapping.DualAuthors"],
-            );
-            const arr = Array.isArray(mappingItems) ? mappingItems : [mappingItems];
-            const entityTypes = arr
-                .flatMap((e) => createEntityTypeTemplate(appConfig, ["customer.dualmapping:package:dual:v1"], e))
-                .filter(Boolean);
-            expect(entityTypes).toHaveLength(1);
-            expect(entityTypes[0].ordId).toBe("customer.dualmapping:entityType:DualAuthors:v1");
         });
     });
 
@@ -877,18 +847,6 @@ describe("templates", () => {
             const apiResourceTemplate = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
 
             expect(apiResourceTemplate).toMatchSnapshot();
-        });
-    });
-
-    describe("getEntityTypeMappings", () => {
-        it("should clean up duplicates", () => {
-            const serviceDefinition = {
-                entities: [{}, {}, {}],
-            };
-            serviceDefinition.entities[0][ORD_ODM_ENTITY_NAME_ANNOTATION] = "Something";
-            serviceDefinition.entities[1][ENTITY_RELATIONSHIP_ANNOTATION] = "sap.sm:Else:v2";
-            serviceDefinition.entities[2][ENTITY_RELATIONSHIP_ANNOTATION] = "sap.odm:Something";
-            expect(_getEntityTypeMappings(serviceDefinition)).toMatchSnapshot();
         });
     });
 

--- a/__tests__/unit/utils/testCustomORDContentFileWithPatch.json
+++ b/__tests__/unit/utils/testCustomORDContentFileWithPatch.json
@@ -18,13 +18,9 @@
             "partOfPackage": "sap.sm:package:smDataProducts:v1",
             "entryPoints": ["/odata/v4/admin"],
             "extensible": null,
-            "entityTypeMappings": [
+            "exposedEntityTypes": [
                 {
-                    "entityTypeTargets": [
-                        {
-                            "ordId": "sap.odm:entityType:BusinessPartner:v1"
-                        }
-                    ]
+                    "ordId": "sap.odm:entityType:BusinessPartner:v1"
                 }
             ]
         }

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -372,7 +372,6 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
             }
         }
 
-        const entityTypeMappings = _getEntityTypeMappings(serviceDefinition);
         const exposedEntityTypes = _getExposedEntityTypes(serviceDefinition);
 
         let obj = {
@@ -392,7 +391,6 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
             extensible: {
                 supported: "no",
             },
-            ...(entityTypeMappings ? { entityTypeMappings } : {}),
             ...(exposedEntityTypes ? { exposedEntityTypes } : []),
             ...ordExtensions,
         };
@@ -432,7 +430,6 @@ const createEventResourceTemplate = (serviceName, serviceDefinition, appConfig, 
     const visibility = _handleVisibility(ordExtensions, serviceDefinition, appConfig.env?.defaultVisibility);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.event, visibility);
     const ordId = `${appConfig.ordNamespace}:eventResource:${_getGroupNameWithNestedNamespace(serviceDefinition, appConfig)}:v1`;
-    const entityTypeMappings = _getEntityTypeMappings(serviceDefinition);
     const exposedEntityTypes = _getExposedEntityTypes(serviceDefinition);
 
     let obj = {
@@ -456,7 +453,6 @@ const createEventResourceTemplate = (serviceName, serviceDefinition, appConfig, 
             _getResourceDefinition("asyncapi-v2", "json", ordId, serviceName, "asyncapi2.json", accessStrategies),
         ],
         extensible: { supported: "no" },
-        ...(entityTypeMappings ? { entityTypeMappings } : {}),
         ...(exposedEntityTypes ? { exposedEntityTypes } : []),
         ...ordExtensions,
     };
@@ -471,28 +467,6 @@ function isPrimaryDataProductService(serviceDefinition) {
         serviceDefinition[DATA_PRODUCT_ANNOTATION] === DATA_PRODUCT_TYPE.primary ||
         !!serviceDefinition[DATA_PRODUCT_SIMPLE_ANNOTATION]
     );
-}
-
-function _getEntityTypeMappings(definitionObj) {
-    if (!definitionObj.entities) {
-        return;
-    }
-    const entities = Object.values(definitionObj.entities).flatMap((entity) => {
-        const entityData = _flattenEntityGraph(entity)
-            .flatMap(createEntityTypeMappingsItemTemplate) // now returns arrays
-            .filter(Boolean);
-        return _.uniqBy(entityData, CONTENT_MERGE_KEY);
-    });
-    const entityTypeTargets = _.uniqBy(entities, CONTENT_MERGE_KEY)
-        .filter((entity) => entity !== undefined)
-        .map(({ ordId }) => ({
-            ordId,
-        }));
-    if (entityTypeTargets.length > 0) {
-        return [{ entityTypeTargets }];
-    } else {
-        return;
-    }
 }
 
 function _getExposedEntityTypes(definitionObj) {
@@ -614,7 +588,6 @@ module.exports = {
     createEventResourceTemplate,
     readORDExtensions,
     _getPackageID,
-    _getEntityTypeMappings,
     _getExposedEntityTypes,
     _propagateORDVisibility,
     _handleVisibility,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "test:integration:mtls": "jest __tests__/integration/mtls-auth.test.js --testPathIgnorePatterns=/node_modules/ --forceExit",
         "test:integration:build": "jest __tests__/integration/cds-build.test.js --testPathIgnorePatterns=/node_modules/ --forceExit",
         "update-snapshot": "jest --ci --updateSnapshot",
-        "cds:version": "cds v -i"
+        "cds:version": "cds v -i",
+        "test:all": "npm run test && npm run test:integration:basic && npm run test:integration:mtls && npm run test:integration:build"
     },
     "devDependencies": {
         "@cap-js/graphql": "^0.14.0",

--- a/xmpl/ord/custom.ord.json
+++ b/xmpl/ord/custom.ord.json
@@ -56,13 +56,9 @@
                 }
             ],
             "ordId": "customer.sample:apiResource:manualImplementedService:v1",
-            "entityTypeMappings": [
+            "exposedEntityTypes": [
                 {
-                    "entityTypeTargets": [
-                        {
-                            "ordId": "sap.odm:entityType:BusinessPartner:v1"
-                        }
-                    ]
+                    "ordId": "sap.odm:entityType:BusinessPartner:v1"
                 }
             ],
             "extensible": {


### PR DESCRIPTION
# Remove Deprecated `entityTypeMappings` Property from ORD Document Generation

### Chore

♻️ **Refactor**: Replaced the deprecated `entityTypeMappings` property (with nested `entityTypeTargets`) with the flattened `exposedEntityTypes` array throughout the ORD document generation pipeline.

### Changes

The `entityTypeMappings` property, which used a nested structure `[{ entityTypeTargets: [{ ordId: "..." }] }]`, has been fully replaced with the simpler `exposedEntityTypes` format `[{ ordId: "..." }]`.

* `lib/templates.js`: Renamed internal function `_getEntityTypeMappings` to `_getExposedEntityTypes` and updated its logic to return a flat array of `{ ordId }` objects directly, instead of wrapping them in `entityTypeTargets`. Updated `createAPIResourceTemplate` and `createEventResourceTemplate` to use the new property name.
* `__tests__/bookshop/srv/admin-service.cds`: Updated `@ORD.Extensions` annotation to use `exposedEntityTypes` instead of `entityTypeMappings.entityTypeTargets`.
* `__tests__/bookshop/ord/custom.ord.json`: Updated custom ORD JSON fixture to use the new flat `exposedEntityTypes` structure.
* `xmpl/ord/custom.ord.json`: Updated example ORD document to use `exposedEntityTypes`.
* `__tests__/__mocks__/internalResourcesCsn.json`, `privateResourcesCsn.json`, `publicResourcesCsn.json`: Updated mock CSN annotations to `@ORD.Extensions.exposedEntityTypes`.
* `__tests__/unit/extend-ord-with-custom.test.js`: Updated test data to use the new `exposedEntityTypes` structure.
* `__tests__/unit/mocked-csn.test.js`: Renamed test descriptions and updated assertions to reference `exposedEntityTypes`.
* `__tests__/unit/ord-visibility-split.test.js`: Updated test fixtures to use `exposedEntityTypes`.
* `__tests__/unit/templates.test.js`: Removed `_getEntityTypeMappings` import and deleted the corresponding test suite; updated to use `_getExposedEntityTypes`.
* `__tests__/unit/utils/testCustomORDContentFileWithPatch.json`: Updated fixture to use the new flat structure.
* Multiple `*.snap` files: Regenerated snapshots to reflect the new `exposedEntityTypes` format.
* `package.json`: Added a `test:all` script to conveniently run all unit and integration tests in sequence.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.43`

- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `5696abd5-a07d-4897-836d-b873de3e03b5`
- File Content Strategy: Full file content
</details>
