### PR TITLE
chore: Remove redundant service name arg from 'resolveApiResourceProtocol'

### DIFF
--- a/__tests__/unit/protocol-resolver.test.js
+++ b/__tests__/unit/protocol-resolver.test.js
@@ -45,7 +45,7 @@ describe("protocol-resolver", () => {
                 }
             `);
             const srvDefinition = model.definitions["MyService"];
-            const result = resolveApiResourceProtocol("MyService", srvDefinition, {
+            const result = resolveApiResourceProtocol(srvDefinition, {
                 isPrimaryDataProduct: isPrimaryDataProductService,
             });
 
@@ -60,7 +60,7 @@ describe("protocol-resolver", () => {
                 "name": "MyService",
                 "@protocol": "unknown-protocol",
             };
-            const result = resolveApiResourceProtocol("MyService", srvDefinition, {
+            const result = resolveApiResourceProtocol(srvDefinition, {
                 isPrimaryDataProduct: isPrimaryDataProductService,
             });
 
@@ -75,7 +75,7 @@ describe("protocol-resolver", () => {
                 "name": "INAService",
                 "@protocol": "ina",
             };
-            const result = resolveApiResourceProtocol("INAService", srvDefinition, {
+            const result = resolveApiResourceProtocol(srvDefinition, {
                 isPrimaryDataProduct: isPrimaryDataProductService,
             });
 
@@ -90,7 +90,7 @@ describe("protocol-resolver", () => {
                 "name": "GraphQLService",
                 "@protocol": "graphql",
             };
-            const result = resolveApiResourceProtocol("GraphQLService", srvDefinition, {
+            const result = resolveApiResourceProtocol(srvDefinition, {
                 isPrimaryDataProduct: isPrimaryDataProductService,
             });
 
@@ -103,7 +103,7 @@ describe("protocol-resolver", () => {
                 "name": "DataProductService",
                 "@DataIntegration.dataProduct.type": "primary",
             };
-            const result = resolveApiResourceProtocol("DataProductService", srvDefinition, {
+            const result = resolveApiResourceProtocol(srvDefinition, {
                 isPrimaryDataProduct: isPrimaryDataProductService,
             });
 
@@ -121,7 +121,7 @@ describe("protocol-resolver", () => {
             ];
 
             testCases.forEach((srvDefinition) => {
-                const result = resolveApiResourceProtocol(srvDefinition.name, srvDefinition, {
+                const result = resolveApiResourceProtocol(srvDefinition, {
                     isPrimaryDataProduct: isPrimaryDataProductService,
                 });
                 result.forEach((r) => {
@@ -136,7 +136,7 @@ describe("protocol-resolver", () => {
                 "name": "CustomService",
                 "@protocol": "custom-protocol",
             };
-            const result = resolveApiResourceProtocol("CustomService", srvDefinition, {
+            const result = resolveApiResourceProtocol(srvDefinition, {
                 isPrimaryDataProduct: isPrimaryDataProductService,
             });
 
@@ -152,7 +152,7 @@ describe("protocol-resolver", () => {
                 }
             `);
             const srvDefinition = model.definitions["DefaultService"];
-            const result = resolveApiResourceProtocol("DefaultService", srvDefinition, {
+            const result = resolveApiResourceProtocol(srvDefinition, {
                 isPrimaryDataProduct: isPrimaryDataProductService,
             });
 
@@ -168,7 +168,7 @@ describe("protocol-resolver", () => {
                 }
             `);
             const srvDefinition = model.definitions["MyService"];
-            const result = resolveApiResourceProtocol("MultiProtocolService", srvDefinition, {
+            const result = resolveApiResourceProtocol(srvDefinition, {
                 isPrimaryDataProduct: isPrimaryDataProductService,
             });
 
@@ -186,7 +186,7 @@ describe("protocol-resolver", () => {
                 }
             `);
             const srvDefinition = model.definitions["MyService"];
-            const result = resolveApiResourceProtocol("MixedProtocolService", srvDefinition, {
+            const result = resolveApiResourceProtocol(srvDefinition, {
                 isPrimaryDataProduct: isPrimaryDataProductService,
             });
 
@@ -208,7 +208,7 @@ describe("protocol-resolver", () => {
                 }
             `);
             const srvDefinition = model.definitions["MyService"];
-            const result = resolveApiResourceProtocol("ComplexService", srvDefinition, {
+            const result = resolveApiResourceProtocol(srvDefinition, {
                 isPrimaryDataProduct: isPrimaryDataProductService,
             });
             expect(result).toHaveLength(2);
@@ -236,7 +236,7 @@ describe("protocol-resolver", () => {
                     }
                 `);
                 const srvDefinition = model.definitions["GraphQLService"];
-                const result = resolveApiResourceProtocol("GraphQLService", srvDefinition, {
+                const result = resolveApiResourceProtocol(srvDefinition, {
                     isPrimaryDataProduct: isPrimaryDataProductService,
                 });
 
@@ -254,7 +254,7 @@ describe("protocol-resolver", () => {
                     }
                 `);
                 const srvDefinition = model.definitions["MyService"];
-                const result = resolveApiResourceProtocol("MixedProtocolService", srvDefinition, {
+                const result = resolveApiResourceProtocol(srvDefinition, {
                     isPrimaryDataProduct: isPrimaryDataProductService,
                 });
 
@@ -275,7 +275,7 @@ describe("protocol-resolver", () => {
                     }
                 `);
                 const srvDefinition = model.definitions["MyService"];
-                const result = resolveApiResourceProtocol("ComplexService", srvDefinition, {
+                const result = resolveApiResourceProtocol(srvDefinition, {
                     isPrimaryDataProduct: isPrimaryDataProductService,
                 });
                 expect(result).toHaveLength(3);

--- a/lib/protocol-resolver.js
+++ b/lib/protocol-resolver.js
@@ -30,16 +30,16 @@ function _getExplicitProtocol(srvDefinition) {
  * - Rule B: Only fallback to OData when no explicit protocol
  * - Rule C: Never produce [null] in entryPoints
  *
- * @param {Object} definition The service definition object.
+ * @param {Object} srvDefinition The service definition object.
  * @param {Object} options Configuration options.
  * @param {Function} options.isPrimaryDataProduct Strategy function to check if service is primary data product.
  * @returns {Array} Array with single {apiProtocol, entryPoints, hasResourceDefinitions} object, or empty array.
  */
-function resolveApiResourceProtocol(definition, options = {}) {
+function resolveApiResourceProtocol(srvDefinition, options = {}) {
     const { isPrimaryDataProduct = () => false } = options;
 
     // 1. Primary Data Product - early return
-    if (isPrimaryDataProduct(definition)) {
+    if (isPrimaryDataProduct(srvDefinition)) {
         return [
             {
                 apiProtocol: ORD_API_PROTOCOL.SAP_DATA_SUBSCRIPTION,
@@ -49,7 +49,7 @@ function resolveApiResourceProtocol(definition, options = {}) {
         ];
     }
 
-    const capEndpoints = cds.service.protocols.endpoints4({ name: definition.name, definition });
+    const capEndpoints = cds.service.protocols.endpoints4({ name: srvDefinition.name, definition: srvDefinition });
     const ordProtocols = [];
     for (const endpoint of capEndpoints) {
         if (PLUGIN_UNSUPPORTED_PROTOCOLS.includes(endpoint.kind)) {
@@ -69,13 +69,13 @@ function resolveApiResourceProtocol(definition, options = {}) {
         }
     }
 
-    const explicit = _getExplicitProtocol(definition);
+    const explicit = _getExplicitProtocol(srvDefinition);
     for (const protocol of explicit) {
         // 2. Handle explicit protocol
         // 2a. Check if it's an ORD-only protocol (e.g., INA)
         if (ORD_ONLY_PROTOCOLS[protocol]) {
             const config = ORD_ONLY_PROTOCOLS[protocol];
-            const path = config.hasEntryPoints ? cds.service.protocols.path4(definition) : null;
+            const path = config.hasEntryPoints ? cds.service.protocols.path4(srvDefinition) : null;
             ordProtocols.push({
                 apiProtocol: config.apiProtocol,
                 entryPoints: path ? [path] : [],
@@ -94,7 +94,7 @@ function resolveApiResourceProtocol(definition, options = {}) {
 
         // 4. Handle explicit protocol with no CAP endpoint (Rule A)
         if (!ordProtocols.some((p) => p.apiProtocol === protocol) && !CAP_TO_ORD_PROTOCOL_MAP[protocol]) {
-            Logger.warn(`Unknown protocol '${protocol}' is not supported, and skipped for service '${definition.name}'.`);
+            Logger.warn(`Unknown protocol '${protocol}' is not supported, and skipped for service '${srvDefinition.name}'.`);
         }
     }
 
@@ -108,7 +108,7 @@ function resolveApiResourceProtocol(definition, options = {}) {
     }
 
     // 5. No explicit protocol and no CAP endpoint - fallback to OData (Rule B)
-    const path = cds.service.protocols.path4(definition);
+    const path = cds.service.protocols.path4(srvDefinition);
     return [
         {
             apiProtocol: ORD_API_PROTOCOL.ODATA_V4,

--- a/lib/protocol-resolver.js
+++ b/lib/protocol-resolver.js
@@ -8,18 +8,6 @@ const {
 const Logger = require("./logger");
 
 /**
- * Gets CAP endpoints for a service using CDS endpoints4().
- *
- * @param {string} serviceName The service name.
- * @param {Object} srvDefinition The service definition object.
- * @returns {Array} Raw endpoints from CDS.
- */
-function _getCapEndpoints(serviceName, srvDefinition) {
-    const srvObj = { name: serviceName, definition: srvDefinition };
-    return cds.service.protocols.endpoints4(srvObj);
-}
-
-/**
  * Reads the explicit @protocol annotation from service definition.
  *
  * @param {Object} srvDefinition The service definition object.
@@ -42,17 +30,16 @@ function _getExplicitProtocol(srvDefinition) {
  * - Rule B: Only fallback to OData when no explicit protocol
  * - Rule C: Never produce [null] in entryPoints
  *
- * @param {string} serviceName The service name.
- * @param {Object} srvDefinition The service definition object.
+ * @param {Object} definition The service definition object.
  * @param {Object} options Configuration options.
  * @param {Function} options.isPrimaryDataProduct Strategy function to check if service is primary data product.
  * @returns {Array} Array with single {apiProtocol, entryPoints, hasResourceDefinitions} object, or empty array.
  */
-function resolveApiResourceProtocol(serviceName, srvDefinition, options = {}) {
+function resolveApiResourceProtocol(definition, options = {}) {
     const { isPrimaryDataProduct = () => false } = options;
 
     // 1. Primary Data Product - early return
-    if (isPrimaryDataProduct(srvDefinition)) {
+    if (isPrimaryDataProduct(definition)) {
         return [
             {
                 apiProtocol: ORD_API_PROTOCOL.SAP_DATA_SUBSCRIPTION,
@@ -62,7 +49,7 @@ function resolveApiResourceProtocol(serviceName, srvDefinition, options = {}) {
         ];
     }
 
-    const capEndpoints = _getCapEndpoints(serviceName, srvDefinition);
+    const capEndpoints = cds.service.protocols.endpoints4({ name: definition.name, definition });
     const ordProtocols = [];
     for (const endpoint of capEndpoints) {
         if (PLUGIN_UNSUPPORTED_PROTOCOLS.includes(endpoint.kind)) {
@@ -82,13 +69,13 @@ function resolveApiResourceProtocol(serviceName, srvDefinition, options = {}) {
         }
     }
 
-    const explicit = _getExplicitProtocol(srvDefinition);
+    const explicit = _getExplicitProtocol(definition);
     for (const protocol of explicit) {
         // 2. Handle explicit protocol
         // 2a. Check if it's an ORD-only protocol (e.g., INA)
         if (ORD_ONLY_PROTOCOLS[protocol]) {
             const config = ORD_ONLY_PROTOCOLS[protocol];
-            const path = config.hasEntryPoints ? cds.service.protocols.path4(srvDefinition) : null;
+            const path = config.hasEntryPoints ? cds.service.protocols.path4(definition) : null;
             ordProtocols.push({
                 apiProtocol: config.apiProtocol,
                 entryPoints: path ? [path] : [],
@@ -107,7 +94,7 @@ function resolveApiResourceProtocol(serviceName, srvDefinition, options = {}) {
 
         // 4. Handle explicit protocol with no CAP endpoint (Rule A)
         if (!ordProtocols.some((p) => p.apiProtocol === protocol) && !CAP_TO_ORD_PROTOCOL_MAP[protocol]) {
-            Logger.warn(`Unknown protocol '${protocol}' is not supported, and skipped for service '${serviceName}'.`);
+            Logger.warn(`Unknown protocol '${protocol}' is not supported, and skipped for service '${definition.name}'.`);
         }
     }
 
@@ -121,7 +108,7 @@ function resolveApiResourceProtocol(serviceName, srvDefinition, options = {}) {
     }
 
     // 5. No explicit protocol and no CAP endpoint - fallback to OData (Rule B)
-    const path = cds.service.protocols.path4(srvDefinition);
+    const path = cds.service.protocols.path4(definition);
     return [
         {
             apiProtocol: ORD_API_PROTOCOL.ODATA_V4,

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -291,7 +291,7 @@ const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, pa
     const visibility = _handleVisibility(ordExtensions, serviceDefinition, appConfig.env?.defaultVisibility);
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.api, visibility);
 
-    const protocolResults = resolveApiResourceProtocol(serviceName, serviceDefinition, {
+    const protocolResults = resolveApiResourceProtocol(serviceDefinition, {
         isPrimaryDataProduct: isPrimaryDataProductService,
     });
     const apiResources = [];

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -113,7 +113,7 @@ Priority Order (highest to lowest):
 const createAPIResourceTemplate = (serviceName, serviceDefinition, appConfig, packageIds, accessStrategies) => {
     const ordExtensions = readORDExtensions(serviceDefinition); // reads @ORD.Extensions.*
     const visibility = _handleVisibility(ordExtensions, serviceDefinition, appConfig.env?.defaultVisibility);
-    const protocolResults = resolveApiResourceProtocol(serviceName, serviceDefinition, options);
+    const protocolResults = resolveApiResourceProtocol(serviceDefinition, options);
     // build one resource object per protocol result
     // spread ordExtensions last to allow annotation overrides
     return apiResources;


### PR DESCRIPTION
# Remove Redundant `serviceName` Argument from `resolveApiResourceProtocol`

### Refactor

♻️ Removed the redundant `serviceName` parameter from the `resolveApiResourceProtocol` function signature. Since the service name is already accessible via `definition.name`, passing it as a separate argument was unnecessary duplication.

### Changes

* `lib/protocol-resolver.js`: Removed the `serviceName` parameter from `resolveApiResourceProtocol` and the internal `_getCapEndpoints` helper function. The function now accepts `(definition, options)` instead of `(serviceName, srvDefinition, options)`. References to `serviceName` are replaced with `definition.name`, and `srvDefinition` is replaced with `definition` throughout the function body. The `_getCapEndpoints` helper was also inlined.
* `lib/templates.js`: Updated the call site of `resolveApiResourceProtocol` to drop the `serviceName` argument.
* `__tests__/unit/protocol-resolver.test.js`: Updated all test calls to `resolveApiResourceProtocol` to use the new two-argument signature `(srvDefinition, options)`.
* `memory-bank/systemPatterns.md`: Updated the documented code snippet to reflect the new function signature.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Correlation ID: `60f7969f-0c3f-48fc-9b91-2bedabfce779`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
