### PR TITLE
feat: Consider annotation '@EndUserText.label' when resolving ORD entity titles

### DIFF
--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -252,6 +252,18 @@ describe("templates", () => {
 
     describe("createEntityTypeTemplate", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-entityType:v1"];
+
+        it("should return entity type with correct title from annotation '@EndUserText.label'", () => {
+            const entityType = createEntityTypeTemplate(appConfig, packageIds, {
+                "ordId": "sap.sm:entityType:SomeAribaDummyEntity:v3",
+                "entityName": "SomeAribaDummyEntity",
+                "@EndUserText.label": "Title of SomeAribaDummyEntity",
+            });
+
+            expect(entityType).toBeDefined();
+            expect(entityType.title).toEqual("Title of SomeAribaDummyEntity");
+        });
+
         it("should return entity type with incorrect version, title and level:root-entity", () => {
             const entityWithVersion = {
                 "ordId": "sap.sm:entityType:SomeAribaDummyEntity:v3b",
@@ -339,6 +351,19 @@ describe("templates", () => {
     });
 
     describe("createAPIResourceTemplate", () => {
+        it("should return api resource with correct title from annotation '@EndUserText.label'", () => {
+            const model = cds.linked(`service MyService @(EndUserText.label: 'This is MyService title' ) { }`);
+
+            const apiResources = createAPIResourceTemplate("MyService", model.definitions["MyService"], appConfig, [
+                "sap.test.cdsrc.sample:package:test-event:v1",
+                "sap.test.cdsrc.sample:package:test-api:v1",
+            ]);
+
+            expect(apiResources).toBeInstanceOf(Array);
+            expect(apiResources.length).toEqual(1);
+            expect(apiResources[0].title).toEqual("This is MyService title");
+        });
+
         it("should create API resource template correctly", () => {
             const serviceName = "MyService";
             const model = cds.linked(`
@@ -569,6 +594,23 @@ describe("templates", () => {
             expect(apiResourceTemplate).toBeInstanceOf(Array);
             expect(apiResourceTemplate).toMatchSnapshot();
             expect(apiResourceTemplate).toEqual([]);
+        });
+
+        it("should return event resource with correct title from annotation '@EndUserText.label'", () => {
+            const serviceName = "MyService";
+            linkedModel = cds.linked(`
+                @EndUserText.label: 'This is test MyService event title'
+                service MyService { }
+            `);
+            const eventResourceTemplate = createEventResourceTemplate(
+                serviceName,
+                linkedModel.definitions[serviceName],
+                appConfig,
+                ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"],
+            );
+
+            expect(eventResourceTemplate).toBeInstanceOf(Array);
+            expect(eventResourceTemplate[0].title).toEqual("This is test MyService event title");
         });
 
         it('should add events with ORD Extension "visibility=public"', () => {

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -220,7 +220,7 @@ const createEntityTypeTemplate = (appConfig, packageIds, entity) => {
     return {
         ordId: entity.ordId,
         localId: entity.entityName,
-        title: entity["@title"] ?? entity["@Common.Label"] ?? entity.entityName,
+        title: entity["@title"] ?? entity["@Common.Label"] ?? entity["@EndUserText.label"] ?? entity.entityName,
         shortDescription: SHORT_DESCRIPTION_PREFIX + entity.entityName,
         description: DESCRIPTION_PREFIX + entity.entityName,
         version: _getEntityVersion(entity),
@@ -386,7 +386,11 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
 
         let obj = {
             ordId,
-            title: serviceDefinition["@title"] ?? serviceDefinition["@Common.Label"] ?? serviceName,
+            title:
+                serviceDefinition["@title"] ??
+                serviceDefinition["@Common.Label"] ??
+                serviceDefinition["@EndUserText.label"] ??
+                serviceName,
             shortDescription: SHORT_DESCRIPTION_PREFIX + serviceName,
             description: serviceDefinition["@Core.Description"] ?? DESCRIPTION_PREFIX + serviceName,
             version: semanticVersion,
@@ -448,6 +452,7 @@ const createEventResourceTemplate = (serviceName, serviceDefinition, appConfig, 
         title:
             serviceDefinition["@title"] ??
             serviceDefinition["@Common.Label"] ??
+            serviceDefinition["@EndUserText.label"] ??
             `ODM ${appConfig.appName.replace(/[^a-zA-Z0-9]/g, "")} Events`,
         shortDescription: `${serviceName} event resource`,
         description:


### PR DESCRIPTION
# Consider `@EndUserText.label` Annotation When Resolving ORD Entity Titles

### New Feature

✨ Extended the ORD title resolution logic to consider the `@EndUserText.label` CDS annotation as a fallback when determining titles for ORD entity types, API resources, and event resources.

### Changes

The annotation `@EndUserText.label` is now included in the title resolution chain, placed between `@Common.Label` and the default entity/service name fallback.

* `lib/templates.js`: Added `@EndUserText.label` as a fallback in the title resolution chain for:
  - **Entity types** (`createEntityTypeTemplate`): `@title` → `@Common.Label` → `@EndUserText.label` → `entityName`
  - **API resources** (`createAPIResourceTemplate`): `@title` → `@Common.Label` → `@EndUserText.label` → `serviceName`
  - **Event resources** (`createEventResourceTemplate`): `@title` → `@Common.Label` → `@EndUserText.label` → default title

* `__tests__/unit/templates.test.js`: Added unit tests to verify the new annotation is correctly resolved for:
  - Entity type titles using `@EndUserText.label`
  - API resource titles using `@EndUserText.label` (via inline CDS annotation syntax `@(EndUserText.label: '...')`)
  - Event resource titles using `@EndUserText.label`

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `7b7dde55-8988-4369-851c-e37aab2af63e`
</details>
