### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.7.0 (2026-05-12)
+
+## What's Changed
+
+- feat: Introduce 'perspective: system-version' for static files by @mlakov in https://github.com/cap-js/ord/pull/412
+- chore(deps): update dependency @sap/cds-compiler to v6.9.1 by @rennovate in https://github.com/cap-js/ord/pull/417
+- chore: Exclude deprecated property 'entityTypeMappings' from ORD document generation by @mlakov in https://github.com/cap-js/ord/pull/418
+- chore: Bump ORD spec version to 1.14 by @mlakov in https://github.com/cap-js/ord/pull/421
+- fix: Do not generate OpenAPI resources for ODataV2 services by @mlakov in https://github.com/cap-js/ord/pull/422
+- chore: Extract app configuration to a dedicated class by @mlakov in https://github.com/cap-js/ord/pull/423
+- chore: Fix IDE warnings by @mlakov in https://github.com/cap-js/ord/pull/425
+- feat: ODMPLANNING-1151 - Correctly handle static / tenant-specific metadata by @mlakov in https://github.com/cap-js/ord/pull/413
+- chore(deps): update dependency @sap/cds-compiler to v6.9.2 by @rennovate in https://github.com/cap-js/ord/pull/427
+- feat: Support internalNamespace config for ORD ID generation by @swennemers in https://github.com/cap-js/ord/pull/424
+- chore: Simplify generation of ORD documents by @mlakov in https://github.com/cap-js/ord/pull/429
+- fix: Only register well-known compile targets by @mlakov in https://github.com/cap-js/ord/pull/428
+
+**Full Changelog**: https://github.com/cap-js/ord/compare/v1.6.0...v1.7.0
+
+
 ## 1.6.0 (2026-04-30)
 
 ## What's Changed


### PR DESCRIPTION
# Release v1.7.0

### Chore

🚀 Release of version **1.7.0** of the `cap-js/ord` package, bundling multiple new features, bug fixes, and chores since v1.6.0.

### Changes

* `CHANGELOG.md`: Added the v1.7.0 changelog entry documenting all changes included in this release.

### What's Included in v1.7.0

**New Features:**
- Introduced `perspective: system-version` for static files ([#412](https://github.com/cap-js/ord/pull/412))
- Correctly handle static / tenant-specific metadata (ODMPLANNING-1151) ([#413](https://github.com/cap-js/ord/pull/413))
- Support `internalNamespace` config for ORD ID generation ([#424](https://github.com/cap-js/ord/pull/424))

**Bug Fixes:**
- Do not generate OpenAPI resources for ODataV2 services ([#422](https://github.com/cap-js/ord/pull/422))
- Only register well-known compile targets ([#428](https://github.com/cap-js/ord/pull/428))

**Chores:**
- Exclude deprecated property `entityTypeMappings` from ORD document generation ([#418](https://github.com/cap-js/ord/pull/418))
- Bump ORD spec version to 1.14 ([#421](https://github.com/cap-js/ord/pull/421))
- Extract app configuration to a dedicated class ([#423](https://github.com/cap-js/ord/pull/423))
- Simplify generation of ORD documents ([#429](https://github.com/cap-js/ord/pull/429))
- Fix IDE warnings ([#425](https://github.com/cap-js/ord/pull/425))
- Dependency updates: `@sap/cds-compiler` bumped to v6.9.1 and v6.9.2

**Full Changelog**: https://github.com/cap-js/ord/compare/v1.6.0...v1.7.0

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `d447154c-d395-45aa-a5f5-a2f685f92344`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
