### PR TITLE
fix: Improve generation of integration dependency ORD ID when version is overridden via .cdsrc.json/package.json

### DIFF
--- a/__tests__/integration/__snapshots__/cds-build.test.js.snap
+++ b/__tests__/integration/__snapshots__/cds-build.test.js.snap
@@ -176,7 +176,7 @@ exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customizat
       ],
       "description": "Custom description from cdsrc",
       "mandatory": false,
-      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v1",
+      "ordId": "customer.capireordintegrationtest:integrationDependency:externalDependencies:v2",
       "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
       "releaseStatus": "beta",
       "title": "Custom External Dependencies",

--- a/lib/integration-dependency.js
+++ b/lib/integration-dependency.js
@@ -89,11 +89,12 @@ function createIntegrationDependency(externalServices, appConfig, packageIds) {
 
     // Read IntegrationDependency level config from cdsrc
     const integrationDepConfig = appConfig.env?.integrationDependency || {};
+    const version = integrationDepConfig.version || "1.0.0";
 
     return {
-        ordId: `${appConfig.ordNamespace}:${ORD_RESOURCE_TYPE.integrationDependency}:${INTEGRATION_DEPENDENCY_RESOURCE_NAME}:v1`,
+        ordId: `${appConfig.ordNamespace}:${ORD_RESOURCE_TYPE.integrationDependency}:${INTEGRATION_DEPENDENCY_RESOURCE_NAME}:v${version.split(".")[0]}`,
         title: "External Dependencies",
-        version: "1.0.0",
+        version: version,
         releaseStatus: "active",
         visibility: RESOURCE_VISIBILITY.public,
         mandatory: false,


### PR DESCRIPTION
# Fix: Correctly Derive Integration Dependency ORD ID from Overridden Version

### Bug Fix

🐛 Fixed an issue where the ORD ID for an integration dependency always used a hardcoded `v1` suffix, even when the version was overridden via `.cdsrc.json` or `package.json`. The major version in the ORD ID is now dynamically derived from the configured version.

### Changes

* `lib/integration-dependency.js`: Extracted the version from `integrationDepConfig.version` (defaulting to `"1.0.0"`), then used the major version component (`v${version.split(".")[0]}`) to construct the `ordId`. Previously, both the `ordId` suffix and the `version` field were hardcoded to `v1` / `"1.0.0"`, ignoring any user-supplied version override.

* `__tests__/integration/__snapshots__/cds-build.test.js.snap`: Updated the snapshot to reflect the corrected ORD ID (`v2` instead of `v1`) when the version is overridden to `2.0.0` via configuration.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `364cfbd0-0cd6-424c-9069-e6f7882db21d`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
