### PR TITLE
chore: Remove redundant service name arg from 'createAPIResourceTemplate'

### DIFF
--- a/__tests__/unit/__snapshots__/namespace.test.js.snap
+++ b/__tests__/unit/__snapshots__/namespace.test.js.snap
@@ -4,7 +4,7 @@ exports[`namespace local and global should not strip a different local namespace
 [
   {
     "apiProtocol": "odata-v4",
-    "description": "Description for MyService",
+    "description": "Description for other.namespace.MyService",
     "entryPoints": [
       "/odata/v4/my",
     ],
@@ -27,7 +27,7 @@ exports[`namespace local and global should not strip a different local namespace
         ],
         "mediaType": "application/json",
         "type": "openapi-v3",
-        "url": "/ord/v1/customer.testNamespace:apiResource:other.namespace.MyService:v1/MyService.oas3.json",
+        "url": "/ord/v1/customer.testNamespace:apiResource:other.namespace.MyService:v1/other.namespace.MyService.oas3.json",
       },
       {
         "accessStrategies": [
@@ -37,11 +37,11 @@ exports[`namespace local and global should not strip a different local namespace
         ],
         "mediaType": "application/xml",
         "type": "edmx",
-        "url": "/ord/v1/customer.testNamespace:apiResource:other.namespace.MyService:v1/MyService.edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:other.namespace.MyService:v1/other.namespace.MyService.edmx",
       },
     ],
-    "shortDescription": "Short description of MyService",
-    "title": "MyService",
+    "shortDescription": "Short description of other.namespace.MyService",
+    "title": "other.namespace.MyService",
     "version": "1.0.0",
     "visibility": "public",
   },
@@ -71,10 +71,10 @@ exports[`namespace local and global should not strip a different local namespace
         ],
         "mediaType": "application/json",
         "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:other.namespace.MyService:v1/MyService.asyncapi2.json",
+        "url": "/ord/v1/customer.testNamespace:eventResource:other.namespace.MyService:v1/other.namespace.MyService.asyncapi2.json",
       },
     ],
-    "shortDescription": "MyService event resource",
+    "shortDescription": "other.namespace.MyService event resource",
     "title": "ODM testAppName Events",
     "version": "1.0.0",
     "visibility": "public",
@@ -86,7 +86,7 @@ exports[`namespace local and global should strip application namespace from loca
 [
   {
     "apiProtocol": "odata-v4",
-    "description": "Description for MyService",
+    "description": "Description for customer.testNamespace.nested.MyService",
     "entryPoints": [
       "/odata/v4/my",
     ],
@@ -109,7 +109,7 @@ exports[`namespace local and global should strip application namespace from loca
         ],
         "mediaType": "application/json",
         "type": "openapi-v3",
-        "url": "/ord/v1/customer.testNamespace:apiResource:nested.MyService:v1/MyService.oas3.json",
+        "url": "/ord/v1/customer.testNamespace:apiResource:nested.MyService:v1/customer.testNamespace.nested.MyService.oas3.json",
       },
       {
         "accessStrategies": [
@@ -119,11 +119,11 @@ exports[`namespace local and global should strip application namespace from loca
         ],
         "mediaType": "application/xml",
         "type": "edmx",
-        "url": "/ord/v1/customer.testNamespace:apiResource:nested.MyService:v1/MyService.edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:nested.MyService:v1/customer.testNamespace.nested.MyService.edmx",
       },
     ],
-    "shortDescription": "Short description of MyService",
-    "title": "MyService",
+    "shortDescription": "Short description of customer.testNamespace.nested.MyService",
+    "title": "customer.testNamespace.nested.MyService",
     "version": "1.0.0",
     "visibility": "public",
   },
@@ -153,10 +153,10 @@ exports[`namespace local and global should strip application namespace from loca
         ],
         "mediaType": "application/json",
         "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:nested.MyService:v1/MyService.asyncapi2.json",
+        "url": "/ord/v1/customer.testNamespace:eventResource:nested.MyService:v1/customer.testNamespace.nested.MyService.asyncapi2.json",
       },
     ],
-    "shortDescription": "MyService event resource",
+    "shortDescription": "customer.testNamespace.nested.MyService event resource",
     "title": "ODM testAppName Events",
     "version": "1.0.0",
     "visibility": "public",
@@ -168,7 +168,7 @@ exports[`namespace local and global should strip application namespace if its th
 [
   {
     "apiProtocol": "odata-v4",
-    "description": "Description for MyService",
+    "description": "Description for customer.testNamespace.MyService",
     "entryPoints": [
       "/odata/v4/my",
     ],
@@ -191,7 +191,7 @@ exports[`namespace local and global should strip application namespace if its th
         ],
         "mediaType": "application/json",
         "type": "openapi-v3",
-        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.oas3.json",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/customer.testNamespace.MyService.oas3.json",
       },
       {
         "accessStrategies": [
@@ -201,11 +201,11 @@ exports[`namespace local and global should strip application namespace if its th
         ],
         "mediaType": "application/xml",
         "type": "edmx",
-        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.edmx",
+        "url": "/ord/v1/customer.testNamespace:apiResource:MyService:v1/customer.testNamespace.MyService.edmx",
       },
     ],
-    "shortDescription": "Short description of MyService",
-    "title": "MyService",
+    "shortDescription": "Short description of customer.testNamespace.MyService",
+    "title": "customer.testNamespace.MyService",
     "version": "1.0.0",
     "visibility": "public",
   },
@@ -235,10 +235,10 @@ exports[`namespace local and global should strip application namespace if its th
         ],
         "mediaType": "application/json",
         "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v1/MyService.asyncapi2.json",
+        "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v1/customer.testNamespace.MyService.asyncapi2.json",
       },
     ],
-    "shortDescription": "MyService event resource",
+    "shortDescription": "customer.testNamespace.MyService event resource",
     "title": "ODM testAppName Events",
     "version": "1.0.0",
     "visibility": "public",

--- a/__tests__/unit/namespace.test.js
+++ b/__tests__/unit/namespace.test.js
@@ -24,7 +24,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["customer.testNamespace.nested.MyService"];
         expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
-        expect(createEventResourceTemplate(srvDefinition, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
     });
 
     it("should strip application namespace if its the same as local namespace", () => {
@@ -49,7 +49,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["customer.testNamespace.MyService"];
         expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
-        expect(createEventResourceTemplate(srvDefinition, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
     });
 
     it("should not strip a different local namespace", () => {
@@ -74,7 +74,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["other.namespace.MyService"];
         expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
-        expect(createEventResourceTemplate(srvDefinition, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
     });
 
     it("should strip internalNamespace when it differs from ordNamespace", () => {

--- a/__tests__/unit/namespace.test.js
+++ b/__tests__/unit/namespace.test.js
@@ -8,8 +8,6 @@ describe("namespace local and global", () => {
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
         };
-        const serviceName = "MyService";
-        const testNamespace = "customer.testNamespace.nested.";
         const model = cds.linked(`
                 namespace customer.testNamespace.nested;
 
@@ -24,9 +22,9 @@ describe("namespace local and global", () => {
                 };
             `);
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
-        const srvDefinition = model.definitions[testNamespace + serviceName];
-        expect(createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
-        expect(createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        const srvDefinition = model.definitions["customer.testNamespace.nested.MyService"];
+        expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(srvDefinition.name, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
     });
 
     it("should strip application namespace if its the same as local namespace", () => {
@@ -35,8 +33,6 @@ describe("namespace local and global", () => {
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
         };
-        const serviceName = "MyService";
-        const testNamespace = "customer.testNamespace.";
         const model = cds.linked(`
                 namespace customer.testNamespace;
 
@@ -51,9 +47,9 @@ describe("namespace local and global", () => {
                 };
             `);
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
-        const srvDefinition = model.definitions[testNamespace + serviceName];
-        expect(createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
-        expect(createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        const srvDefinition = model.definitions["customer.testNamespace.MyService"];
+        expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(srvDefinition.name, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
     });
 
     it("should not strip a different local namespace", () => {
@@ -62,8 +58,6 @@ describe("namespace local and global", () => {
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
         };
-        const serviceName = "MyService";
-        const testNamespace = "other.namespace.";
         const model = cds.linked(`
                 namespace other.namespace;
 
@@ -78,9 +72,9 @@ describe("namespace local and global", () => {
                 };
             `);
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
-        const srvDefinition = model.definitions[testNamespace + serviceName];
-        expect(createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
-        expect(createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        const srvDefinition = model.definitions["other.namespace.MyService"];
+        expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(srvDefinition.name, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
     });
 
     it("should strip internalNamespace when it differs from ordNamespace", () => {
@@ -90,7 +84,6 @@ describe("namespace local and global", () => {
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
         };
-        const serviceName = "SourcingService";
         const model = cds.linked(`
             namespace com.sap.sourcing.api.v1;
             service SourcingService {
@@ -101,11 +94,11 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["com.sap.sourcing.api.v1.SourcingService"];
 
-        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        const apiResult = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
         expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:SourcingService:v1");
         expect(apiResult[0].partOfGroups[0]).toBe("sap.cds:service:sap.sourcing:SourcingService");
 
-        const eventResult = createEventResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        const eventResult = createEventResourceTemplate(srvDefinition.name, srvDefinition, appConfig, packageIds);
         expect(eventResult[0].ordId).toBe("sap.sourcing:eventResource:SourcingService:v1");
     });
 
@@ -116,7 +109,6 @@ describe("namespace local and global", () => {
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
         };
-        const serviceName = "SourcingService";
         const model = cds.linked(`
             namespace com.sap.sourcing.nested;
             service SourcingService {
@@ -127,7 +119,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["com.sap.sourcing.nested.SourcingService"];
 
-        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        const apiResult = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
         expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:nested.SourcingService:v1");
     });
 
@@ -138,7 +130,6 @@ describe("namespace local and global", () => {
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
         };
-        const serviceName = "BillingService";
         const model = cds.linked(`
             namespace sap.sourcing.internal;
             service BillingService {
@@ -149,7 +140,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["sap.sourcing.internal.BillingService"];
 
-        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        const apiResult = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
         expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:BillingService:v1");
     });
 
@@ -159,7 +150,6 @@ describe("namespace local and global", () => {
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
         };
-        const serviceName = "SomeService";
         const model = cds.linked(`
             namespace sap.sourcingExtra;
             service SomeService {
@@ -170,7 +160,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["sap.sourcingExtra.SomeService"];
 
-        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        const apiResult = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
         expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:sap.sourcingExtra.SomeService:v1");
     });
 
@@ -181,7 +171,6 @@ describe("namespace local and global", () => {
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
         };
-        const serviceName = "SomeService";
         const model = cds.linked(`
             namespace com.sap.sourcingExtra;
             service SomeService {
@@ -192,7 +181,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["com.sap.sourcingExtra.SomeService"];
 
-        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        const apiResult = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
         expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:com.sap.sourcingExtra.SomeService:v1");
     });
 
@@ -203,7 +192,6 @@ describe("namespace local and global", () => {
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
         };
-        const serviceName = "MyService";
         const model = cds.linked(`
             namespace other.namespace;
             service MyService {
@@ -214,7 +202,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["other.namespace.MyService"];
 
-        const apiResult = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+        const apiResult = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
         expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:other.namespace.MyService:v1");
     });
 });

--- a/__tests__/unit/ord-visibility-split.test.js
+++ b/__tests__/unit/ord-visibility-split.test.js
@@ -104,30 +104,27 @@ describe("templates", () => {
         ];
 
         it("should assign the correct partOfPackage for public API", () => {
-            const serviceName = "PublicAPI";
-            const serviceDefinition = { "@ORD.Extensions.visibility": "public", "entities": [], "name": serviceName };
+            const serviceDefinition = { "@ORD.Extensions.visibility": "public", "entities": [], "name": "PublicAPI" };
 
-            const apiResource = createAPIResourceTemplate(serviceName, serviceDefinition, appConfig, packageIds, {});
+            const apiResource = createAPIResourceTemplate(serviceDefinition, appConfig, packageIds, {});
 
             expect(apiResource).not.toBeNull();
             expect(apiResource[0].partOfPackage).toBe("sap.test.cdsrc.sample:package:test-api:v1");
         });
 
         it("should assign the correct partOfPackage for internal API", () => {
-            const serviceName = "InternalAPI";
-            const serviceDefinition = { "@ORD.Extensions.visibility": "internal", "entities": [], "name": serviceName };
+            const serviceDefinition = { "@ORD.Extensions.visibility": "internal", "entities": [], "name": "InternalAPI" };
 
-            const apiResource = createAPIResourceTemplate(serviceName, serviceDefinition, appConfig, packageIds, {});
+            const apiResource = createAPIResourceTemplate(serviceDefinition, appConfig, packageIds, {});
 
             expect(apiResource).not.toBeNull();
             expect(apiResource[0].partOfPackage).toBe("sap.test.cdsrc.sample:package:test-api-internal:v1");
         });
 
         it("should return null for private API", () => {
-            const serviceName = "PrivateAPI";
-            const serviceDefinition = { "@ORD.Extensions.visibility": "private", "entities": [], "name": serviceName };
+            const serviceDefinition = { "@ORD.Extensions.visibility": "private", "entities": [], "name": "PrivateAPI" };
 
-            const apiResource = createAPIResourceTemplate(serviceName, serviceDefinition, appConfig, packageIds, {});
+            const apiResource = createAPIResourceTemplate(serviceDefinition, appConfig, packageIds, {});
 
             expect(apiResource).toHaveLength(0);
         });

--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -342,7 +342,7 @@ describe("templates", () => {
         it("should return api resource with correct title from annotation '@EndUserText.label'", () => {
             const model = cds.linked(`service MyService @(EndUserText.label: 'This is MyService title' ) { }`);
 
-            const apiResources = createAPIResourceTemplate("MyService", model.definitions["MyService"], appConfig, [
+            const apiResources = createAPIResourceTemplate(model.definitions["MyService"], appConfig, [
                 "sap.test.cdsrc.sample:package:test-event:v1",
                 "sap.test.cdsrc.sample:package:test-api:v1",
             ]);

--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -340,7 +340,6 @@ describe("templates", () => {
 
     describe("createAPIResourceTemplate", () => {
         it("should create API resource template correctly", () => {
-            const serviceName = "MyService";
             const model = cds.linked(`
                 service MyService {
                    entity Books {
@@ -354,12 +353,10 @@ describe("templates", () => {
                 "sap.test.cdsrc.sample:package:test-event:v1",
                 "sap.test.cdsrc.sample:package:test-api:v1",
             ];
-            expect(createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+            expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
         });
 
         it("should not create API resource template when the visibility is private", () => {
-            const serviceName = "MyService";
-            const testNamespace = "customer.testNamespace.";
             const model = cds.linked(`
                 namespace customer.testNamespace;
                 service MyService {
@@ -376,8 +373,8 @@ describe("templates", () => {
                 "sap.test.cdsrc.sample:package:test-event:v1",
                 "sap.test.cdsrc.sample:package:test-api:v1",
             ];
-            const srvDefinition = model.definitions[testNamespace + serviceName];
-            expect(createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds)).toEqual([]);
+            const srvDefinition = model.definitions["customer.testNamespace.MyService"];
+            expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toEqual([]);
         });
 
         describe("MCP protocol resource definitions", () => {
@@ -401,7 +398,6 @@ describe("templates", () => {
 
                 const { createAPIResourceTemplate: createAPIResourceTemplateMocked } = require("../../lib/templates");
 
-                const serviceName = "McpService";
                 const model = cds.linked(`
                     service McpService {
                        entity Items {
@@ -415,7 +411,6 @@ describe("templates", () => {
                 const accessStrategies = [{ type: "open" }];
 
                 const apiResourceTemplate = createAPIResourceTemplateMocked(
-                    serviceName,
                     srvDefinition,
                     appConfig,
                     packageIds,
@@ -473,7 +468,6 @@ describe("templates", () => {
 
     describe("ordExtension", () => {
         it('should add apiResources with ORD Extension "visibility=public"', () => {
-            const serviceName = "MyService";
             linkedModel = cds.linked(`
                 @ODM.entityName: 'testOdmEntity'
                 entity MyBooks {
@@ -496,17 +490,16 @@ describe("templates", () => {
                     }
                 };
             `);
-            const srvDefinition = linkedModel.definitions[serviceName];
+            const srvDefinition = linkedModel.definitions["MyService"];
             appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
             const packageIds = ["customer.testNamespace:package:test:v1"];
-            const apiResourceTemplate = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+            const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
 
             expect(apiResourceTemplate).toBeInstanceOf(Array);
             expect(apiResourceTemplate).toMatchSnapshot();
         });
 
         it("should include internal API resources but ensure they appear in a separate package", () => {
-            const serviceName = "MyService";
             linkedModel = cds.linked(`
                 @ODM.entityName: 'testOdmEntity'
                 entity MyBooks {
@@ -528,10 +521,10 @@ describe("templates", () => {
                     }
                 };
             `);
-            const srvDefinition = linkedModel.definitions[serviceName];
+            const srvDefinition = linkedModel.definitions["MyService"];
             appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
             const packageIds = ["customer.testNamespace:package:test:v1"];
-            const apiResourceTemplate = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+            const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
 
             expect(apiResourceTemplate).toBeInstanceOf(Array);
             expect(apiResourceTemplate).toMatchSnapshot();
@@ -539,7 +532,6 @@ describe("templates", () => {
         });
 
         it('should not add apiResources with ORD Extension "visibility=private"', () => {
-            const serviceName = "MyService";
             linkedModel = cds.linked(`
                 @ODM.entityName: 'testOdmEntity'
                 entity MyBooks {
@@ -561,10 +553,10 @@ describe("templates", () => {
                     }
                 };
             `);
-            const srvDefinition = linkedModel.definitions[serviceName];
+            const srvDefinition = linkedModel.definitions["MyService"];
             appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
             const packageIds = ["customer.testNamespace:package:test:v1"];
-            const apiResourceTemplate = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+            const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
 
             expect(apiResourceTemplate).toBeInstanceOf(Array);
             expect(apiResourceTemplate).toMatchSnapshot();
@@ -680,7 +672,6 @@ describe("templates", () => {
         });
 
         it("should find composition and association entities for related service", () => {
-            const serviceName = "MyService";
             linkedModel = cds.linked(`
                 entity AppCustomers {
                     key ID         : String;
@@ -712,16 +703,15 @@ describe("templates", () => {
                     }
                 };
             `);
-            const srvDefinition = linkedModel.definitions[serviceName];
+            const srvDefinition = linkedModel.definitions["MyService"];
             appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
             const packageIds = ["customer.testNamespace:package:test:v1"];
-            const apiResourceTemplate = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+            const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
 
             expect(apiResourceTemplate).toMatchSnapshot();
         });
 
         it("should find association on nested entities for related service", () => {
-            const serviceName = "MyService";
             linkedModel = cds.linked(`
                 entity SecureApps {
                     key ID          : String;
@@ -753,16 +743,15 @@ describe("templates", () => {
                     }
                 };
             `);
-            const srvDefinition = linkedModel.definitions[serviceName];
+            const srvDefinition = linkedModel.definitions["MyService"];
             appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
             const packageIds = ["customer.testNamespace:package:test:v1"];
-            const apiResourceTemplate = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+            const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
 
             expect(apiResourceTemplate).toMatchSnapshot();
         });
 
         it("should find composition on nested entities for related service", () => {
-            const serviceName = "MyService";
             linkedModel = cds.linked(`
                 entity SecureApps {
                     key ID          : String;
@@ -794,16 +783,15 @@ describe("templates", () => {
                     }
                 };
             `);
-            const srvDefinition = linkedModel.definitions[serviceName];
+            const srvDefinition = linkedModel.definitions["MyService"];
             appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
             const packageIds = ["customer.testNamespace:package:test:v1"];
-            const apiResourceTemplate = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+            const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
 
             expect(apiResourceTemplate).toMatchSnapshot();
         });
 
         it("should find ordId on circular relations", () => {
-            const serviceName = "MyService";
             linkedModel = cds.linked(`
                 entity SecureApps {
                     key ID          : String;
@@ -843,10 +831,10 @@ describe("templates", () => {
                     }
                 };
             `);
-            const srvDefinition = linkedModel.definitions[serviceName];
+            const srvDefinition = linkedModel.definitions["MyService"];
             appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
             const packageIds = ["customer.testNamespace:package:test:v1"];
-            const apiResourceTemplate = createAPIResourceTemplate(serviceName, srvDefinition, appConfig, packageIds);
+            const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig, packageIds);
 
             expect(apiResourceTemplate).toMatchSnapshot();
         });

--- a/__tests__/unit/version-suffix-extraction.test.js
+++ b/__tests__/unit/version-suffix-extraction.test.js
@@ -16,12 +16,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
     describe("Positive Test Cases - Valid v<number> patterns", () => {
         test("should handle .v0 suffix correctly", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v0",
+                name: "DataService.v0",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v0",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -36,12 +35,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should handle .v1 suffix correctly", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v1",
+                name: "DataService.v1",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v1",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -56,12 +54,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should handle .v2 suffix correctly", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v2",
+                name: "DataService.v2",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v2",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -76,12 +73,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should handle .v10 suffix correctly", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v10",
+                name: "DataService.v10",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v10",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -96,12 +92,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should handle complex service names with .v1 suffix", () => {
             const serviceDefinition = {
-                name: "sap.test.complex.DataProductService.v1",
+                name: "complex.DataProductService.v1",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "complex.DataProductService.v1",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -118,12 +113,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
     describe("Negative Test Cases - Invalid patterns", () => {
         test("should use current behavior for .v1.1 suffix (invalid pattern)", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v1.1",
+                name: "DataService.v1.1",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v1.1",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -138,12 +132,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should use current behavior for .v1.0 suffix (invalid pattern)", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v1.0",
+                name: "DataService.v1.0",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v1.0",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -158,12 +151,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should use current behavior for .version1 suffix (invalid pattern)", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.version1",
+                name: "DataService.version1",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.version1",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -178,12 +170,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should use current behavior for .beta suffix (invalid pattern)", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.beta",
+                name: "DataService.beta",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.beta",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -198,12 +189,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should use current behavior for .v suffix (invalid pattern)", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v",
+                name: "DataService.v",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -220,12 +210,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
     describe("Edge Case Tests", () => {
         test("should use current behavior for data product service without version suffix", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService",
+                name: "DataService",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -240,12 +229,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should use current behavior for non-data product service with valid version suffix", () => {
             const serviceDefinition = {
-                name: "sap.test.RegularService.v2",
+                name: "RegularService.v2",
                 // No DATA_PRODUCT_ANNOTATION - this is a regular service
             };
 
             const result = createAPIResourceTemplate(
-                "RegularService.v2",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -260,12 +248,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should use current behavior for non-primary data product service", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v2",
+                name: "DataService.v2",
                 [DATA_PRODUCT_ANNOTATION]: "secondary", // Not primary
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v2",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -282,12 +269,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
     describe("Data Product Specific Properties", () => {
         test("should maintain data product specific properties with version extraction", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v2",
+                name: "DataService.v2",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v2",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -308,12 +294,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
     describe("Tests with @data.product annotation", () => {
         test("should handle .v1 suffix correctly with @data.product annotation", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v1",
+                name: "DataService.v1",
                 [DATA_PRODUCT_SIMPLE_ANNOTATION]: true,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v1",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -330,12 +315,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should handle .v2 suffix correctly with @data.product annotation", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v2",
+                name: "DataService.v2",
                 [DATA_PRODUCT_SIMPLE_ANNOTATION]: "yes",
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v2",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -350,12 +334,11 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should use current behavior when @data.product is false", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v2",
+                name: "DataService.v2",
                 [DATA_PRODUCT_SIMPLE_ANNOTATION]: false,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v2",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -370,13 +353,12 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should prioritize @DataIntegration.dataProduct.type over @data.product for version extraction", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v3",
+                name: "DataService.v3",
                 [DATA_PRODUCT_ANNOTATION]: DATA_PRODUCT_TYPE.primary,
                 [DATA_PRODUCT_SIMPLE_ANNOTATION]: false,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v3",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,
@@ -391,13 +373,12 @@ describe("Version Suffix Extraction for Data Product Services", () => {
 
         test("should apply @data.product when @DataIntegration.dataProduct.type is not primary", () => {
             const serviceDefinition = {
-                name: "sap.test.DataService.v2",
+                name: "DataService.v2",
                 [DATA_PRODUCT_ANNOTATION]: "secondary",
                 [DATA_PRODUCT_SIMPLE_ANNOTATION]: true,
             };
 
             const result = createAPIResourceTemplate(
-                "DataService.v2",
                 serviceDefinition,
                 mockAppConfig,
                 mockPackageIds,

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -25,15 +25,9 @@ const _getGroups = (csn, appConfig) => {
 };
 
 const _getAPIResources = (csn, appConfig, packageIds, accessStrategies) => {
-    return appConfig.apiResourceNames.flatMap((apiResourceName) =>
-        createAPIResourceTemplate(
-            apiResourceName,
-            csn.definitions[apiResourceName],
-            appConfig,
-            packageIds,
-            accessStrategies,
-        ),
-    );
+    return appConfig.apiResourceNames
+        .map((name) => csn.definitions[name])
+        .flatMap((definition) => createAPIResourceTemplate(definition, appConfig, packageIds, accessStrategies));
 };
 
 const _getEventResources = (csn, appConfig, packageIds, accessStrategies) => {

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -28,7 +28,7 @@ const _getGroups = (csn, appConfig) => {
 const _getAPIResources = (csn, appConfig, packageIds, accessStrategies) => {
     return appConfig.apiResourceNames
         .map((name) => csn.definitions[name])
-        .flatMap((definition) => createAPIResourceTemplate(definition, appConfig, packageIds, accessStrategies));
+        .flatMap((srvDefinition) => createAPIResourceTemplate(srvDefinition, appConfig, packageIds, accessStrategies));
 };
 
 const _getEventResources = (csn, appConfig, packageIds, accessStrategies) => {

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -279,26 +279,25 @@ function _handleVisibility(ordExtensions, definition, defaultVisibility = RESOUR
  * This is a template function to create API Resource object for API Resource Array.
  * Properties of an API resource can be overwritten by the ORD extensions. Example: visibility.
  * Ensures proper visibility compliance by checking associated EntityTypes.
- * @param {string} serviceName The name of the service.
- * @param {object} serviceDefinition The definition of the service
+ * @param {object} definition The definition of the service
  * @param {object} appConfig - The application configuration.
  * @param {Array} packageIds - The available package identifiers.
  * @param {Array} accessStrategies The array of accessStrategies objects
  * @returns {Array} An array of objects for the API Resources.
  */
-const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, packageIds, accessStrategies) => {
-    const ordExtensions = readORDExtensions(serviceDefinition);
-    const visibility = _handleVisibility(ordExtensions, serviceDefinition, appConfig.env?.defaultVisibility);
+const createAPIResourceTemplate = (definition, appConfig, packageIds, accessStrategies) => {
+    const ordExtensions = readORDExtensions(definition);
+    const visibility = _handleVisibility(ordExtensions, definition, appConfig.env?.defaultVisibility);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.api, visibility);
 
-    const protocolResults = resolveApiResourceProtocol(serviceName, serviceDefinition, {
+    const protocolResults = resolveApiResourceProtocol(definition.name, definition, {
         isPrimaryDataProduct: isPrimaryDataProductService,
     });
     const apiResources = [];
 
     // If no protocols were generated, skip this service
     if (protocolResults.length === 0) {
-        Logger.info(`No supported protocols for service '${serviceName}', skipping API resource generation.`);
+        Logger.info(`No supported protocols for service '${definition.name}', skipping API resource generation.`);
         return apiResources;
     }
 
@@ -307,15 +306,15 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
         version,
         semanticVersion,
         extracted = null;
-    if (isPrimaryDataProductService(serviceDefinition)) {
-        extracted = _extractVersionFromServiceName(serviceDefinition.name);
+    if (isPrimaryDataProductService(definition)) {
+        extracted = _extractVersionFromServiceName(definition.name);
 
-        cleanServiceName = _getCleanServiceName(extracted?.cleanName || serviceDefinition.name, appConfig);
+        cleanServiceName = _getCleanServiceName(extracted?.cleanName || definition.name, appConfig);
         semanticVersion = ordExtensions.version || extracted?.semanticVersion || "1.0.0";
         version = `v${semanticVersion.split(".")[0]}`;
     } else {
         // Non-data product - use current behavior
-        cleanServiceName = _getCleanServiceName(serviceDefinition.name, appConfig);
+        cleanServiceName = _getCleanServiceName(definition.name, appConfig);
         semanticVersion = ordExtensions.version || "1.0.0";
         version = `v${semanticVersion.split(".")[0]}`;
     }
@@ -335,7 +334,7 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
                         "sap-csn-interop-effective-v1",
                         "json",
                         ordId,
-                        serviceName,
+                        definition.name,
                         "csn.json",
                         accessStrategies,
                     ),
@@ -343,7 +342,7 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
             } else if (apiProtocol === ORD_API_PROTOCOL.REST) {
                 // REST only has OpenAPI, no EDMX
                 resourceDefinitions = [
-                    _getResourceDefinition("openapi-v3", "json", ordId, serviceName, "oas3.json", accessStrategies),
+                    _getResourceDefinition("openapi-v3", "json", ordId, definition.name, "oas3.json", accessStrategies),
                 ];
             } else if (apiProtocol === ORD_API_PROTOCOL.MCP) {
                 resourceDefinitions = [
@@ -351,7 +350,7 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
                         MCP_RESOURCE_DEFINITION_TYPE,
                         "json",
                         ordId,
-                        serviceName,
+                        definition.name,
                         "mcp.json",
                         accessStrategies,
                     ),
@@ -362,38 +361,38 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
                     {
                         type: "graphql-sdl",
                         mediaType: "text/plain",
-                        url: `/ord/v1/${ordId}/${serviceName}.graphql`,
+                        url: `/ord/v1/${ordId}/${definition.name}.graphql`,
                         accessStrategies: ensureAccessStrategies(accessStrategies, {
-                            resourceName: `${serviceName} (graphql-sdl)`,
+                            resourceName: `${definition.name} (graphql-sdl)`,
                         }),
                     },
                 ];
             } else if (apiProtocol === ORD_API_PROTOCOL.ODATA_V2) {
                 // openapi-v3 is not supported for OData V2, only EDMX
                 resourceDefinitions = [
-                    _getResourceDefinition("edmx", "xml", ordId, serviceName, "edmx", accessStrategies),
+                    _getResourceDefinition("edmx", "xml", ordId, definition.name, "edmx", accessStrategies),
                 ];
             } else {
                 // odata-v4 and others have both OpenAPI and EDMX
                 resourceDefinitions = [
-                    _getResourceDefinition("openapi-v3", "json", ordId, serviceName, "oas3.json", accessStrategies),
-                    _getResourceDefinition("edmx", "xml", ordId, serviceName, "edmx", accessStrategies),
+                    _getResourceDefinition("openapi-v3", "json", ordId, definition.name, "oas3.json", accessStrategies),
+                    _getResourceDefinition("edmx", "xml", ordId, definition.name, "edmx", accessStrategies),
                 ];
             }
         }
 
-        const exposedEntityTypes = _getExposedEntityTypes(serviceDefinition);
+        const exposedEntityTypes = _getExposedEntityTypes(definition);
 
         let obj = {
             ordId,
-            title: serviceDefinition["@title"] ?? serviceDefinition["@Common.Label"] ?? serviceName,
-            shortDescription: SHORT_DESCRIPTION_PREFIX + serviceName,
-            description: serviceDefinition["@Core.Description"] ?? DESCRIPTION_PREFIX + serviceName,
+            title: definition["@title"] ?? definition["@Common.Label"] ?? definition.name,
+            shortDescription: SHORT_DESCRIPTION_PREFIX + definition.name,
+            description: definition["@Core.Description"] ?? DESCRIPTION_PREFIX + definition.name,
             version: semanticVersion,
             lastUpdate: appConfig.lastUpdate,
             visibility,
             partOfPackage: packageId,
-            partOfGroups: [_getGroupID(serviceDefinition, defaults.groupTypeId, appConfig)],
+            partOfGroups: [_getGroupID(definition, defaults.groupTypeId, appConfig)],
             releaseStatus: "active",
             apiProtocol,
             resourceDefinitions,
@@ -406,7 +405,7 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
         };
 
         // Special handling for data product services
-        if (isPrimaryDataProductService(serviceDefinition)) {
+        if (isPrimaryDataProductService(definition)) {
             obj.direction = "outbound";
             if (extracted) {
                 // Overwrite partOfGroups
@@ -490,7 +489,9 @@ function _getExposedEntityTypes(definitionObj) {
     });
     const exposedEntityTypes = _.uniqBy(entities, CONTENT_MERGE_KEY)
         .filter((entity) => !!entity)
-        .map((entity) => ({ ordId: entity.isODMMapping ? entity.ordId : (entity[`${ORD_EXTENSIONS_PREFIX}ordId`] || entity.ordId) }));
+        .map((entity) => ({
+            ordId: entity.isODMMapping ? entity.ordId : entity[`${ORD_EXTENSIONS_PREFIX}ordId`] || entity.ordId,
+        }));
 
     if (exposedEntityTypes.length > 0) {
         return exposedEntityTypes;

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -273,24 +273,24 @@ function _handleVisibility(ordExtensions, definition, defaultVisibility = RESOUR
  * This is a template function to create API Resource object for API Resource Array.
  * Properties of an API resource can be overwritten by the ORD extensions. Example: visibility.
  * Ensures proper visibility compliance by checking associated EntityTypes.
- * @param {object} definition The definition of the service
+ * @param {object} srvDefinition The definition of the service
  * @param {object} appConfig - The application configuration.
  * @param {Array} packageIds - The available package identifiers.
  * @param {Array} accessStrategies The array of accessStrategies objects
  * @returns {Array} An array of objects for the API Resources.
  */
-const createAPIResourceTemplate = (definition, appConfig, packageIds, accessStrategies) => {
-    const ordExtensions = readORDExtensions(definition);
-    const visibility = _handleVisibility(ordExtensions, definition, appConfig.env?.defaultVisibility);
+const createAPIResourceTemplate = (srvDefinition, appConfig, packageIds, accessStrategies) => {
+    const ordExtensions = readORDExtensions(srvDefinition);
+    const visibility = _handleVisibility(ordExtensions, srvDefinition, appConfig.env?.defaultVisibility);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.api, visibility);
-    const protocolResults = resolveApiResourceProtocol(definition, definition, {
+    const protocolResults = resolveApiResourceProtocol(srvDefinition, {
         isPrimaryDataProduct: isPrimaryDataProductService,
     });
     const apiResources = [];
 
     // If no protocols were generated, skip this service
     if (protocolResults.length === 0) {
-        Logger.info(`No supported protocols for service '${definition.name}', skipping API resource generation.`);
+        Logger.info(`No supported protocols for service '${srvDefinition.name}', skipping API resource generation.`);
         return apiResources;
     }
 
@@ -299,15 +299,15 @@ const createAPIResourceTemplate = (definition, appConfig, packageIds, accessStra
         version,
         semanticVersion,
         extracted = null;
-    if (isPrimaryDataProductService(definition)) {
-        extracted = _extractVersionFromServiceName(definition.name);
+    if (isPrimaryDataProductService(srvDefinition)) {
+        extracted = _extractVersionFromServiceName(srvDefinition.name);
 
-        cleanServiceName = _getCleanServiceName(extracted?.cleanName || definition.name, appConfig);
+        cleanServiceName = _getCleanServiceName(extracted?.cleanName || srvDefinition.name, appConfig);
         semanticVersion = ordExtensions.version || extracted?.semanticVersion || "1.0.0";
         version = `v${semanticVersion.split(".")[0]}`;
     } else {
         // Non-data product - use current behavior
-        cleanServiceName = _getCleanServiceName(definition.name, appConfig);
+        cleanServiceName = _getCleanServiceName(srvDefinition.name, appConfig);
         semanticVersion = ordExtensions.version || "1.0.0";
         version = `v${semanticVersion.split(".")[0]}`;
     }
@@ -327,7 +327,7 @@ const createAPIResourceTemplate = (definition, appConfig, packageIds, accessStra
                         "sap-csn-interop-effective-v1",
                         "json",
                         ordId,
-                        definition.name,
+                        srvDefinition.name,
                         "csn.json",
                         accessStrategies,
                     ),
@@ -335,7 +335,14 @@ const createAPIResourceTemplate = (definition, appConfig, packageIds, accessStra
             } else if (apiProtocol === ORD_API_PROTOCOL.REST) {
                 // REST only has OpenAPI, no EDMX
                 resourceDefinitions = [
-                    _getResourceDefinition("openapi-v3", "json", ordId, definition.name, "oas3.json", accessStrategies),
+                    _getResourceDefinition(
+                        "openapi-v3",
+                        "json",
+                        ordId,
+                        srvDefinition.name,
+                        "oas3.json",
+                        accessStrategies,
+                    ),
                 ];
             } else if (apiProtocol === ORD_API_PROTOCOL.MCP) {
                 resourceDefinitions = [
@@ -343,7 +350,7 @@ const createAPIResourceTemplate = (definition, appConfig, packageIds, accessStra
                         MCP_RESOURCE_DEFINITION_TYPE,
                         "json",
                         ordId,
-                        definition.name,
+                        srvDefinition.name,
                         "mcp.json",
                         accessStrategies,
                     ),
@@ -354,38 +361,49 @@ const createAPIResourceTemplate = (definition, appConfig, packageIds, accessStra
                     {
                         type: "graphql-sdl",
                         mediaType: "text/plain",
-                        url: `/ord/v1/${ordId}/${definition.name}.graphql`,
+                        url: `/ord/v1/${ordId}/${srvDefinition.name}.graphql`,
                         accessStrategies: ensureAccessStrategies(accessStrategies, {
-                            resourceName: `${definition.name} (graphql-sdl)`,
+                            resourceName: `${srvDefinition.name} (graphql-sdl)`,
                         }),
                     },
                 ];
             } else if (apiProtocol === ORD_API_PROTOCOL.ODATA_V2) {
                 // openapi-v3 is not supported for OData V2, only EDMX
                 resourceDefinitions = [
-                    _getResourceDefinition("edmx", "xml", ordId, definition.name, "edmx", accessStrategies),
+                    _getResourceDefinition("edmx", "xml", ordId, srvDefinition.name, "edmx", accessStrategies),
                 ];
             } else {
                 // odata-v4 and others have both OpenAPI and EDMX
                 resourceDefinitions = [
-                    _getResourceDefinition("openapi-v3", "json", ordId, definition.name, "oas3.json", accessStrategies),
-                    _getResourceDefinition("edmx", "xml", ordId, definition.name, "edmx", accessStrategies),
+                    _getResourceDefinition(
+                        "openapi-v3",
+                        "json",
+                        ordId,
+                        srvDefinition.name,
+                        "oas3.json",
+                        accessStrategies,
+                    ),
+                    _getResourceDefinition("edmx", "xml", ordId, srvDefinition.name, "edmx", accessStrategies),
                 ];
             }
         }
 
-        const exposedEntityTypes = _getExposedEntityTypes(definition);
+        const exposedEntityTypes = _getExposedEntityTypes(srvDefinition);
 
         let obj = {
             ordId,
-            title: definition["@title"] ?? definition["@Common.Label"] ?? definition["@EndUserText.label"] ?? definition.name,
-            shortDescription: SHORT_DESCRIPTION_PREFIX + definition.name,
-            description: definition["@Core.Description"] ?? DESCRIPTION_PREFIX + definition.name,
+            title:
+                srvDefinition["@title"] ??
+                srvDefinition["@Common.Label"] ??
+                srvDefinition["@EndUserText.label"] ??
+                srvDefinition.name,
+            shortDescription: SHORT_DESCRIPTION_PREFIX + srvDefinition.name,
+            description: srvDefinition["@Core.Description"] ?? DESCRIPTION_PREFIX + srvDefinition.name,
             version: semanticVersion,
             lastUpdate: appConfig.lastUpdate,
             visibility,
             partOfPackage: packageId,
-            partOfGroups: [_getGroupID(appConfig, definition)],
+            partOfGroups: [_getGroupID(appConfig, srvDefinition)],
             releaseStatus: "active",
             apiProtocol,
             resourceDefinitions,
@@ -398,7 +416,7 @@ const createAPIResourceTemplate = (definition, appConfig, packageIds, accessStra
         };
 
         // Special handling for data product services
-        if (isPrimaryDataProductService(definition)) {
+        if (isPrimaryDataProductService(srvDefinition)) {
             obj.direction = "outbound";
             if (extracted) {
                 // Overwrite partOfGroups


### PR DESCRIPTION
# Remove Redundant `serviceName` Argument from `createAPIResourceTemplate`

### Refactor

♻️ Removed the redundant `serviceName` string parameter from `createAPIResourceTemplate` in favor of deriving the service name directly from the `definition.name` property already available on the service definition object. This eliminates a duplicated data argument and makes the function signature cleaner and more consistent.

### Changes

* `lib/templates.js`: Removed `serviceName` as the first parameter of `createAPIResourceTemplate`. All internal usages of `serviceName` have been replaced with `definition.name`. Updated JSDoc accordingly. Also minor reformatting of a `.map()` callback in `_getExposedEntityTypes`.
* `lib/ord.js`: Updated `_getAPIResources` to map API resource names to their definitions first, then pass each definition directly to `createAPIResourceTemplate` (without the name argument).
* `__tests__/unit/templates.test.js`: Updated all `createAPIResourceTemplate` call sites to remove the `serviceName` argument and inline service name lookups where needed.
* `__tests__/unit/namespace.test.js`: Removed redundant `serviceName` and `testNamespace` local variables; call `createAPIResourceTemplate` without the name argument. Also updated `createEventResourceTemplate` calls to use `srvDefinition.name`.
* `__tests__/unit/ord-visibility-split.test.js`: Removed standalone `serviceName` variables and updated `createAPIResourceTemplate` calls to the new signature.
* `__tests__/unit/version-suffix-extraction.test.js`: Removed the first `serviceName` argument from all `createAPIResourceTemplate` calls. Service definition `name` fields simplified to no longer include the namespace prefix (since the name is read from the definition object directly).
* `__tests__/unit/__snapshots__/namespace.test.js.snap`: Updated snapshots to reflect that `description`, `shortDescription`, `title`, and resource definition URLs now correctly use the full namespaced service name (e.g., `other.namespace.MyService`) instead of the bare short name (`MyService`).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `7ec4d67a-8550-4769-86db-fd54fdbc31c2`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
</details>
