### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.8.0 (2026-05-15)
+
+## What's Changed
+
+- chore: Remove generation of default consumption bundle by @mlakov in https://github.com/cap-js/ord/pull/431
+- fix: Correctly generate exposed entity types when '@ORD.Extensions.ordId' is used on entity by @mlakov in https://github.com/cap-js/ord/pull/436
+- fix: Improve generation of API resource ORD IDs when '@ORD.Extensions.version' is specified by @mlakov in https://github.com/cap-js/ord/pull/437
+- fix: Improve generation of entity type ORD IDs when '@ORD.Extensions.version' is specified by @mlakov in https://github.com/cap-js/ord/pull/438
+- fix: Improve generation of event resource ORD IDs when '@ORD.Extensions.version' is specified by @mlakov in https://github.com/cap-js/ord/pull/439
+- fix: Improve generation of integration dependency ORD ID when version is overridden via .cdsrc.json/package.json by @mlakov in https://github.com/cap-js/ord/pull/440
+- fix: Correctly generate resource definition URLs when '@ORD.Extensions.ordId' is used by @mlakov in https://github.com/cap-js/ord/pull/435
+- feat: Consider annotation '@EndUserText.label' when resolving ORD entity titles by @mlakov in https://github.com/cap-js/ord/pull/442
+- fix: Correctly generate API resources for multi-protocol CDS services by @mlakov in https://github.com/cap-js/ord/pull/445
+- chore: Remove redundant service name arg from 'createGroupsTemplateForService' by @mlakov in https://github.com/cap-js/ord/pull/446
+- chore: Remove redundant group type id arg from '_getGroupID' by @mlakov in https://github.com/cap-js/ord/pull/447
+- chore: Remove redundant service name arg from 'createAPIResourceTemplate' by @mlakov in https://github.com/cap-js/ord/pull/448
+- chore: Remove redundant service name arg from 'createEventResourceTemplate' by @mlakov in https://github.com/cap-js/ord/pull/449
+- chore: Remove redundant service name arg from 'resolveApiResourceProtocol' by @mlakov in https://github.com/cap-js/ord/pull/450
+- Update dependency express to v5 by @rennovate in https://github.com/cap-js/ord/pull/451
+- Update Node.js to v24 by @rennovate in https://github.com/cap-js/ord/pull/452
+
+**Full Changelog**: https://github.com/cap-js/ord/compare/v1.7.0...v1.8.0
+
 ## 1.7.0 (2026-05-12)
 
 ## What's Changed
@@ -22,7 +45,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - fix: Only register well-known compile targets by @mlakov in https://github.com/cap-js/ord/pull/428
 
 **Full Changelog**: https://github.com/cap-js/ord/compare/v1.6.0...v1.7.0
-
 
 ## 1.6.0 (2026-04-30)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cap-js/ord",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "description": "CAP Plugin for generating ORD document.",
     "repository": "cap-js/ord",
     "author": "SAP SE (https://www.sap.com)",


### PR DESCRIPTION
# Release v1.8.0

🔧 **Chore**: Bumps the package version to `1.8.0` and updates the changelog with all changes included in this release.

### Changes

* `package.json`: Version bumped from `1.7.0` to `1.8.0`.
* `CHANGELOG.md`: Added release notes for `v1.8.0` (2026-05-15), summarizing all merged pull requests since `v1.7.0`.

### What's Included in v1.8.0

**Bug Fixes 🐛**
- Correctly generate exposed entity types when `@ORD.Extensions.ordId` is used on an entity.
- Improve generation of API resource, entity type, and event resource ORD IDs when `@ORD.Extensions.version` is specified.
- Improve generation of integration dependency ORD ID when version is overridden via `.cdsrc.json`/`package.json`.
- Correctly generate resource definition URLs when `@ORD.Extensions.ordId` is used.
- Correctly generate API resources for multi-protocol CDS services.

**New Features ✨**
- Consider annotation `@EndUserText.label` when resolving ORD entity titles.

**Chores 🔧**
- Remove generation of default consumption bundle.
- Remove redundant arguments from several internal functions (`createGroupsTemplateForService`, `_getGroupID`, `createAPIResourceTemplate`, `createEventResourceTemplate`, `resolveApiResourceProtocol`).
- Update dependency `express` to v5.
- Update Node.js to v24.

**Full Changelog**: https://github.com/cap-js/ord/compare/v1.7.0...v1.8.0

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `6717331e-49ec-44c2-906b-d7a9ea131ec0`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
