### PR TITLE
chore: Bump ORD spec version to 1.14

### DIFF
--- a/__tests__/integration/__snapshots__/cds-build.test.js.snap
+++ b/__tests__/integration/__snapshots__/cds-build.test.js.snap
@@ -184,7 +184,7 @@ exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customizat
       "visibility": "internal",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -397,7 +397,7 @@ exports[`ORD Build Integration Tests IntegrationDependency with custom.ord.json 
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -609,7 +609,7 @@ exports[`ORD Build Integration Tests Successful Build should generate ord-docume
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",

--- a/__tests__/integration/basic-auth.test.js
+++ b/__tests__/integration/basic-auth.test.js
@@ -153,7 +153,7 @@ describe("ORD Integration Tests - Basic Authentication", () => {
                 .expect(200);
 
             expect(response.headers["content-type"]).toMatch(/application\/json/);
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.12");
+            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
         });
 
         test("should return ORD document with standard Authorization header", async () => {
@@ -162,7 +162,7 @@ describe("ORD Integration Tests - Basic Authentication", () => {
                 .set("Authorization", VALID_AUTH) // standard case
                 .expect(200);
 
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.12");
+            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
         });
 
         test("should reject invalid password", async () => {
@@ -223,7 +223,7 @@ describe("ORD Integration Tests - Basic Authentication", () => {
         });
 
         test("should have required ORD structure", () => {
-            expect(ordDocument).toHaveProperty("openResourceDiscovery", "1.12");
+            expect(ordDocument).toHaveProperty("openResourceDiscovery", "1.14");
             expect(ordDocument).toHaveProperty("description");
             expect(Array.isArray(ordDocument.apiResources)).toBe(true);
             expect(Array.isArray(ordDocument.eventResources)).toBe(true);

--- a/__tests__/integration/mtls-auth.test.js
+++ b/__tests__/integration/mtls-auth.test.js
@@ -289,7 +289,7 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
 
             const response = await request(BASE_URL).get(ORD_DOCUMENT_ENDPOINT).set(mtlsHeaders).expect(200);
 
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.12");
+            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
         });
     });
 
@@ -305,7 +305,7 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
             const response = await request(BASE_URL).get(ORD_DOCUMENT_ENDPOINT).set(mtlsHeaders).expect(200);
 
             expect(response.headers["content-type"]).toMatch(/application\/json/);
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.12");
+            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
         });
 
         test("should return ORD config without authentication (endpoint is always open)", async () => {
@@ -418,7 +418,7 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
         });
 
         test("should have required ORD structure", () => {
-            expect(ordDocument).toHaveProperty("openResourceDiscovery", "1.12");
+            expect(ordDocument).toHaveProperty("openResourceDiscovery", "1.14");
             expect(ordDocument).toHaveProperty("description");
             expect(Array.isArray(ordDocument.apiResources)).toBe(true);
             expect(Array.isArray(ordDocument.eventResources)).toBe(true);
@@ -587,7 +587,7 @@ describe("ORD Integration Tests - mTLS Development Mode (cfMtls object with conf
             const response = await request(BASE_URL).get(ORD_DOCUMENT_ENDPOINT).set(mtlsHeaders).expect(200);
 
             // Success means fetchMtlsCertInfo worked correctly
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.12");
+            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
         });
 
         test("should reject requests with cert info not matching fetched config", async () => {
@@ -624,7 +624,7 @@ describe("ORD Integration Tests - mTLS Development Mode (cfMtls object with conf
             const response = await request(BASE_URL).get(ORD_DOCUMENT_ENDPOINT).set(mtlsHeaders).expect(200);
 
             expect(response.headers["content-type"]).toMatch(/application\/json/);
-            expect(response.body).toHaveProperty("openResourceDiscovery", "1.12");
+            expect(response.body).toHaveProperty("openResourceDiscovery", "1.14");
         });
 
         test("should return ORD config without authentication (endpoint is always open)", async () => {
@@ -699,7 +699,7 @@ describe("ORD Integration Tests - mTLS Development Mode (cfMtls object with conf
         });
 
         test("should have required ORD structure", () => {
-            expect(ordDocument).toHaveProperty("openResourceDiscovery", "1.12");
+            expect(ordDocument).toHaveProperty("openResourceDiscovery", "1.14");
             expect(ordDocument).toHaveProperty("description");
             expect(Array.isArray(ordDocument.apiResources)).toBe(true);
             expect(Array.isArray(ordDocument.eventResources)).toBe(true);

--- a/__tests__/unit/__snapshots__/defaults.test.js.snap
+++ b/__tests__/unit/__snapshots__/defaults.test.js.snap
@@ -37,7 +37,7 @@ exports[`defaults description should return default value 1`] = `"this is an app
 
 exports[`defaults groupTypeId should return default value 1`] = `"sap.cds:service"`;
 
-exports[`defaults openResourceDiscovery should return default value 1`] = `"1.12"`;
+exports[`defaults openResourceDiscovery should return default value 1`] = `"1.14"`;
 
 exports[`defaults packages should not contain partOfProducts if no productsOrdId found 1`] = `
 [

--- a/__tests__/unit/__snapshots__/mocked-csn.test.js.snap
+++ b/__tests__/unit/__snapshots__/mocked-csn.test.js.snap
@@ -261,7 +261,7 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
       "title": "This is test Cinema Service title",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -386,7 +386,7 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
       "title": "EbMtEmitter Service",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",

--- a/__tests__/unit/__snapshots__/ord.e2e.test.js.snap
+++ b/__tests__/unit/__snapshots__/ord.e2e.test.js.snap
@@ -1002,7 +1002,7 @@ exports[`Tests for Data Product definition Check interop CSN annotation mapping 
       "title": "Test Service",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for cap js ord.",
@@ -2259,7 +2259,7 @@ exports[`Tests for Data Product definition Check interop CSN service name parsin
       "title": "Simple Service",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for cap js ord.",
@@ -2384,7 +2384,7 @@ exports[`Tests for eventResource and apiResource should block MTXServices when m
       "title": "My Service",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -2509,7 +2509,7 @@ exports[`Tests for eventResource and apiResource should block OpenResourceDiscov
       "title": "My Service",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -2634,7 +2634,7 @@ exports[`Tests for eventResource and apiResource should exclude external service
       "title": "My Service",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -2759,7 +2759,7 @@ exports[`Tests for eventResource and apiResource should exclude service when it 
       "title": "My Service",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -3034,7 +3034,7 @@ exports[`Tests for products and packages should not contain products property if
       "title": "v1 Service",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -3301,7 +3301,7 @@ exports[`Tests for products and packages should raise error log when custom prod
       "title": "v1 Service",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -3576,7 +3576,7 @@ exports[`Tests for products and packages should use valid custom products ordId 
       "title": "v1 Service",
     },
   ],
-  "openResourceDiscovery": "1.12",
+  "openResourceDiscovery": "1.14",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -76,7 +76,7 @@ const LEVEL = Object.freeze({
     subEntity: "sub-entity",
 });
 
-const OPEN_RESOURCE_DISCOVERY_VERSION = "1.12";
+const OPEN_RESOURCE_DISCOVERY_VERSION = "1.14";
 
 const OPENAPI_SERVERS_ANNOTATION = "@OpenAPI.servers";
 


### PR DESCRIPTION
# Bump ORD Spec Version from 1.12 to 1.14

### Chore

🔧 Updated the Open Resource Discovery (ORD) specification version from `1.12` to `1.14` across the entire codebase, including the core constant, all test snapshots, and integration/unit tests.

### Changes

* `lib/constants.js`: Updated `OPEN_RESOURCE_DISCOVERY_VERSION` constant from `"1.12"` to `"1.14"`.
* `__tests__/unit/__snapshots__/defaults.test.js.snap`: Updated snapshot expectation for the default `openResourceDiscovery` value.
* `__tests__/unit/__snapshots__/mocked-csn.test.js.snap`: Updated all `openResourceDiscovery` snapshot values.
* `__tests__/unit/__snapshots__/ord.e2e.test.js.snap`: Updated all `openResourceDiscovery` snapshot values across multiple test cases.
* `__tests__/integration/__snapshots__/cds-build.test.js.snap`: Updated all `openResourceDiscovery` snapshot values.
* `__tests__/integration/basic-auth.test.js`: Updated assertions expecting the ORD document to return version `"1.14"`.
* `__tests__/integration/mtls-auth.test.js`: Updated assertions expecting the ORD document to return version `"1.14"` across all mTLS test suites.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.43`

- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `2b2b4458-02e6-4124-bb36-473101b9a6c5`
</details>
