### PR TITLE
chore: Remove generation of default consumption bundle

### DIFF
--- a/__tests__/integration/__snapshots__/basic-auth.test.js.snap
+++ b/__tests__/integration/__snapshots__/basic-auth.test.js.snap
@@ -127,16 +127,6 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
       "visibility": "public",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "describedSystemVersion": {
     "version": "0.1.0",
   },
@@ -337,16 +327,6 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
       "title": "SupplierService",
       "version": "1.0.0",
       "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "describedSystemVersion": {
@@ -551,16 +531,6 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
       "visibility": "public",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "description": "this is an application description",
   "eventResources": [
     {
@@ -758,16 +728,6 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
       "title": "SupplierService",
       "version": "1.0.0",
       "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "describedSystemVersion": {

--- a/__tests__/integration/__snapshots__/cds-build.test.js.snap
+++ b/__tests__/integration/__snapshots__/cds-build.test.js.snap
@@ -91,16 +91,6 @@ exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customizat
       "visibility": "public",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "describedSystemVersion": {
     "version": "1.0.0",
   },
@@ -304,16 +294,6 @@ exports[`ORD Build Integration Tests IntegrationDependency with custom.ord.json 
       "visibility": "public",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "describedSystemVersion": {
     "version": "0.1.0",
   },
@@ -515,16 +495,6 @@ exports[`ORD Build Integration Tests Successful Build should generate ord-docume
       "title": "SupplierService",
       "version": "1.0.0",
       "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "describedSystemVersion": {

--- a/__tests__/integration/__snapshots__/mtls-auth.test.js.snap
+++ b/__tests__/integration/__snapshots__/mtls-auth.test.js.snap
@@ -91,16 +91,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
       "visibility": "public",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "describedSystemVersion": {
     "version": "0.0.1",
   },
@@ -301,16 +291,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
       "title": "SupplierService",
       "version": "1.0.0",
       "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "describedSystemVersion": {
@@ -625,16 +605,6 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) Production 
       "visibility": "public",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "describedSystemVersion": {
     "version": "0.0.1",
   },
@@ -835,16 +805,6 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
       "title": "SupplierService",
       "version": "1.0.0",
       "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2026-05-04T13:45:01+01:00",
-      "ordId": "capireordintegrationtest:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "describedSystemVersion": {

--- a/__tests__/unit/__snapshots__/defaults.test.js.snap
+++ b/__tests__/unit/__snapshots__/defaults.test.js.snap
@@ -206,19 +206,6 @@ exports[`defaults baseTemplate should return correct value when tenant is not gi
 }
 `;
 
-exports[`defaults consumptionBundles should return default value 1`] = `
-[
-  {
-    "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-    "lastUpdate": "2024-06-20T14:04:01+01:00",
-    "ordId": "sapxref:consumptionBundle:noAuth:v1",
-    "shortDescription": "If we have another protected API then it will be another object",
-    "title": "Unprotected resources",
-    "version": "1.0.0",
-  },
-]
-`;
-
 exports[`defaults description should return default value 1`] = `"this is an application description"`;
 
 exports[`defaults groupTypeId should return default value 1`] = `"sap.cds:service"`;

--- a/__tests__/unit/__snapshots__/mocked-csn.test.js.snap
+++ b/__tests__/unit/__snapshots__/mocked-csn.test.js.snap
@@ -139,16 +139,6 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
       "visibility": "public",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "description": "this is an application description",
   "eventResources": [
     {
@@ -335,16 +325,6 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
       "title": "EbMtEmitter",
       "version": "1.0.0",
       "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "description": "this is an application description",

--- a/__tests__/unit/__snapshots__/ord.e2e.test.js.snap
+++ b/__tests__/unit/__snapshots__/ord.e2e.test.js.snap
@@ -123,16 +123,6 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "visibility": "internal",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "dataProducts": [
     {
       "category": "business-object",
@@ -423,16 +413,6 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "title": "sap.capdpprod.DPBooks.v1",
       "version": "1.0.0",
       "visibility": "internal",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "dataProducts": [
@@ -727,16 +707,6 @@ exports[`End-to-end test for ORD document Tests for default ORD document when .c
       "visibility": "internal",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "dataProducts": [
     {
       "category": "business-object",
@@ -952,16 +922,6 @@ exports[`Tests for Data Product definition Check interop CSN annotation mapping 
       "title": "Test Service Title",
       "version": "1.0.0",
       "visibility": "public",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capjsord:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "description": "this is an application description",
@@ -2206,16 +2166,6 @@ exports[`Tests for Data Product definition Check interop CSN service name parsin
       "visibility": "public",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capjsord:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "description": "this is an application description",
   "groups": [
     {
@@ -2303,16 +2253,6 @@ exports[`Tests for eventResource and apiResource should block MTXServices when m
       "title": "cds.xt.MyService",
       "version": "1.0.0",
       "visibility": "internal",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "description": "this is an application description",
@@ -2430,16 +2370,6 @@ exports[`Tests for eventResource and apiResource should block OpenResourceDiscov
       "visibility": "internal",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "description": "this is an application description",
   "eventResources": [
     {
@@ -2555,16 +2485,6 @@ exports[`Tests for eventResource and apiResource should exclude external service
       "visibility": "internal",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "description": "this is an application description",
   "eventResources": [
     {
@@ -2678,16 +2598,6 @@ exports[`Tests for eventResource and apiResource should exclude service when it 
       "title": "MyService",
       "version": "1.0.0",
       "visibility": "internal",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "description": "this is an application description",
@@ -2881,16 +2791,6 @@ exports[`Tests for products and packages should not contain products property if
       "title": "sap.capdpprod.DPBooks.v1",
       "version": "1.0.0",
       "visibility": "internal",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "description": "this is an application description",
@@ -3138,16 +3038,6 @@ exports[`Tests for products and packages should raise error log when custom prod
       "title": "sap.capdpprod.DPBooks.v1",
       "version": "1.0.0",
       "visibility": "internal",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "description": "this is an application description",
@@ -3403,16 +3293,6 @@ exports[`Tests for products and packages should use valid custom products ordId 
       "title": "sap.capdpprod.DPBooks.v1",
       "version": "1.0.0",
       "visibility": "internal",
-    },
-  ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "lastUpdate": "2024-11-04T14:33:25+01:00",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
     },
   ],
   "description": "this is an application description",

--- a/__tests__/unit/__snapshots__/split-up-packages-csn.test.js.snap
+++ b/__tests__/unit/__snapshots__/split-up-packages-csn.test.js.snap
@@ -299,15 +299,6 @@ exports[`ORD Generation for Business Accelerator Hub Tests for ORD document for 
       "visibility": "public",
     },
   ],
-  "consumptionBundles": [
-    {
-      "description": "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-      "ordId": "capirebookshopordsample:consumptionBundle:noAuth:v1",
-      "shortDescription": "If we have another protected API then it will be another object",
-      "title": "Unprotected resources",
-      "version": "1.0.0",
-    },
-  ],
   "description": "Business Accelerator Hub ORD Test",
   "eventResources": [
     {

--- a/__tests__/unit/defaults.test.js
+++ b/__tests__/unit/defaults.test.js
@@ -158,16 +158,6 @@ describe("defaults", () => {
         });
     });
 
-    describe("consumptionBundles", () => {
-        const testAppConfig = {
-            appName: "sap.xref",
-            lastUpdate: "2024-06-20T14:04:01+01:00",
-        };
-        it("should return default value", () => {
-            expect(defaults.consumptionBundles(testAppConfig)).toMatchSnapshot();
-        });
-    });
-
     describe("baseTemplate", () => {
         it("should return correct value when no tenant is given and toggles & extensions are disabled", () => {
             cds.env.requires.toggles = false;

--- a/__tests__/unit/split-up-packages-csn.test.js
+++ b/__tests__/unit/split-up-packages-csn.test.js
@@ -42,7 +42,6 @@ describe("ORD Generation for Business Accelerator Hub", () => {
             expect(document).not.toBeUndefined();
             document.apiResources.forEach((api) => delete api.lastUpdate);
             document.eventResources.forEach((event) => delete event.lastUpdate);
-            document.consumptionBundles.forEach((con) => delete con.lastUpdate);
             expect(document).toMatchSnapshot();
             expect(document.openResourceDiscovery).toBe("1.10");
             expect(document.policyLevels).toEqual(["sap:core:v1"]);

--- a/docs/ord.md
+++ b/docs/ord.md
@@ -18,7 +18,7 @@
     - [internalNamespace](#internalnamespace)
 7. [ORD Root Properties](#ord-root-property)
 8. [External Data Products](#external-data-products)
-
+9. [Consumption Bundles](#consumption-bundles)
 ---
 
 ## Introduction
@@ -431,6 +431,37 @@ When your application consumes external Data Products, the plugin auto-generates
 annotate sap.sai.Supplier.v1 with @ORD.Extensions: {
     title      : 'SAI Supplier API',
     description: 'Integration with SAP Analytics Intelligence Supplier Data Product'
+};
+```
+
+---
+
+## Consumption Bundles
+
+Consumption bundles can be defined via `.cdsrc.json/package.json`(section `ord`, property `consumptionBundles`) and the contents of your `customOrdContentFile`.
+CDS services can be linked to consumption bundles via the `@ORD.Extensions.partOfConsumptionBundles` annotation.
+
+**Example: Configure consumption bundles via `.cdsrc.json`:**
+
+```json
+{
+    "ord": {
+        "consumptionBundles": [
+            {
+                "ordId": "capjsorddemo:consumptionBundle:public:v1",
+                "title": "Public API resources",
+                "version": "1.0.0"
+            }
+        ]
+    }
+}
+```
+
+**Example: Assign service to consumption bundle via `@ORD.Extensions` annotation:**
+
+```cds
+annotate sap.sai.Supplier with @ORD.Extensions: {
+    partOfConsumptionBundles: ['capjsorddemo:consumptionBundle:public:v1']
 };
 ```
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -122,17 +122,6 @@ module.exports = {
             CONTENT_MERGE_KEY,
         );
     },
-    consumptionBundles: (appConfig) => [
-        {
-            ordId: `${regexWithRemoval(appConfig.appName)}:consumptionBundle:noAuth:v1`,
-            version: "1.0.0",
-            lastUpdate: appConfig.lastUpdate,
-            title: "Unprotected resources",
-            shortDescription: "If we have another protected API then it will be another object",
-            description:
-                "This Consumption Bundle contains all resources of the reference app which are unprotected and do not require authentication",
-        },
-    ],
     baseTemplate: (authConfig, tenant) => {
         // Get access strategies from the provided authConfig
         // If auth config is not available, fall back to empty array

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -75,7 +75,6 @@ const _createDefaultORDDocument = (linkedCsn, appConfig, authConfig) => {
         packages: packages,
         description: appConfig.env?.description || defaults.description,
         openResourceDiscovery: appConfig.env?.openResourceDiscovery || defaults.openResourceDiscovery,
-        consumptionBundles: appConfig.env?.consumptionBundles || defaults.consumptionBundles(appConfig),
 
         // Conditionally added top-level properties
         ...(!entityTypes.length ? {} : { entityTypes: entityTypes }),
@@ -84,6 +83,7 @@ const _createDefaultORDDocument = (linkedCsn, appConfig, authConfig) => {
         ...(appConfig.existingProductORDId ? {} : { products: [products[0]] }),
         ...(!appConfig.serviceNames.length ? {} : { groups: _getGroups(linkedCsn, appConfig) }),
         ...(!integrationDependencies.length ? {} : { integrationDependencies: integrationDependencies }),
+        ...(!appConfig.env?.consumptionBundles?.length ? {} : { consumptionBundles: appConfig.env.consumptionBundles }),
     };
 };
 


### PR DESCRIPTION
# Remove Default Consumption Bundle Generation

### Chore

🔧 Removes the automatic generation of a default `consumptionBundles` entry from the ORD document. Previously, a hardcoded "Unprotected resources" consumption bundle was always included in the generated ORD document. This change makes `consumptionBundles` an opt-in field — it is now only included in the output if explicitly provided via the app configuration (`appConfig.env.consumptionBundles`).

### Changes

* `lib/defaults.js`: Removed the `consumptionBundles` default factory function that always generated a static "Unprotected resources" bundle.
* `lib/ord.js`: Changed `consumptionBundles` from an unconditionally included top-level property (falling back to the default) to a conditionally included property that is only added when `appConfig.env.consumptionBundles` is explicitly set and non-empty.
* `__tests__/unit/defaults.test.js`: Removed the unit test for the now-deleted `consumptionBundles` default function.
* `__tests__/unit/split-up-packages-csn.test.js`: Removed the `delete con.lastUpdate` cleanup step that was needed for the default consumption bundle snapshot.
* **Snapshot files** (`basic-auth.test.js.snap`, `cds-build.test.js.snap`, `mtls-auth.test.js.snap`, `defaults.test.js.snap`, `mocked-csn.test.js.snap`, `ord.e2e.test.js.snap`, `split-up-packages-csn.test.js.snap`): Updated all snapshots to remove the previously auto-generated `consumptionBundles` array from expected ORD document outputs.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Correlation ID: `78910b5d-c2d1-4e43-ac48-ea0c77f89aee`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
