### PR TITLE
feat: Support internalNamespace config for ORD ID generation

### DIFF
--- a/__tests__/unit/namespace.test.js
+++ b/__tests__/unit/namespace.test.js
@@ -82,4 +82,97 @@ describe("namespace local and global", () => {
         expect(createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
         expect(createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
     });
+
+    it("should strip internalNamespace when it differs from ordNamespace", () => {
+        const appConfig = {
+            ordNamespace: "sap.sourcing",
+            internalNamespace: "com.sap.sourcing.api.v1",
+            appName: "testAppName",
+            lastUpdate: "2022-12-19T15:47:04+00:00",
+        };
+        const serviceName = "SourcingService";
+        const model = cds.linked(`
+            namespace com.sap.sourcing.api.v1;
+            service SourcingService {
+                entity Orders { key ID: UUID; }
+            };
+            annotate SourcingService with @ORD.Extensions : { visibility : 'public' };
+        `);
+        const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
+        const srvDefinition = model.definitions["com.sap.sourcing.api.v1.SourcingService"];
+
+        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:SourcingService:v1");
+        expect(apiResult[0].partOfGroups[0]).toBe("sap.cds:service:sap.sourcing:SourcingService");
+
+        const eventResult = createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        expect(eventResult[0].ordId).toBe("sap.sourcing:eventResource:SourcingService:v1");
+    });
+
+    it("should strip internalNamespace and handle leading dot for sub-namespaces", () => {
+        // Same substring(1) / startsWith(".") behavior as ordNamespace stripping
+        const appConfig = {
+            ordNamespace: "sap.sourcing",
+            internalNamespace: "com.sap.sourcing",
+            appName: "testAppName",
+            lastUpdate: "2022-12-19T15:47:04+00:00",
+        };
+        const serviceName = "SourcingService";
+        const model = cds.linked(`
+            namespace com.sap.sourcing.nested;
+            service SourcingService {
+                entity Orders { key ID: UUID; }
+            };
+            annotate SourcingService with @ORD.Extensions : { visibility : 'public' };
+        `);
+        const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
+        const srvDefinition = model.definitions["com.sap.sourcing.nested.SourcingService"];
+
+        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:nested.SourcingService:v1");
+    });
+
+    it("should prefer ordNamespace over internalNamespace when both could match", () => {
+        const appConfig = {
+            ordNamespace: "sap.sourcing",
+            internalNamespace: "sap.sourcing.internal",
+            appName: "testAppName",
+            lastUpdate: "2022-12-19T15:47:04+00:00",
+        };
+        const serviceName = "BillingService";
+        const model = cds.linked(`
+            namespace sap.sourcing.nested;
+            service BillingService {
+                entity Invoices { key ID: UUID; }
+            };
+            annotate BillingService with @ORD.Extensions : { visibility : 'public' };
+        `);
+        const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
+        const srvDefinition = model.definitions["sap.sourcing.nested.BillingService"];
+
+        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:nested.BillingService:v1");
+    });
+
+    it("should not strip when neither ordNamespace nor internalNamespace matches", () => {
+        const appConfig = {
+            ordNamespace: "sap.sourcing",
+            internalNamespace: "com.sap.sourcing.api.v1",
+            appName: "testAppName",
+            lastUpdate: "2022-12-19T15:47:04+00:00",
+        };
+        const serviceName = "MyService";
+        const model = cds.linked(`
+            namespace other.namespace;
+            service MyService {
+                entity Orders { key ID: UUID; }
+            };
+            annotate MyService with @ORD.Extensions : { visibility : 'public' };
+        `);
+        const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
+        const srvDefinition = model.definitions["other.namespace.MyService"];
+
+        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:other.namespace.MyService:v1");
+    });
 });

--- a/__tests__/unit/namespace.test.js
+++ b/__tests__/unit/namespace.test.js
@@ -110,7 +110,6 @@ describe("namespace local and global", () => {
     });
 
     it("should strip internalNamespace and handle leading dot for sub-namespaces", () => {
-        // Same substring(1) / startsWith(".") behavior as ordNamespace stripping
         const appConfig = {
             ordNamespace: "sap.sourcing",
             internalNamespace: "com.sap.sourcing",
@@ -132,7 +131,7 @@ describe("namespace local and global", () => {
         expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:nested.SourcingService:v1");
     });
 
-    it("should prefer ordNamespace over internalNamespace when both could match", () => {
+    it("should prefer internalNamespace over ordNamespace when both could match", () => {
         const appConfig = {
             ordNamespace: "sap.sourcing",
             internalNamespace: "sap.sourcing.internal",
@@ -141,17 +140,60 @@ describe("namespace local and global", () => {
         };
         const serviceName = "BillingService";
         const model = cds.linked(`
-            namespace sap.sourcing.nested;
+            namespace sap.sourcing.internal;
             service BillingService {
                 entity Invoices { key ID: UUID; }
             };
             annotate BillingService with @ORD.Extensions : { visibility : 'public' };
         `);
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
-        const srvDefinition = model.definitions["sap.sourcing.nested.BillingService"];
+        const srvDefinition = model.definitions["sap.sourcing.internal.BillingService"];
 
         const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
-        expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:nested.BillingService:v1");
+        expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:BillingService:v1");
+    });
+
+    it("should not strip a partial ordNamespace match (dot-boundary guard)", () => {
+        const appConfig = {
+            ordNamespace: "sap.sourcing",
+            appName: "testAppName",
+            lastUpdate: "2022-12-19T15:47:04+00:00",
+        };
+        const serviceName = "SomeService";
+        const model = cds.linked(`
+            namespace sap.sourcingExtra;
+            service SomeService {
+                entity Foo { key ID: UUID; }
+            };
+            annotate SomeService with @ORD.Extensions : { visibility : 'public' };
+        `);
+        const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
+        const srvDefinition = model.definitions["sap.sourcingExtra.SomeService"];
+
+        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:sap.sourcingExtra.SomeService:v1");
+    });
+
+    it("should not strip a partial internalNamespace match (dot-boundary guard)", () => {
+        const appConfig = {
+            ordNamespace: "sap.sourcing",
+            internalNamespace: "com.sap.sourcing",
+            appName: "testAppName",
+            lastUpdate: "2022-12-19T15:47:04+00:00",
+        };
+        const serviceName = "SomeService";
+        const model = cds.linked(`
+            namespace com.sap.sourcingExtra;
+            service SomeService {
+                entity Foo { key ID: UUID; }
+            };
+            annotate SomeService with @ORD.Extensions : { visibility : 'public' };
+        `);
+        const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
+        const srvDefinition = model.definitions["com.sap.sourcingExtra.SomeService"];
+
+        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:com.sap.sourcingExtra.SomeService:v1");
     });
 
     it("should not strip when neither ordNamespace nor internalNamespace matches", () => {

--- a/docs/ord.md
+++ b/docs/ord.md
@@ -14,6 +14,8 @@
 5. [Authentication](#authentication)
     - [CF mTLS Authentication](#cf-mtls-authentication)
 6. [Parameters](#parameters)
+    - [defaultVisibility](#defaultvisibility)
+    - [internalNamespace](#internalnamespace)
 7. [ORD Root Properties](#ord-root-property)
 8. [External Data Products](#external-data-products)
 
@@ -371,6 +373,32 @@ If not specified, the plugin uses its built-in default.
 
 ---
 
+### `internalNamespace`
+
+Use `internalNamespace` when your CAP model's internal CDS namespace differs from the configured ORD `namespace`. The plugin strips the `internalNamespace` prefix from fully-qualified service names when building ORD IDs and group IDs, keeping them concise.
+
+**Example:**
+
+```json
+{
+    "ord": {
+        "namespace": "sap.sourcing",
+        "internalNamespace": "com.sap.sourcing.api.v1"
+    }
+}
+```
+
+With this configuration, a service declared in namespace `com.sap.sourcing.api.v1` produces:
+
+|                             | ORD ID                                                                               |
+| --------------------------- | ------------------------------------------------------------------------------------ |
+| Without `internalNamespace` | `sap.sourcing:apiResource:com.sap.sourcing.api.v1.SourcingMasterDataAPIServiceV1:v1` |
+| With `internalNamespace`    | `sap.sourcing:apiResource:SourcingMasterDataAPIServiceV1:v1`                         |
+
+> **Note:** If a service name already starts with the configured `namespace`, that prefix takes priority and `internalNamespace` is not consulted.
+
+---
+
 ## ORD Root Property
 
 More information, see [ORD Document specification](https://pages.github.tools.sap/CentralEngineering/open-resource-discovery-specification/spec-v1/interfaces/document)
@@ -391,9 +419,9 @@ When your application consumes external Data Products, the plugin auto-generates
 
 ```json
 {
-  "dependencies": {
-    "sap-sai-supplier-v1": "<package-source>"
-  }
+    "dependencies": {
+        "sap-sai-supplier-v1": "<package-source>"
+    }
 }
 ```
 
@@ -410,14 +438,15 @@ annotate sap.sai.Supplier.v1 with @ORD.Extensions: {
 
 ## Summary
 
-| Scenario                         | Approach                                                                |
-| -------------------------------- | ----------------------------------------------------------------------- |
-| Global Metadata                  | Define in `.cdsrc.json` under `ord`                                     |
-| Service Metadata                 | Use `@ORD.Extensions` annotations in `.cds` files                       |
-| OpenAPI Servers                  | Use `@OpenAPI.servers` annotation                                       |
-| Custom ORD Content               | Use `customOrdContentFile`                                              |
-| Linking to Existing SAP Products | Use `existingProductORDId`                                              |
-| Defining Custom Products         | Add `products` section manually                                         |
-| Basic Authentication             | Configure `ord.authentication.basic`                                    |
-| CF mTLS Authentication           | Set `ord.authentication.cfMtls: true` + `CF_MTLS_TRUSTED_CERTS` env var |
+| Scenario                         | Approach                                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Global Metadata                  | Define in `.cdsrc.json` under `ord`                                                              |
+| Service Metadata                 | Use `@ORD.Extensions` annotations in `.cds` files                                                |
+| OpenAPI Servers                  | Use `@OpenAPI.servers` annotation                                                                |
+| Custom ORD Content               | Use `customOrdContentFile`                                                                       |
+| Linking to Existing SAP Products | Use `existingProductORDId`                                                                       |
+| Defining Custom Products         | Add `products` section manually                                                                  |
+| Basic Authentication             | Configure `ord.authentication.basic`                                                             |
+| CF mTLS Authentication           | Set `ord.authentication.cfMtls: true` + `CF_MTLS_TRUSTED_CERTS` env var                          |
+| CDS/ORD Namespace Mismatch       | Set `internalNamespace` to strip the CDS namespace prefix from ORD IDs                           |
 | External Data Products           | Services with `@cds.external`, `@data.product`, `@cds.dp.ordId` generate IntegrationDependencies |

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -15,6 +15,7 @@ module.exports = class Configuration {
         const packageName = this._loadNameFromPackageJson();
         const eventApplicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
         const ordNamespace = cds.env["ord"]?.namespace || `customer.${packageName.replace(/[^a-zA-Z0-9]/g, "")}`;
+        const internalNamespace = env?.internalNamespace;
 
         if (eventApplicationNamespace && ordNamespace !== eventApplicationNamespace) {
             Logger.warn("ORD and AsyncAPI namespaces should be the same.");
@@ -23,6 +24,7 @@ module.exports = class Configuration {
         this._env = env;
         this._packageName = packageName;
         this._ordNamespace = ordNamespace;
+        this._internalNamespace = internalNamespace;
         this._lastUpdate = getRFC3339Date();
         this._serviceNames = this._resolveServiceNames(csn);
         this._existingProductORDId = env?.existingProductORDId;
@@ -55,6 +57,10 @@ module.exports = class Configuration {
 
     get ordNamespace() {
         return this._ordNamespace;
+    }
+
+    get internalNamespace() {
+        return this._internalNamespace;
     }
 
     get policyLevels() {

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -78,22 +78,23 @@ function _getGroupID(serviceDefinition, groupTypeId = defaults.groupTypeId, appC
     return `${groupTypeId}:${appConfig.ordNamespace}:${_getCleanServiceName(serviceDefinition, appConfig)}`;
 }
 
+function _startsWithNamespace(name, namespace) {
+    if (!name.startsWith(namespace)) return false;
+    const rest = name.substring(namespace.length);
+    return rest === "" || rest.startsWith(".");
+}
+
 function _getCleanServiceName({ name }, appConfig) {
-    if (name.startsWith(appConfig.ordNamespace)) {
-        let sortedName = name.substring(appConfig.ordNamespace.length);
-        if (sortedName.startsWith(".")) {
-            sortedName = sortedName.substring(1);
-        }
-        return sortedName;
+    let sortedName = name;
+    if (appConfig.internalNamespace && _startsWithNamespace(name, appConfig.internalNamespace)) {
+        sortedName = name.substring(appConfig.internalNamespace.length);
+    } else if (_startsWithNamespace(name, appConfig.ordNamespace)) {
+        sortedName = name.substring(appConfig.ordNamespace.length);
     }
-    if (appConfig.internalNamespace && name.startsWith(appConfig.internalNamespace)) {
-        let sortedName = name.substring(appConfig.internalNamespace.length);
-        if (sortedName.startsWith(".")) {
-            sortedName = sortedName.substring(1);
-        }
-        return sortedName;
+    if (sortedName.startsWith(".")) {
+        sortedName = sortedName.substring(1);
     }
-    return name;
+    return sortedName;
 }
 
 /**
@@ -311,8 +312,8 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
         extracted = _extractVersionFromServiceName(serviceDefinition.name);
         if (extracted) {
             // Create a temporary service definition with the clean name for namespace processing
-            const cleanServiceDefinition = { ...serviceDefinition, name: extracted.cleanName };
-            cleanServiceName = _getCleanServiceName(cleanServiceDefinition, appConfig);
+            const versionExtractedServiceDefinition = { ...serviceDefinition, name: extracted.cleanName };
+            cleanServiceName = _getCleanServiceName(versionExtractedServiceDefinition, appConfig);
             version = extracted.version;
             semanticVersion = extracted.semanticVersion;
         } else {
@@ -355,7 +356,14 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
                 ];
             } else if (apiProtocol === ORD_API_PROTOCOL.MCP) {
                 resourceDefinitions = [
-                    _getResourceDefinition(MCP_RESOURCE_DEFINITION_TYPE, "json", ordId, serviceName, "mcp.json", accessStrategies),
+                    _getResourceDefinition(
+                        MCP_RESOURCE_DEFINITION_TYPE,
+                        "json",
+                        ordId,
+                        serviceName,
+                        "mcp.json",
+                        accessStrategies,
+                    ),
                 ];
             } else if (apiProtocol === ORD_API_PROTOCOL.GRAPHQL) {
                 // GraphQL only has GraphQL SDL

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -75,18 +75,25 @@ const createEntityTypeMappingsItemTemplate = (entity) => {
 };
 
 function _getGroupID(serviceDefinition, groupTypeId = defaults.groupTypeId, appConfig) {
-    return `${groupTypeId}:${appConfig.ordNamespace}:${_getGroupNameWithNestedNamespace(serviceDefinition, appConfig)}`;
+    return `${groupTypeId}:${appConfig.ordNamespace}:${_getCleanServiceName(serviceDefinition, appConfig)}`;
 }
 
-function _getGroupNameWithNestedNamespace({ name }, appConfig) {
-    if (!name.startsWith(appConfig.ordNamespace)) {
-        return name;
+function _getCleanServiceName({ name }, appConfig) {
+    if (name.startsWith(appConfig.ordNamespace)) {
+        let sortedName = name.substring(appConfig.ordNamespace.length);
+        if (sortedName.startsWith(".")) {
+            sortedName = sortedName.substring(1);
+        }
+        return sortedName;
     }
-    let sortedName = name.substring(appConfig.ordNamespace.length);
-    if (sortedName.startsWith(".")) {
-        sortedName = sortedName.substring(1);
+    if (appConfig.internalNamespace && name.startsWith(appConfig.internalNamespace)) {
+        let sortedName = name.substring(appConfig.internalNamespace.length);
+        if (sortedName.startsWith(".")) {
+            sortedName = sortedName.substring(1);
+        }
+        return sortedName;
     }
-    return sortedName;
+    return name;
 }
 
 /**
@@ -305,18 +312,18 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
         if (extracted) {
             // Create a temporary service definition with the clean name for namespace processing
             const cleanServiceDefinition = { ...serviceDefinition, name: extracted.cleanName };
-            cleanServiceName = _getGroupNameWithNestedNamespace(cleanServiceDefinition, appConfig);
+            cleanServiceName = _getCleanServiceName(cleanServiceDefinition, appConfig);
             version = extracted.version;
             semanticVersion = extracted.semanticVersion;
         } else {
             // Invalid pattern - use current behavior
-            cleanServiceName = _getGroupNameWithNestedNamespace(serviceDefinition, appConfig);
+            cleanServiceName = _getCleanServiceName(serviceDefinition, appConfig);
             version = "v1";
             semanticVersion = "1.0.0";
         }
     } else {
         // Non-data product - use current behavior
-        cleanServiceName = _getGroupNameWithNestedNamespace(serviceDefinition, appConfig);
+        cleanServiceName = _getCleanServiceName(serviceDefinition, appConfig);
         version = "v1";
         semanticVersion = "1.0.0";
     }
@@ -428,7 +435,7 @@ const createEventResourceTemplate = (serviceName, serviceDefinition, appConfig, 
     const ordExtensions = readORDExtensions(serviceDefinition);
     const visibility = _handleVisibility(ordExtensions, serviceDefinition, appConfig.env?.defaultVisibility);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.event, visibility);
-    const ordId = `${appConfig.ordNamespace}:eventResource:${_getGroupNameWithNestedNamespace(serviceDefinition, appConfig)}:v1`;
+    const ordId = `${appConfig.ordNamespace}:eventResource:${_getCleanServiceName(serviceDefinition, appConfig)}:v1`;
     const exposedEntityTypes = _getExposedEntityTypes(serviceDefinition);
 
     let obj = {


### PR DESCRIPTION
When a CAP app's internal CDS namespace differs from its configured ORD namespace, generated ORD IDs previously embedded the full internal namespace prefix. A new optional `cds.env.ord.internalNamespace` setting is now stripped as a fallback when the service name does not start with `ordNamespace`, producing clean IDs like
`sap.sourcing:apiResource:SourcingMasterDataAPIServiceV1:v1` instead of `sap.sourcing:apiResource:com.sap.sourcing.api.v1.SourcingMasterDataAPIServiceV1:v1`.

Also renames `_getGroupNameWithNestedNamespace` → `_getCleanServiceName` for clarity.

Closes #419