### PR TITLE
fix: Correctly generetate API resources for multi-protocol CDS services

### DIFF
--- a/__tests__/integration/__snapshots__/basic-auth.test.js.snap
+++ b/__tests__/integration/__snapshots__/basic-auth.test.js.snap
@@ -126,6 +126,39 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
       "version": "1.0.0",
       "visibility": "public",
     },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService-rest:v1/SupplierService.oas3.json",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
   ],
   "describedSystemVersion": {
     "version": "0.1.0",
@@ -321,6 +354,39 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
           "mediaType": "application/xml",
           "type": "edmx",
           "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService-rest:v1/SupplierService.oas3.json",
         },
       ],
       "shortDescription": "Short description of SupplierService",
@@ -530,6 +596,39 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
       "version": "1.0.0",
       "visibility": "public",
     },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService-rest:v1/SupplierService.oas3.json?perspective=system-instance",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
   ],
   "description": "this is an application description",
   "eventResources": [
@@ -722,6 +821,39 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
           "mediaType": "application/xml",
           "type": "edmx",
           "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "basic-auth",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService-rest:v1/SupplierService.oas3.json",
         },
       ],
       "shortDescription": "Short description of SupplierService",

--- a/__tests__/integration/__snapshots__/cds-build.test.js.snap
+++ b/__tests__/integration/__snapshots__/cds-build.test.js.snap
@@ -90,6 +90,39 @@ exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customizat
       "version": "1.0.0",
       "visibility": "public",
     },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "customer.capireordintegrationtest_apiResource_SupplierService-rest_v1/SupplierService.oas3.json",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
   ],
   "describedSystemVersion": {
     "version": "1.0.0",
@@ -293,6 +326,39 @@ exports[`ORD Build Integration Tests IntegrationDependency with custom.ord.json 
       "version": "1.0.0",
       "visibility": "public",
     },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "customer.capireordintegrationtest_apiResource_SupplierService-rest_v1/SupplierService.oas3.json",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
   ],
   "describedSystemVersion": {
     "version": "0.1.0",
@@ -489,6 +555,39 @@ exports[`ORD Build Integration Tests Successful Build should generate ord-docume
           "mediaType": "application/xml",
           "type": "edmx",
           "url": "customer.capireordintegrationtest_apiResource_SupplierService_v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "open",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "customer.capireordintegrationtest_apiResource_SupplierService-rest_v1/SupplierService.oas3.json",
         },
       ],
       "shortDescription": "Short description of SupplierService",

--- a/__tests__/integration/__snapshots__/mtls-auth.test.js.snap
+++ b/__tests__/integration/__snapshots__/mtls-auth.test.js.snap
@@ -90,6 +90,39 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
       "version": "1.0.0",
       "visibility": "public",
     },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService-rest:v1/SupplierService.oas3.json",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
   ],
   "describedSystemVersion": {
     "version": "0.0.1",
@@ -285,6 +318,39 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "mediaType": "application/xml",
           "type": "edmx",
           "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService-rest:v1/SupplierService.oas3.json",
         },
       ],
       "shortDescription": "Short description of SupplierService",
@@ -604,6 +670,39 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) Production 
       "version": "1.0.0",
       "visibility": "public",
     },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService-rest:v1/SupplierService.oas3.json",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
   ],
   "describedSystemVersion": {
     "version": "0.0.1",
@@ -799,6 +898,39 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
           "mediaType": "application/xml",
           "type": "edmx",
           "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService:v1/SupplierService.edmx",
+        },
+      ],
+      "shortDescription": "Short description of SupplierService",
+      "title": "SupplierService",
+      "version": "1.0.0",
+      "visibility": "public",
+    },
+    {
+      "apiProtocol": "rest",
+      "description": "Description for SupplierService",
+      "entryPoints": [
+        "/rest/supplier",
+      ],
+      "extensible": {
+        "supported": "no",
+      },
+      "lastUpdate": "2026-05-04T13:45:01+01:00",
+      "ordId": "customer.capireordintegrationtest:apiResource:SupplierService-rest:v1",
+      "partOfGroups": [
+        "sap.cds:service:customer.capireordintegrationtest:SupplierService",
+      ],
+      "partOfPackage": "customer.capireordintegrationtest:package:capireordintegrationtest:v1",
+      "releaseStatus": "active",
+      "resourceDefinitions": [
+        {
+          "accessStrategies": [
+            {
+              "type": "sap:cmp-mtls:v1",
+            },
+          ],
+          "mediaType": "application/json",
+          "type": "openapi-v3",
+          "url": "/ord/v1/customer.capireordintegrationtest:apiResource:SupplierService-rest:v1/SupplierService.oas3.json",
         },
       ],
       "shortDescription": "Short description of SupplierService",

--- a/__tests__/integration/basic-auth.test.js
+++ b/__tests__/integration/basic-auth.test.js
@@ -289,7 +289,7 @@ describe("ORD Integration Tests - Basic Authentication", () => {
         });
 
         test("should contain expected resources", () => {
-            expect(ordDocument.apiResources).toHaveLength(2);
+            expect(ordDocument.apiResources).toHaveLength(3);
             expect(ordDocument.eventResources).toHaveLength(1);
             expect(ordDocument.packages).toHaveLength(1);
         });
@@ -366,7 +366,7 @@ describe("ORD Integration Tests - Basic Authentication", () => {
         });
 
         test("should contain expected resources", () => {
-            expect(ordDocument.apiResources).toHaveLength(2);
+            expect(ordDocument.apiResources).toHaveLength(3);
             expect(ordDocument.eventResources).toHaveLength(1);
             expect(ordDocument.packages).toHaveLength(1);
         });

--- a/__tests__/integration/integration-test-app/srv/test-service.cds
+++ b/__tests__/integration/integration-test-app/srv/test-service.cds
@@ -35,6 +35,8 @@ annotate TestService with @OpenAPI.servers: [
 ];
 
 // Service consuming external Data Products
+@rest
+@odata
 service SupplierService {
     entity SaiSuppliers as projection on SaiSupplier.Supplier;
     entity S4Suppliers  as projection on S4Supplier.Supplier;

--- a/__tests__/integration/mtls-auth.test.js
+++ b/__tests__/integration/mtls-auth.test.js
@@ -453,7 +453,7 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
         });
 
         test("should contain expected resources", () => {
-            expect(ordDocument.apiResources).toHaveLength(2);
+            expect(ordDocument.apiResources).toHaveLength(3);
             expect(ordDocument.eventResources).toHaveLength(1);
             expect(ordDocument.packages).toHaveLength(1);
         });
@@ -536,7 +536,7 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
         });
 
         test("should contain expected resources", () => {
-            expect(ordDocument.apiResources).toHaveLength(2);
+            expect(ordDocument.apiResources).toHaveLength(3);
             expect(ordDocument.eventResources).toHaveLength(1);
             expect(ordDocument.packages).toHaveLength(1);
         });

--- a/__tests__/unit/__snapshots__/templates.test.js.snap
+++ b/__tests__/unit/__snapshots__/templates.test.js.snap
@@ -48,6 +48,249 @@ exports[`templates createAPIResourceTemplate should create API resource template
 ]
 `;
 
+exports[`templates createAPIResourceTemplate should create API resource template correctly for multi-protocol services 1`] = `
+[
+  {
+    "apiProtocol": "odata-v4",
+    "description": "Description for MyService",
+    "entryPoints": [
+      "/odata/v4/my",
+    ],
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:apiResource:MyService:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "openapi-v3",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.oas3.json",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/xml",
+        "type": "edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.edmx",
+      },
+    ],
+    "shortDescription": "Short description of MyService",
+    "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+  {
+    "apiProtocol": "rest",
+    "description": "Description for MyService",
+    "entryPoints": [
+      "/rest/my",
+    ],
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:apiResource:MyService-rest:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "openapi-v3",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService-rest:v1/MyService.oas3.json",
+      },
+    ],
+    "shortDescription": "Short description of MyService",
+    "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;
+
+exports[`templates createAPIResourceTemplate should create API resource template correctly for multi-protocol services when ordId is overridden 1`] = `
+[
+  {
+    "apiProtocol": "odata-v4",
+    "description": "Description for MyService",
+    "entryPoints": [
+      "/odata/v4/my",
+    ],
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:apiResource:MyService-customized-odata-v4:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "openapi-v3",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService-customized-odata-v4:v1/MyService.oas3.json",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/xml",
+        "type": "edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService-customized-odata-v4:v1/MyService.edmx",
+      },
+    ],
+    "shortDescription": "Short description of MyService",
+    "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+  {
+    "apiProtocol": "rest",
+    "description": "Description for MyService",
+    "entryPoints": [
+      "/rest/my",
+    ],
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:apiResource:MyService-customized-rest:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "openapi-v3",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService-customized-rest:v1/MyService.oas3.json",
+      },
+    ],
+    "shortDescription": "Short description of MyService",
+    "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;
+
+exports[`templates createAPIResourceTemplate should create API resource template correctly for multi-protocol services when ordId is overridden for specific protocol 1`] = `
+[
+  {
+    "apiProtocol": "odata-v4",
+    "description": "Description for MyService",
+    "entryPoints": [
+      "/odata/v4/my",
+    ],
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:apiResource:MyService:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "openapi-v3",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.oas3.json",
+      },
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/xml",
+        "type": "edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.edmx",
+      },
+    ],
+    "shortDescription": "Short description of MyService",
+    "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+  {
+    "apiProtocol": "rest",
+    "description": "Description for MyService",
+    "entryPoints": [
+      "/rest/my",
+    ],
+    "extensible": {
+      "supported": "no",
+    },
+    "lastUpdate": "2022-12-19T15:47:04+00:00",
+    "ordId": "customer.testNamespace:apiResource:MyService-customized-rest:v1",
+    "partOfGroups": [
+      "sap.cds:service:customer.testNamespace:MyService",
+    ],
+    "partOfPackage": "sap.test.cdsrc.sample:package:test-api:v1",
+    "releaseStatus": "active",
+    "resourceDefinitions": [
+      {
+        "accessStrategies": [
+          {
+            "type": "open",
+          },
+        ],
+        "mediaType": "application/json",
+        "type": "openapi-v3",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService-customized-rest:v1/MyService.oas3.json",
+      },
+    ],
+    "shortDescription": "Short description of MyService",
+    "title": "MyService",
+    "version": "1.0.0",
+    "visibility": "public",
+  },
+]
+`;
+
 exports[`templates createEntityTypeTemplate should return entity type with default version, title and level:sub-entity 1`] = `
 {
   "description": "Description for SomeAribaDummyEntity",

--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -339,6 +339,72 @@ describe("templates", () => {
     });
 
     describe("createAPIResourceTemplate", () => {
+        it("should create API resource template correctly for multi-protocol services", () => {
+            const model = cds.linked(`
+                @rest
+                @odata
+                service MyService {}
+            `);
+
+            const result = createAPIResourceTemplate(
+                "MyService", //
+                model.definitions["MyService"], //
+                appConfig, //
+                ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"],
+            );
+
+            expect(result).toBeInstanceOf(Array);
+            expect(result).toHaveLength(2);
+            expect(result[0].ordId).toEqual("customer.testNamespace:apiResource:MyService:v1");
+            expect(result[1].ordId).toEqual("customer.testNamespace:apiResource:MyService-rest:v1");
+            expect(result).toMatchSnapshot();
+        });
+
+        it("should create API resource template correctly for multi-protocol services when ordId is overridden for specific protocol", () => {
+            const model = cds.linked(`
+                @rest
+                @odata
+                @![protocol('rest')].ORD.Extensions.ordId: 'customer.testNamespace:apiResource:MyService-customized-rest:v1'
+                service MyService {}
+            `);
+
+            const result = createAPIResourceTemplate(
+                "MyService", //
+                model.definitions["MyService"], //
+                appConfig, //
+                ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"],
+            );
+
+            expect(result).toBeInstanceOf(Array);
+            expect(result).toHaveLength(2);
+            expect(result[0].ordId).toEqual("customer.testNamespace:apiResource:MyService:v1");
+            expect(result[1].ordId).toEqual("customer.testNamespace:apiResource:MyService-customized-rest:v1");
+            expect(result).toMatchSnapshot();
+        });
+
+        it("should create API resource template correctly for multi-protocol services when ordId is overridden", () => {
+            const model = cds.linked(`
+                @rest
+                @odata
+                @ORD.Extensions.ordId: 'customer.testNamespace:apiResource:MyService-customized-odata-v4:v1'
+                @![protocol('rest')].ORD.Extensions.ordId: 'customer.testNamespace:apiResource:MyService-customized-rest:v1'
+                service MyService {}
+            `);
+
+            const result = createAPIResourceTemplate(
+                "MyService", //
+                model.definitions["MyService"], //
+                appConfig, //
+                ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"],
+            );
+
+            expect(result).toBeInstanceOf(Array);
+            expect(result).toHaveLength(2);
+            expect(result[0].ordId).toEqual("customer.testNamespace:apiResource:MyService-customized-odata-v4:v1");
+            expect(result[1].ordId).toEqual("customer.testNamespace:apiResource:MyService-customized-rest:v1");
+            expect(result).toMatchSnapshot();
+        });
+
         it("should create API resource template correctly", () => {
             const serviceName = "MyService";
             const model = cds.linked(`

--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -346,18 +346,12 @@ describe("templates", () => {
                 service MyService {}
             `);
 
-            const result = createAPIResourceTemplate(
-                "MyService", //
-                model.definitions["MyService"], //
-                appConfig, //
-                ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"],
-            );
-
-            expect(result).toBeInstanceOf(Array);
-            expect(result).toHaveLength(2);
-            expect(result[0].ordId).toEqual("customer.testNamespace:apiResource:MyService:v1");
-            expect(result[1].ordId).toEqual("customer.testNamespace:apiResource:MyService-rest:v1");
-            expect(result).toMatchSnapshot();
+            expect(
+                createAPIResourceTemplate("MyService", model.definitions["MyService"], appConfig, [
+                    "sap.test.cdsrc.sample:package:test-event:v1",
+                    "sap.test.cdsrc.sample:package:test-api:v1",
+                ]),
+            ).toMatchSnapshot();
         });
 
         it("should create API resource template correctly for multi-protocol services when ordId is overridden for specific protocol", () => {
@@ -368,18 +362,12 @@ describe("templates", () => {
                 service MyService {}
             `);
 
-            const result = createAPIResourceTemplate(
-                "MyService", //
-                model.definitions["MyService"], //
-                appConfig, //
-                ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"],
-            );
-
-            expect(result).toBeInstanceOf(Array);
-            expect(result).toHaveLength(2);
-            expect(result[0].ordId).toEqual("customer.testNamespace:apiResource:MyService:v1");
-            expect(result[1].ordId).toEqual("customer.testNamespace:apiResource:MyService-customized-rest:v1");
-            expect(result).toMatchSnapshot();
+            expect(
+                createAPIResourceTemplate("MyService", model.definitions["MyService"], appConfig, [
+                    "sap.test.cdsrc.sample:package:test-event:v1",
+                    "sap.test.cdsrc.sample:package:test-api:v1",
+                ]),
+            ).toMatchSnapshot();
         });
 
         it("should create API resource template correctly for multi-protocol services when ordId is overridden", () => {
@@ -391,18 +379,12 @@ describe("templates", () => {
                 service MyService {}
             `);
 
-            const result = createAPIResourceTemplate(
-                "MyService", //
-                model.definitions["MyService"], //
-                appConfig, //
-                ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"],
-            );
-
-            expect(result).toBeInstanceOf(Array);
-            expect(result).toHaveLength(2);
-            expect(result[0].ordId).toEqual("customer.testNamespace:apiResource:MyService-customized-odata-v4:v1");
-            expect(result[1].ordId).toEqual("customer.testNamespace:apiResource:MyService-customized-rest:v1");
-            expect(result).toMatchSnapshot();
+            expect(
+                createAPIResourceTemplate("MyService", model.definitions["MyService"], appConfig, [
+                    "sap.test.cdsrc.sample:package:test-event:v1",
+                    "sap.test.cdsrc.sample:package:test-api:v1",
+                ]),
+            ).toMatchSnapshot();
         });
 
         it("should create API resource template correctly", () => {

--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -347,7 +347,7 @@ describe("templates", () => {
             `);
 
             expect(
-                createAPIResourceTemplate("MyService", model.definitions["MyService"], appConfig, [
+                createAPIResourceTemplate(model.definitions["MyService"], appConfig, [
                     "sap.test.cdsrc.sample:package:test-event:v1",
                     "sap.test.cdsrc.sample:package:test-api:v1",
                 ]),
@@ -363,7 +363,7 @@ describe("templates", () => {
             `);
 
             expect(
-                createAPIResourceTemplate("MyService", model.definitions["MyService"], appConfig, [
+                createAPIResourceTemplate(model.definitions["MyService"], appConfig, [
                     "sap.test.cdsrc.sample:package:test-event:v1",
                     "sap.test.cdsrc.sample:package:test-api:v1",
                 ]),
@@ -380,7 +380,7 @@ describe("templates", () => {
             `);
 
             expect(
-                createAPIResourceTemplate("MyService", model.definitions["MyService"], appConfig, [
+                createAPIResourceTemplate(model.definitions["MyService"], appConfig, [
                     "sap.test.cdsrc.sample:package:test-event:v1",
                     "sap.test.cdsrc.sample:package:test-api:v1",
                 ]),

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -32,11 +32,11 @@ function unflatten(flattedObject) {
     return result;
 }
 
-function readORDExtensions(model) {
+function readORDExtensions(model, prefix = ORD_EXTENSIONS_PREFIX) {
     const ordExtensions = {};
     for (const key in model) {
-        if (key.startsWith(ORD_EXTENSIONS_PREFIX)) {
-            const ordKey = key.replace(ORD_EXTENSIONS_PREFIX, "");
+        if (key.startsWith(prefix)) {
+            const ordKey = key.replace(prefix, "");
             ordExtensions[ordKey] = model[key];
         }
     }
@@ -320,10 +320,13 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
         version = `v${semanticVersion.split(".")[0]}`;
     }
 
-    const ordId = ordExtensions.ordId || `${appConfig.ordNamespace}:apiResource:${cleanServiceName}:${version}`;
-
-    protocolResults.forEach((protocolResult) => {
+    protocolResults.forEach((protocolResult, index) => {
         const { apiProtocol, entryPoints, hasResourceDefinitions } = protocolResult;
+        const protocolExtensions = readORDExtensions(serviceDefinition, `@protocol('${apiProtocol}').ORD.Extensions.`);
+        const ordId =
+            protocolExtensions.ordId ||
+            ordExtensions.ordId ||
+            `${appConfig.ordNamespace}:apiResource:${cleanServiceName}${index === 0 ? "" : `-${apiProtocol}`}:${version}`;
 
         // Build resource definitions based on protocol
         let resourceDefinitions = [];
@@ -403,6 +406,7 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
             },
             ...(exposedEntityTypes ? { exposedEntityTypes } : []),
             ...ordExtensions,
+            ...protocolExtensions,
         };
 
         // Special handling for data product services
@@ -490,7 +494,9 @@ function _getExposedEntityTypes(definitionObj) {
     });
     const exposedEntityTypes = _.uniqBy(entities, CONTENT_MERGE_KEY)
         .filter((entity) => !!entity)
-        .map((entity) => ({ ordId: entity.isODMMapping ? entity.ordId : (entity[`${ORD_EXTENSIONS_PREFIX}ordId`] || entity.ordId) }));
+        .map((entity) => ({
+            ordId: entity.isODMMapping ? entity.ordId : entity[`${ORD_EXTENSIONS_PREFIX}ordId`] || entity.ordId,
+        }));
 
     if (exposedEntityTypes.length > 0) {
         return exposedEntityTypes;

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -314,7 +314,7 @@ const createAPIResourceTemplate = (srvDefinition, appConfig, packageIds, accessS
 
     protocolResults.forEach((protocolResult, index) => {
         const { apiProtocol, entryPoints, hasResourceDefinitions } = protocolResult;
-        const protocolExtensions = readORDExtensions(serviceDefinition, `@protocol('${apiProtocol}').ORD.Extensions.`);
+        const protocolExtensions = readORDExtensions(srvDefinition, `@protocol('${apiProtocol}').ORD.Extensions.`);
         const ordId =
             protocolExtensions.ordId ||
             ordExtensions.ordId ||


### PR DESCRIPTION
# Fix: Correctly Generate API Resources for Multi-Protocol CDS Services

### Bug Fix

🐛 Fixes an issue where CDS services annotated with multiple protocols (e.g., `@rest` and `@odata`) were not correctly generating separate ORD API resource entries for each protocol. Previously, only a single API resource was emitted; now each protocol produces its own distinct `apiResource` with the appropriate `ordId`, `entryPoints`, `resourceDefinitions`, and `apiProtocol` fields.

### Changes

* `lib/templates.js`: Refactored `readORDExtensions` to accept a configurable prefix parameter. Updated `createAPIResourceTemplate` to compute the `ordId` per-protocol (appending `-{protocol}` suffix for non-primary protocols) and to read protocol-specific ORD extension overrides via `@protocol('...').ORD.Extensions.*` annotations. Protocol-specific extensions are now spread onto each generated resource object alongside the global ORD extensions.

* `__tests__/integration/integration-test-app/srv/test-service.cds`: Added `@rest` and `@odata` annotations to `SupplierService` to exercise multi-protocol behavior in integration tests.

* `__tests__/integration/basic-auth.test.js` / `mtls-auth.test.js`: Updated expected `apiResources` count from `2` to `3` to account for the new REST API resource generated for `SupplierService`.

* `__tests__/integration/__snapshots__/basic-auth.test.js.snap`, `cds-build.test.js.snap`, `mtls-auth.test.js.snap`: Updated snapshots to include the new REST API resource (`SupplierService-rest`) with an OpenAPI v3 resource definition and correct `ordId`.

* `__tests__/unit/templates.test.js`: Added unit tests covering multi-protocol service template generation, including cases where `ordId` is overridden globally, per-protocol, or both.

* `__tests__/unit/__snapshots__/templates.test.js.snap`: Added snapshot expectations for the new multi-protocol test cases, covering default and customized `ordId` scenarios.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `9279fbb2-8146-4870-84b5-c27b12bac737`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
