### PR TITLE
chore: Remove redundant service name arg from 'createGroupsTemplateForService'

### DIFF
--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -110,23 +110,21 @@ describe("visibility handling", () => {
     });
 
     it("returns undefined if ORD.Extensions.visibility is private", () => {
-        const serviceName = "customer.testNamespace.MyService";
         const serviceDefinition = {
-            "name": serviceName,
+            "name": "customer.testNamespace.MyService",
             "@ORD.Extensions.visibility": "private",
         };
-        const group = createGroupsTemplateForService(serviceName, serviceDefinition, appConfig);
-        expect(group).toBeUndefined();
+
+        expect(createGroupsTemplateForService(serviceDefinition, appConfig)).toBeUndefined();
     });
 
     it("returns group object if ORD.Extensions.visibility is internal", () => {
-        const serviceName = "customer.testNamespace.MyService";
         const serviceDefinition = {
-            "name": serviceName,
+            "name": "customer.testNamespace.MyService",
             "@ORD.Extensions.visibility": "internal",
         };
-        const group = createGroupsTemplateForService(serviceName, serviceDefinition, appConfig);
-        expect(group).toEqual({
+
+        expect(createGroupsTemplateForService(serviceDefinition, appConfig)).toEqual({
             groupId: "sap.cds:service:customer.testNamespace:MyService",
             groupTypeId: "sap.cds:service",
             title: "My Service",
@@ -134,10 +132,9 @@ describe("visibility handling", () => {
     });
 
     it("returns group object if ORD.Extensions.visibility is not set", () => {
-        const serviceName = "customer.testNamespace.MyService";
-        const serviceDefinition = { name: serviceName };
-        const group = createGroupsTemplateForService(serviceName, serviceDefinition, appConfig);
-        expect(group).toEqual({
+        const serviceDefinition = { name: "customer.testNamespace.MyService" };
+
+        expect(createGroupsTemplateForService(serviceDefinition, appConfig)).toEqual({
             groupId: "sap.cds:service:customer.testNamespace:MyService",
             groupTypeId: "sap.cds:service",
             title: "My Service",
@@ -313,28 +310,19 @@ describe("templates", () => {
         });
 
         it("should return default value when groupIds do not have groupId", () => {
-            const testServiceName = "testServiceName";
-            const testResult = {
+            expect(createGroupsTemplateForService(serviceDefinition, appConfig)).toEqual({
                 groupId: "sap.cds:service:customer.testNamespace:testServiceName",
                 groupTypeId: "sap.cds:service",
                 title: "test Service",
-            };
-            expect(createGroupsTemplateForService(testServiceName, serviceDefinition, appConfig)).toEqual(testResult);
+            });
         });
 
         it('should return default value with a proper Service title when "Service" keyword is missing', () => {
-            const testServiceName = "testServName";
-            const testResult = {
-                groupId: "sap.cds:service:customer.testNamespace:testServiceName",
+            expect(createGroupsTemplateForService({ ...serviceDefinition, name: "testServName" }, appConfig)).toEqual({
+                groupId: "sap.cds:service:customer.testNamespace:testServName",
                 groupTypeId: "sap.cds:service",
                 title: "testServName Service",
-            };
-            expect(createGroupsTemplateForService(testServiceName, serviceDefinition, appConfig)).toEqual(testResult);
-        });
-
-        it("should return undefined when no service definition", () => {
-            const testServiceName = "testServiceName";
-            expect(createGroupsTemplateForService(testServiceName, null, appConfig)).not.toBeDefined();
+            });
         });
     });
 

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -21,7 +21,7 @@ const {
 const _getGroups = (csn, appConfig) => {
     return appConfig.serviceNames
         .map((name) => csn.definitions[name])
-        .flatMap((definition) => createGroupsTemplateForService(definition, appConfig))
+        .flatMap((srvDefinition) => createGroupsTemplateForService(srvDefinition, appConfig))
         .filter((resource) => !!resource);
 };
 

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -20,7 +20,8 @@ const {
 
 const _getGroups = (csn, appConfig) => {
     return appConfig.serviceNames
-        .flatMap((serviceName) => createGroupsTemplateForService(serviceName, csn.definitions[serviceName], appConfig))
+        .map((name) => csn.definitions[name])
+        .flatMap((definition) => createGroupsTemplateForService(definition, appConfig))
         .filter((resource) => !!resource);
 };
 

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -162,30 +162,24 @@ function _getResourceDefinition(resourceType, mediaType, ordId, serviceName, fil
 /**
  * This is a template function to create group object of a service for groups array in ORD doc.
  *
- * @param {string} serviceName The name of the service.
- * @param {object} serviceDefinition The definition of the service
+ * @param {object} definition The definition of the service
  * @param {object} appConfig - The application configuration.
  * @returns {Object} A group object.
  */
-const createGroupsTemplateForService = (serviceName, serviceDefinition, appConfig) => {
-    const ordExtensions = readORDExtensions(serviceDefinition);
+const createGroupsTemplateForService = (definition, appConfig) => {
+    const ordExtensions = readORDExtensions(definition);
+    const visibility = _handleVisibility(ordExtensions, definition, appConfig.env?.defaultVisibility);
 
-    if (!serviceDefinition) {
-        Logger.warn("Unable to find service definition:", serviceName);
-        return undefined;
-    }
-
-    const visibility = _handleVisibility(ordExtensions, serviceDefinition, appConfig.env?.defaultVisibility);
     if (visibility === RESOURCE_VISIBILITY.private) {
         // If the visibility of the service is private, do not create a group
-        Logger.info("Skipping group creation for private service:", serviceName);
+        Logger.info("Skipping group creation for private service:", definition.name);
         return undefined;
     }
 
     return {
-        groupId: _getGroupID(serviceDefinition, defaults.groupTypeId, appConfig),
+        groupId: _getGroupID(definition, defaults.groupTypeId, appConfig),
         groupTypeId: defaults.groupTypeId,
-        title: ordExtensions.title ?? _getTitleFromServiceName(serviceName),
+        title: ordExtensions.title ?? _getTitleFromServiceName(definition.name),
     };
 };
 

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -162,24 +162,24 @@ function _getResourceDefinition(resourceType, mediaType, ordId, serviceName, fil
 /**
  * This is a template function to create group object of a service for groups array in ORD doc.
  *
- * @param {object} definition The definition of the service
+ * @param {object} srvDefinition The definition of the service
  * @param {object} appConfig - The application configuration.
  * @returns {Object} A group object.
  */
-const createGroupsTemplateForService = (definition, appConfig) => {
-    const ordExtensions = readORDExtensions(definition);
-    const visibility = _handleVisibility(ordExtensions, definition, appConfig.env?.defaultVisibility);
+const createGroupsTemplateForService = (srvDefinition, appConfig) => {
+    const ordExtensions = readORDExtensions(srvDefinition);
+    const visibility = _handleVisibility(ordExtensions, srvDefinition, appConfig.env?.defaultVisibility);
 
     if (visibility === RESOURCE_VISIBILITY.private) {
         // If the visibility of the service is private, do not create a group
-        Logger.info("Skipping group creation for private service:", definition.name);
+        Logger.info("Skipping group creation for private service:", srvDefinition.name);
         return undefined;
     }
 
     return {
-        groupId: _getGroupID(definition, defaults.groupTypeId, appConfig),
+        groupId: _getGroupID(srvDefinition, defaults.groupTypeId, appConfig),
         groupTypeId: defaults.groupTypeId,
-        title: ordExtensions.title ?? _getTitleFromServiceName(definition.name),
+        title: ordExtensions.title ?? _getTitleFromServiceName(srvDefinition.name),
     };
 };
 


### PR DESCRIPTION
# Remove Redundant `serviceName` Argument from `createGroupsTemplateForService`

### Chore

♻️ **Refactor:** Simplified the `createGroupsTemplateForService` function signature by removing the redundant `serviceName` parameter, since the service name is already accessible via `definition.name`.

### Changes

* `lib/templates.js`: Removed the `serviceName` parameter from `createGroupsTemplateForService`. The function now accepts only `(definition, appConfig)` and derives the service name directly from `definition.name`. Also removed the now-unnecessary null-check guard for `serviceDefinition`. Updated JSDoc accordingly.
* `lib/ord.js`: Updated the call site in `_getGroups` to map service names to their definitions first, then pass only the definition (and `appConfig`) to `createGroupsTemplateForService`.
* `__tests__/unit/templates.test.js`: Updated all test cases to match the new two-argument signature — removed intermediate `serviceName` variables and updated assertions to call `createGroupsTemplateForService(serviceDefinition, appConfig)` directly. Also removed a now-obsolete test case that verified behavior when `null` was passed as the service definition.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `f03947b8-7ea0-40e9-8288-4d5189d6ff4a`
- Event Trigger: `pull_request.opened`
</details>
