### PR TITLE
chore: Fix IDE warnings

### DIFF
--- a/lib/integration-dependency.js
+++ b/lib/integration-dependency.js
@@ -122,6 +122,4 @@ module.exports = {
     // Exported for testing
     collectExternalServices,
     createIntegrationDependency,
-    parseDataProductOrdId,
-    isExternalDataProduct,
 };

--- a/lib/interop-csn.js
+++ b/lib/interop-csn.js
@@ -54,7 +54,7 @@ function add_i18n_texts(csn) {
             if (n.startsWith("@")) {
                 let annoVal = o[n];
                 if (typeof annoVal === "string" && annoVal.startsWith("{i18n>")) {
-                    let [, x] = annoVal.match(/^\{i18n>(.*)\}$/) || [];
+                    let [, x] = annoVal.match(/^\{i18n>(.*)}$/) || [];
                     if (x) keys.add(x);
                 }
             }

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -156,7 +156,7 @@ function _getResourceDefinition(resourceType, mediaType, ordId, serviceName, fil
  *
  * @param {string} serviceName The name of the service.
  * @param {object} serviceDefinition The definition of the service
- * @param {Set} groupIds A set of group ids.
+ * @param {object} appConfig - The application configuration.
  * @returns {Object} A group object.
  */
 const createGroupsTemplateForService = (serviceName, serviceDefinition, appConfig) => {
@@ -481,10 +481,9 @@ function _getExposedEntityTypes(definitionObj) {
         .map(({ ordId }) => ({
             ordId,
         }));
+
     if (exposedEntityTypes.length > 0) {
         return exposedEntityTypes;
-    } else {
-        return;
     }
 }
 


### PR DESCRIPTION
# Chore: Fix IDE Warnings

♻️ **Refactor**: Cleaned up minor IDE warnings across several files by removing unused exports, fixing regex patterns, and simplifying redundant code.

### Changes

* `lib/integration-dependency.js`: Removed unused exports `parseDataProductOrdId` and `isExternalDataProduct` from the `module.exports` block.
* `lib/interop-csn.js`: Fixed a regex pattern by removing an unnecessary escape character — changed `\}` to `}` at the end of the i18n key extraction pattern.
* `lib/templates.js`: 
  - Corrected a JSDoc `@param` tag for `createGroupsTemplateForService` (was incorrectly documenting a `groupIds` param instead of `appConfig`).
  - Removed a redundant `else { return; }` branch in `_getExposedEntityTypes`, simplifying the control flow since the function implicitly returns `undefined` when the condition is not met.
  - Added a blank line for formatting consistency.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.43`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `c68899c3-1801-4117-9c62-2d03c4d8100a`
- Event Trigger: `pull_request.opened`
</details>
