### PR TITLE
feat: Add support for access strategy 'sap.businesshub:mtls:v1'

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This will output something like `admin:$2y$05$...` - use only the hash part (sta
 
 #### CF mTLS Authentication
 
-Configure Cloud Foundry mutual TLS authentication for SAP BTP Cloud Foundry environments.
+Configure Cloud Foundry mutual TLS authentication for SAP BTP Cloud Foundry environments. Possible values include 'sap:cmp-mtls:v1' and 'sap.businesshub:mtls:v1'.
 
 **Production Configuration with UCL (Recommended)**
 
@@ -135,7 +135,7 @@ For SAP UCL (Unified Customer Landscape) integration, enable mTLS in `.cdsrc.jso
 export CF_MTLS_TRUSTED_CERTS='{
   "configEndpoints": ["https://your-ucl-endpoint/v1/info"],
   "rootCaDn": ["CN=SAP Cloud Root CA,O=SAP SE,L=Walldorf,C=DE"],
-  "accessStrategies": ["sap:cmp-mtls:v1"]
+  "accessStrategies": ["sap:cmp-mtls:v1", "sap.businesshub:mtls:v1"]
 }'
 ```
 
@@ -148,7 +148,7 @@ For custom certificates without UCL:
 export CF_MTLS_TRUSTED_CERTS='{
   "certs": [{"issuer": "CN=My CA,O=MyOrg", "subject": "CN=my-service,O=MyOrg"}],
   "rootCaDn": ["CN=My Root CA,O=MyOrg"],
-  "accessStrategies": ["sap:cmp-mtls:v1"]
+  "accessStrategies": ["sap:cmp-mtls:v1", "sap.businesshub:mtls:v1"]
 }'
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,11 @@ For SAP UCL (Unified Customer Landscape) integration, enable mTLS in `.cdsrc.jso
 ```
 
 ```bash
+# Example configuration of the CF_MTLS_TRUSTED_CERTS environment variable
 export CF_MTLS_TRUSTED_CERTS='{
   "configEndpoints": ["https://your-ucl-endpoint/v1/info"],
-  "rootCaDn": ["CN=SAP Cloud Root CA,O=SAP SE,L=Walldorf,C=DE"]
+  "rootCaDn": ["CN=SAP Cloud Root CA,O=SAP SE,L=Walldorf,C=DE"],
+  "accessStrategies": ["sap:cmp-mtls:v1"]
 }'
 ```
 
@@ -142,9 +144,11 @@ export CF_MTLS_TRUSTED_CERTS='{
 For custom certificates without UCL:
 
 ```bash
+# Example configuration of the CF_MTLS_TRUSTED_CERTS environment variable
 export CF_MTLS_TRUSTED_CERTS='{
   "certs": [{"issuer": "CN=My CA,O=MyOrg", "subject": "CN=my-service,O=MyOrg"}],
-  "rootCaDn": ["CN=My Root CA,O=MyOrg"]
+  "rootCaDn": ["CN=My Root CA,O=MyOrg"],
+  "accessStrategies": ["sap:cmp-mtls:v1"]
 }'
 ```
 
@@ -157,13 +161,14 @@ For local development, configure the full mTLS settings directly in `.cdsrc.json
     "ord": {
         "authentication": {
             "cfMtls": {
+                "rootCaDn": ["CN=Test Root CA,O=MyOrg,C=DE"],
+                "accessStrategies": ["sap:cmp-mtls:v1","sap.businesshub:mtls:v1"],
                 "certs": [
                     {
                         "issuer": "CN=Test CA,O=MyOrg,C=DE",
                         "subject": "CN=test-client,O=MyOrg,C=DE"
                     }
-                ],
-                "rootCaDn": ["CN=Test Root CA,O=MyOrg,C=DE"]
+                ]
             }
         }
     }

--- a/__tests__/integration/__snapshots__/mtls-auth.test.js.snap
+++ b/__tests__/integration/__snapshots__/mtls-auth.test.js.snap
@@ -26,6 +26,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
             {
               "type": "sap:cmp-mtls:v1",
             },
+            {
+              "type": "sap.businesshub:mtls:v1",
+            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -35,6 +38,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -69,6 +75,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
             {
               "type": "sap:cmp-mtls:v1",
             },
+            {
+              "type": "sap.businesshub:mtls:v1",
+            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -78,6 +87,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -111,6 +123,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -146,6 +161,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -261,6 +279,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
             {
               "type": "sap:cmp-mtls:v1",
             },
+            {
+              "type": "sap.businesshub:mtls:v1",
+            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -270,6 +291,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -304,6 +328,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
             {
               "type": "sap:cmp-mtls:v1",
             },
+            {
+              "type": "sap.businesshub:mtls:v1",
+            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -313,6 +340,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -346,6 +376,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -381,6 +414,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -479,6 +515,9 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           {
             "type": "sap:cmp-mtls:v1",
           },
+          {
+            "type": "sap.businesshub:mtls:v1",
+          },
         ],
         "perspective": "system-version",
         "url": "/ord/v1/documents/ord-document",
@@ -511,6 +550,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) ORD Documen
         {
           "type": "sap:cmp-mtls:v1",
         },
+        {
+          "type": "sap.businesshub:mtls:v1",
+        },
       ],
       "mediaType": "application/json",
       "type": "openapi-v3",
@@ -520,6 +562,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) ORD Documen
       "accessStrategies": [
         {
           "type": "sap:cmp-mtls:v1",
+        },
+        {
+          "type": "sap.businesshub:mtls:v1",
         },
       ],
       "mediaType": "application/xml",
@@ -557,6 +602,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) ORD Documen
         {
           "type": "sap:cmp-mtls:v1",
         },
+        {
+          "type": "sap.businesshub:mtls:v1",
+        },
       ],
       "mediaType": "application/json",
       "type": "openapi-v3",
@@ -566,6 +614,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) ORD Documen
       "accessStrategies": [
         {
           "type": "sap:cmp-mtls:v1",
+        },
+        {
+          "type": "sap.businesshub:mtls:v1",
         },
       ],
       "mediaType": "application/xml",
@@ -606,6 +657,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) Production 
             {
               "type": "sap:cmp-mtls:v1",
             },
+            {
+              "type": "sap.businesshub:mtls:v1",
+            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -615,6 +669,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) Production 
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -649,6 +706,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) Production 
             {
               "type": "sap:cmp-mtls:v1",
             },
+            {
+              "type": "sap.businesshub:mtls:v1",
+            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -658,6 +718,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) Production 
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -691,6 +754,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) Production 
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -726,6 +792,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) Production 
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -841,6 +910,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
             {
               "type": "sap:cmp-mtls:v1",
             },
+            {
+              "type": "sap.businesshub:mtls:v1",
+            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -850,6 +922,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -884,6 +959,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
             {
               "type": "sap:cmp-mtls:v1",
             },
+            {
+              "type": "sap.businesshub:mtls:v1",
+            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -893,6 +971,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -926,6 +1007,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -961,6 +1045,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
+            },
+            {
+              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -1059,6 +1146,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
           {
             "type": "sap:cmp-mtls:v1",
           },
+          {
+            "type": "sap.businesshub:mtls:v1",
+          },
         ],
         "perspective": "system-version",
         "url": "/ord/v1/documents/ord-document",
@@ -1067,6 +1157,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
         "accessStrategies": [
           {
             "type": "sap:cmp-mtls:v1",
+          },
+          {
+            "type": "sap.businesshub:mtls:v1",
           },
         ],
         "perspective": "system-instance",
@@ -1085,6 +1178,9 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
         "accessStrategies": [
           {
             "type": "sap:cmp-mtls:v1",
+          },
+          {
+            "type": "sap.businesshub:mtls:v1",
           },
         ],
         "perspective": "system-version",

--- a/__tests__/integration/__snapshots__/mtls-auth.test.js.snap
+++ b/__tests__/integration/__snapshots__/mtls-auth.test.js.snap
@@ -26,9 +26,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
             {
               "type": "sap:cmp-mtls:v1",
             },
-            {
-              "type": "sap.businesshub:mtls:v1",
-            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -38,9 +35,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
-            },
-            {
-              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -75,9 +69,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
             {
               "type": "sap:cmp-mtls:v1",
             },
-            {
-              "type": "sap.businesshub:mtls:v1",
-            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -87,9 +78,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
-            },
-            {
-              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -123,9 +111,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
-            },
-            {
-              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -161,9 +146,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
-            },
-            {
-              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -279,9 +261,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
             {
               "type": "sap:cmp-mtls:v1",
             },
-            {
-              "type": "sap.businesshub:mtls:v1",
-            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -291,9 +270,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
-            },
-            {
-              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -328,9 +304,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
             {
               "type": "sap:cmp-mtls:v1",
             },
-            {
-              "type": "sap.businesshub:mtls:v1",
-            },
           ],
           "mediaType": "application/json",
           "type": "openapi-v3",
@@ -340,9 +313,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
-            },
-            {
-              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/xml",
@@ -376,9 +346,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
-            },
-            {
-              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -414,9 +381,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
           "accessStrategies": [
             {
               "type": "sap:cmp-mtls:v1",
-            },
-            {
-              "type": "sap.businesshub:mtls:v1",
             },
           ],
           "mediaType": "application/json",
@@ -514,9 +478,6 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
         "accessStrategies": [
           {
             "type": "sap:cmp-mtls:v1",
-          },
-          {
-            "type": "sap.businesshub:mtls:v1",
           },
         ],
         "perspective": "system-version",

--- a/__tests__/integration/basic-auth.test.js
+++ b/__tests__/integration/basic-auth.test.js
@@ -3,6 +3,7 @@ const { spawn } = require("child_process");
 const path = require("path");
 
 const utils = require("../utils");
+const { ORD_ACCESS_STRATEGY } = require("../../lib/constants");
 
 const BASE_URL = "http://localhost:4004";
 const ORD_CONFIG_ENDPOINT = "/.well-known/open-resource-discovery";
@@ -132,7 +133,7 @@ describe("ORD Integration Tests - Basic Authentication", () => {
                     documents: [
                         {
                             url: "/ord/v1/documents/ord-document",
-                            accessStrategies: [{ type: "basic-auth" }],
+                            accessStrategies: [{ type: ORD_ACCESS_STRATEGY.Basic }],
                             perspective: "system-version",
                         },
                     ],
@@ -312,23 +313,25 @@ describe("ORD Integration Tests - Basic Authentication", () => {
             // Verify API resources have 'basic-auth' accessStrategies
             ordDocument.apiResources.forEach((apiResource) => {
                 apiResource.resourceDefinitions.forEach((resDef) => {
-                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "basic-auth" }]));
-                    expect(resDef.accessStrategies.some((s) => s.type === "basic-auth")).toBe(true);
+                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: ORD_ACCESS_STRATEGY.Basic }]));
+                    expect(resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.Basic)).toBe(true);
                 });
             });
 
             // Verify Event resources have 'basic-auth' accessStrategies
             ordDocument.eventResources.forEach((eventResource) => {
                 eventResource.resourceDefinitions.forEach((resDef) => {
-                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "basic-auth" }]));
-                    expect(resDef.accessStrategies.some((s) => s.type === "basic-auth")).toBe(true);
+                    expect(resDef.accessStrategies).toEqual(
+                        expect.arrayContaining([{ type: ORD_ACCESS_STRATEGY.Basic }]),
+                    );
+                    expect(resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.Basic)).toBe(true);
                 });
             });
 
             // Verify no resource has 'open' accessStrategy
             [...ordDocument.apiResources, ...ordDocument.eventResources].forEach((resource) => {
                 resource.resourceDefinitions.forEach((resDef) => {
-                    const hasOpen = resDef.accessStrategies.some((s) => s.type === "open");
+                    const hasOpen = resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.Open);
                     expect(hasOpen).toBe(false);
                 });
             });
@@ -389,23 +392,27 @@ describe("ORD Integration Tests - Basic Authentication", () => {
             // Verify API resources have 'basic-auth' accessStrategies
             ordDocument.apiResources.forEach((apiResource) => {
                 apiResource.resourceDefinitions.forEach((resDef) => {
-                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "basic-auth" }]));
-                    expect(resDef.accessStrategies.some((s) => s.type === "basic-auth")).toBe(true);
+                    expect(resDef.accessStrategies).toEqual(
+                        expect.arrayContaining([{ type: ORD_ACCESS_STRATEGY.Basic }]),
+                    );
+                    expect(resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.Basic)).toBe(true);
                 });
             });
 
             // Verify Event resources have 'basic-auth' accessStrategies
             ordDocument.eventResources.forEach((eventResource) => {
                 eventResource.resourceDefinitions.forEach((resDef) => {
-                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "basic-auth" }]));
-                    expect(resDef.accessStrategies.some((s) => s.type === "basic-auth")).toBe(true);
+                    expect(resDef.accessStrategies).toEqual(
+                        expect.arrayContaining([{ type: ORD_ACCESS_STRATEGY.Basic }]),
+                    );
+                    expect(resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.Basic)).toBe(true);
                 });
             });
 
             // Verify no resource has 'open' accessStrategy
             [...ordDocument.apiResources, ...ordDocument.eventResources].forEach((resource) => {
                 resource.resourceDefinitions.forEach((resDef) => {
-                    const hasOpen = resDef.accessStrategies.some((s) => s.type === "open");
+                    const hasOpen = resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.Open);
                     expect(hasOpen).toBe(false);
                 });
             });

--- a/__tests__/integration/mtls-auth.test.js
+++ b/__tests__/integration/mtls-auth.test.js
@@ -202,13 +202,14 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
         // 2. Prepare mTLS config via environment variable
         // This is the recommended production setup: cfMtls: true in config + env var for certs
         const mtlsConfig = {
+            rootCaDn: [MOCK_ROOT_CA_DN],
+            accessStrategies: ["sap:cmp-mtls:v1", "sap.businesshub:mtls:v1"],
             certs: [
                 {
                     issuer: MOCK_CERT_CONFIG_RESPONSE.certIssuer,
                     subject: MOCK_CERT_CONFIG_RESPONSE.certSubject,
                 },
             ],
-            rootCaDn: [MOCK_ROOT_CA_DN],
         };
 
         // 3. Start CDS with cfMtls: true config and CF_MTLS_TRUSTED_CERTS env var

--- a/__tests__/integration/mtls-auth.test.js
+++ b/__tests__/integration/mtls-auth.test.js
@@ -37,7 +37,7 @@ const net = require("net");
 const fs = require("fs");
 
 const utils = require("../utils");
-const { CF_MTLS_HEADERS } = require("../../lib/constants");
+const { CF_MTLS_HEADERS, ORD_ACCESS_STRATEGY } = require("../../lib/constants");
 
 const ORD_CONFIG_ENDPOINT = "/.well-known/open-resource-discovery";
 const ORD_DOCUMENT_ENDPOINT = "/ord/v1/documents/ord-document";
@@ -203,7 +203,7 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
         // This is the recommended production setup: cfMtls: true in config + env var for certs
         const mtlsConfig = {
             rootCaDn: [MOCK_ROOT_CA_DN],
-            accessStrategies: ["sap:cmp-mtls:v1", "sap.businesshub:mtls:v1"],
+            accessStrategies: [ORD_ACCESS_STRATEGY.CmpMtls, ORD_ACCESS_STRATEGY.BahMtls],
             certs: [
                 {
                     issuer: MOCK_CERT_CONFIG_RESPONSE.certIssuer,
@@ -477,23 +477,25 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
             // Verify API resources have 'sap:cmp-mtls:v1' accessStrategies
             ordDocument.apiResources.forEach((apiResource) => {
                 apiResource.resourceDefinitions.forEach((resDef) => {
-                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "sap:cmp-mtls:v1" }]));
-                    expect(resDef.accessStrategies.some((s) => s.type === "sap:cmp-mtls:v1")).toBe(true);
+                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: ORD_ACCESS_STRATEGY.CmpMtls }]));
+                    expect(resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.CmpMtls)).toBe(true);
                 });
             });
 
             // Verify Event resources have 'sap:cmp-mtls:v1' accessStrategies
             ordDocument.eventResources.forEach((eventResource) => {
                 eventResource.resourceDefinitions.forEach((resDef) => {
-                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "sap:cmp-mtls:v1" }]));
-                    expect(resDef.accessStrategies.some((s) => s.type === "sap:cmp-mtls:v1")).toBe(true);
+                    expect(resDef.accessStrategies).toEqual(
+                        expect.arrayContaining([{ type: ORD_ACCESS_STRATEGY.CmpMtls }]),
+                    );
+                    expect(resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.CmpMtls)).toBe(true);
                 });
             });
 
             // Verify no resource has 'open' accessStrategy
             [...ordDocument.apiResources, ...ordDocument.eventResources].forEach((resource) => {
                 resource.resourceDefinitions.forEach((resDef) => {
-                    const hasOpen = resDef.accessStrategies.some((s) => s.type === "open");
+                    const hasOpen = resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.Open);
                     expect(hasOpen).toBe(false);
                 });
             });
@@ -560,23 +562,27 @@ describe("ORD Integration Tests - mTLS Production Mode (cfMtls: true)", () => {
             // Verify API resources have 'sap:cmp-mtls:v1' accessStrategies
             ordDocument.apiResources.forEach((apiResource) => {
                 apiResource.resourceDefinitions.forEach((resDef) => {
-                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "sap:cmp-mtls:v1" }]));
-                    expect(resDef.accessStrategies.some((s) => s.type === "sap:cmp-mtls:v1")).toBe(true);
+                    expect(resDef.accessStrategies).toEqual(
+                        expect.arrayContaining([{ type: ORD_ACCESS_STRATEGY.CmpMtls }]),
+                    );
+                    expect(resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.CmpMtls)).toBe(true);
                 });
             });
 
             // Verify Event resources have 'sap:cmp-mtls:v1' accessStrategies
             ordDocument.eventResources.forEach((eventResource) => {
                 eventResource.resourceDefinitions.forEach((resDef) => {
-                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "sap:cmp-mtls:v1" }]));
-                    expect(resDef.accessStrategies.some((s) => s.type === "sap:cmp-mtls:v1")).toBe(true);
+                    expect(resDef.accessStrategies).toEqual(
+                        expect.arrayContaining([{ type: ORD_ACCESS_STRATEGY.CmpMtls }]),
+                    );
+                    expect(resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.CmpMtls)).toBe(true);
                 });
             });
 
             // Verify no resource has 'open' accessStrategy
             [...ordDocument.apiResources, ...ordDocument.eventResources].forEach((resource) => {
                 resource.resourceDefinitions.forEach((resDef) => {
-                    const hasOpen = resDef.accessStrategies.some((s) => s.type === "open");
+                    const hasOpen = resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.Open);
                     expect(hasOpen).toBe(false);
                 });
             });
@@ -826,16 +832,20 @@ describe("ORD Integration Tests - mTLS Development Mode (cfMtls object with conf
             // Verify API resources have 'sap:cmp-mtls:v1' accessStrategies
             ordDocument.apiResources.forEach((apiResource) => {
                 apiResource.resourceDefinitions.forEach((resDef) => {
-                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "sap:cmp-mtls:v1" }]));
-                    expect(resDef.accessStrategies.some((s) => s.type === "sap:cmp-mtls:v1")).toBe(true);
+                    expect(resDef.accessStrategies).toEqual(
+                        expect.arrayContaining([{ type: ORD_ACCESS_STRATEGY.CmpMtls }]),
+                    );
+                    expect(resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.CmpMtls)).toBe(true);
                 });
             });
 
             // Verify Event resources have 'sap:cmp-mtls:v1' accessStrategies
             ordDocument.eventResources.forEach((eventResource) => {
                 eventResource.resourceDefinitions.forEach((resDef) => {
-                    expect(resDef.accessStrategies).toEqual(expect.arrayContaining([{ type: "sap:cmp-mtls:v1" }]));
-                    expect(resDef.accessStrategies.some((s) => s.type === "sap:cmp-mtls:v1")).toBe(true);
+                    expect(resDef.accessStrategies).toEqual(
+                        expect.arrayContaining([{ type: ORD_ACCESS_STRATEGY.CmpMtls }]),
+                    );
+                    expect(resDef.accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.CmpMtls)).toBe(true);
                 });
             });
         });

--- a/__tests__/unit/access-strategies.test.js
+++ b/__tests__/unit/access-strategies.test.js
@@ -101,17 +101,17 @@ describe("access-strategies", () => {
         });
 
         it("should return true for basic strategy", () => {
-            const strategies = [ORD_ACCESS_STRATEGY.Basic];
+            const strategies = [{type: ORD_ACCESS_STRATEGY.Basic}];
             expect(hasNonOpenStrategies(strategies)).toBe(true);
         });
 
         it("should return true for CF mTLS strategy", () => {
-            const strategies = [ORD_ACCESS_STRATEGY.CmpMtls];
+            const strategies = [{type: ORD_ACCESS_STRATEGY.CmpMtls}];
             expect(hasNonOpenStrategies(strategies)).toBe(true);
         });
 
         it("should return true for mixed strategies including non-open", () => {
-            const strategies = [ORD_ACCESS_STRATEGY.Open, ORD_ACCESS_STRATEGY.Basic];
+            const strategies = [{type: ORD_ACCESS_STRATEGY.Open}, {type: ORD_ACCESS_STRATEGY.Basic}];
             expect(hasNonOpenStrategies(strategies)).toBe(true);
         });
     });
@@ -122,12 +122,12 @@ describe("access-strategies", () => {
         });
 
         it("should not throw for only open strategy", () => {
-            const strategies = [ORD_ACCESS_STRATEGY.Open];
+            const strategies = [{type: ORD_ACCESS_STRATEGY.Open}];
             expect(() => ensureNoOpenWhenNonOpenPresent(strategies)).not.toThrow();
         });
 
         it("should not throw for only non-open strategies", () => {
-            const strategies = [ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls ];
+            const strategies = [{type: ORD_ACCESS_STRATEGY.Basic}, {type: ORD_ACCESS_STRATEGY.CmpMtls} ];
             expect(() => ensureNoOpenWhenNonOpenPresent(strategies)).not.toThrow();
         });
 
@@ -158,7 +158,7 @@ describe("access-strategies", () => {
             });
 
             it("should return strategies if provided", () => {
-                const strategies = [ORD_ACCESS_STRATEGY.Basic];
+                const strategies = [{type: ORD_ACCESS_STRATEGY.Basic }];
                 const result = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
                 expect(result).toEqual(strategies);
@@ -183,7 +183,7 @@ describe("access-strategies", () => {
             });
 
             it("should validate and return valid strategies", () => {
-                const strategies = [ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls];
+                const strategies = [{type: ORD_ACCESS_STRATEGY.Basic}, {type: ORD_ACCESS_STRATEGY.CmpMtls}];
                 const result = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
                 expect(result).toEqual(strategies);
@@ -196,7 +196,7 @@ describe("access-strategies", () => {
             });
 
             it("should return strategies if provided", () => {
-                const strategies = [ORD_ACCESS_STRATEGY.Basic];
+                const strategies = [{type: ORD_ACCESS_STRATEGY.Basic}];
                 const result = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
                 expect(result).toEqual(strategies);
@@ -255,7 +255,7 @@ describe("access-strategies", () => {
             });
 
             it("should allow multiple non-open strategies", () => {
-                const strategies = [ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls];
+                const strategies = [{type: ORD_ACCESS_STRATEGY.Basic}, {type: ORD_ACCESS_STRATEGY.CmpMtls}];
 
                 const result = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 

--- a/__tests__/unit/access-strategies.test.js
+++ b/__tests__/unit/access-strategies.test.js
@@ -15,8 +15,7 @@ describe("access-strategies", () => {
 
     describe("getAccessStrategiesFromAuthConfig", () => {
         it("should return open strategy for empty auth config", () => {
-            const authConfig = { accessStrategies: [] };
-            const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+            const strategies = getAccessStrategiesFromAuthConfig([]);
 
             expect(strategies).toEqual([{type: ORD_ACCESS_STRATEGY.Open}]);
         });
@@ -46,8 +45,7 @@ describe("access-strategies", () => {
         });
 
         it("should map Open auth type to open strategy", () => {
-            const authConfig = { accessStrategies: [ORD_ACCESS_STRATEGY.Open] };
-            const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+            const strategies = getAccessStrategiesFromAuthConfig([ORD_ACCESS_STRATEGY.Open]);
 
             expect(strategies).toEqual([{type: ORD_ACCESS_STRATEGY.Open}]);
         });
@@ -62,8 +60,7 @@ describe("access-strategies", () => {
         });
 
         it("should handle unknown auth types gracefully", () => {
-            const authConfig = { types: ["unknown-type"] };
-            const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+            const strategies = getAccessStrategiesFromAuthConfig(["unknown-type"]);
 
             // Should fallback to open since no valid types found
             expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
@@ -82,9 +79,8 @@ describe("access-strategies", () => {
             ]);
         });
 
-        it("should handle invalid authConfig.types gracefully", () => {
-            const authConfig = { types: "not-an-array" };
-            const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+        it("should handle invalid accessStrategies gracefully", () => {
+            const strategies = getAccessStrategiesFromAuthConfig("not-an-array");
 
             expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
         });
@@ -281,9 +277,7 @@ describe("access-strategies", () => {
         });
 
         it("should handle open-only configuration", () => {
-            const authConfig = { accessStrategies: [ORD_ACCESS_STRATEGY.Open] };
-
-            const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+            const strategies = getAccessStrategiesFromAuthConfig([ORD_ACCESS_STRATEGY.Open]);
             const validated = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
             expect(validated).toEqual([{type:ORD_ACCESS_STRATEGY.Open}]);

--- a/__tests__/unit/access-strategies.test.js
+++ b/__tests__/unit/access-strategies.test.js
@@ -45,7 +45,7 @@ describe("access-strategies", () => {
             const authConfig = { types: [AUTHENTICATION_TYPE.CfMtls] };
             const strategies = getAccessStrategiesFromAuthConfig(authConfig);
 
-            expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.CfMtls }]);
+            expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.CmpMtls }, { type: ORD_ACCESS_STRATEGY.BahMtls }]);
         });
 
         it("should map Open auth type to open strategy", () => {
@@ -61,7 +61,11 @@ describe("access-strategies", () => {
             };
             const strategies = getAccessStrategiesFromAuthConfig(authConfig);
 
-            expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CfMtls }]);
+            expect(strategies).toEqual([
+                { type: ORD_ACCESS_STRATEGY.Basic },
+                { type: ORD_ACCESS_STRATEGY.CmpMtls },
+                { type: ORD_ACCESS_STRATEGY.BahMtls },
+            ]);
         });
 
         it("should handle unknown auth types gracefully", () => {
@@ -78,7 +82,11 @@ describe("access-strategies", () => {
             };
             const strategies = getAccessStrategiesFromAuthConfig(authConfig);
 
-            expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CfMtls }]);
+            expect(strategies).toEqual([
+                { type: ORD_ACCESS_STRATEGY.Basic },
+                { type: ORD_ACCESS_STRATEGY.CmpMtls },
+                { type: ORD_ACCESS_STRATEGY.BahMtls },
+            ]);
         });
 
         it("should handle invalid authConfig.types gracefully", () => {
@@ -109,7 +117,7 @@ describe("access-strategies", () => {
         });
 
         it("should return true for CF mTLS strategy", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.CfMtls }];
+            const strategies = [{ type: ORD_ACCESS_STRATEGY.CmpMtls }];
             expect(hasNonOpenStrategies(strategies)).toBe(true);
         });
 
@@ -130,7 +138,7 @@ describe("access-strategies", () => {
         });
 
         it("should not throw for only non-open strategies", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CfMtls }];
+            const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CmpMtls }];
             expect(() => ensureNoOpenWhenNonOpenPresent(strategies)).not.toThrow();
         });
 
@@ -140,7 +148,7 @@ describe("access-strategies", () => {
         });
 
         it("should throw when open coexists with CF mTLS", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Open }, { type: ORD_ACCESS_STRATEGY.CfMtls }];
+            const strategies = [{ type: ORD_ACCESS_STRATEGY.Open }, { type: ORD_ACCESS_STRATEGY.CmpMtls }];
             expect(() => ensureNoOpenWhenNonOpenPresent(strategies)).toThrow(/cannot coexist/);
         });
 
@@ -148,7 +156,7 @@ describe("access-strategies", () => {
             const strategies = [
                 { type: ORD_ACCESS_STRATEGY.Basic },
                 { type: ORD_ACCESS_STRATEGY.Open },
-                { type: ORD_ACCESS_STRATEGY.CfMtls },
+                { type: ORD_ACCESS_STRATEGY.CmpMtls },
             ];
             expect(() => ensureNoOpenWhenNonOpenPresent(strategies)).toThrow(/cannot coexist/);
         });
@@ -186,7 +194,7 @@ describe("access-strategies", () => {
             });
 
             it("should validate and return valid strategies", () => {
-                const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CfMtls }];
+                const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CmpMtls }];
                 const result = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
                 expect(result).toEqual(strategies);
@@ -258,7 +266,7 @@ describe("access-strategies", () => {
             });
 
             it("should allow multiple non-open strategies", () => {
-                const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CfMtls }];
+                const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CmpMtls }];
 
                 const result = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
@@ -291,12 +299,12 @@ describe("access-strategies", () => {
         });
 
         it("should return true for valid CF mTLS strategy", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.CfMtls }];
+            const strategies = [{ type: ORD_ACCESS_STRATEGY.CmpMtls }];
             expect(isValidAccessStrategies(strategies)).toBe(true);
         });
 
         it("should return true for multiple valid strategies", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CfMtls }];
+            const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CmpMtls }];
             expect(isValidAccessStrategies(strategies)).toBe(true);
         });
 
@@ -325,7 +333,11 @@ describe("access-strategies", () => {
             const strategies = getAccessStrategiesFromAuthConfig(authConfig);
             const validated = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
-            expect(validated).toEqual([{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CfMtls }]);
+            expect(validated).toEqual([
+                { type: ORD_ACCESS_STRATEGY.Basic },
+                { type: ORD_ACCESS_STRATEGY.CmpMtls },
+                { type: ORD_ACCESS_STRATEGY.BahMtls },
+            ]);
             expect(hasNonOpenStrategies(validated)).toBe(true);
             expect(isValidAccessStrategies(validated)).toBe(true);
         });

--- a/__tests__/unit/access-strategies.test.js
+++ b/__tests__/unit/access-strategies.test.js
@@ -4,9 +4,8 @@ const {
     ensureAccessStrategies,
     hasNonOpenStrategies,
     ensureNoOpenWhenNonOpenPresent,
-    isValidAccessStrategies,
 } = require("../../lib/access-strategies");
-const { AUTHENTICATION_TYPE, ORD_ACCESS_STRATEGY } = require("../../lib/constants");
+const { ORD_ACCESS_STRATEGY } = require("../../lib/constants");
 
 describe("access-strategies", () => {
     beforeEach(() => {
@@ -16,55 +15,49 @@ describe("access-strategies", () => {
 
     describe("getAccessStrategiesFromAuthConfig", () => {
         it("should return open strategy for empty auth config", () => {
-            const authConfig = { types: [] };
+            const authConfig = { accessStrategies: [] };
             const strategies = getAccessStrategiesFromAuthConfig(authConfig);
 
-            expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
+            expect(strategies).toEqual([{type: ORD_ACCESS_STRATEGY.Open}]);
         });
 
         it("should return open strategy for undefined auth config", () => {
             const strategies = getAccessStrategiesFromAuthConfig(undefined);
 
-            expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
+            expect(strategies).toEqual([{type: ORD_ACCESS_STRATEGY.Open}]);
         });
 
         it("should return open strategy for null auth config", () => {
             const strategies = getAccessStrategiesFromAuthConfig(null);
 
-            expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
+            expect(strategies).toEqual([{type: ORD_ACCESS_STRATEGY.Open}]);
         });
 
         it("should map Basic auth type to basic-auth strategy", () => {
-            const authConfig = { types: [AUTHENTICATION_TYPE.Basic] };
-            const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+            const strategies = getAccessStrategiesFromAuthConfig([ORD_ACCESS_STRATEGY.Basic]);
 
-            expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.Basic }]);
+            expect(strategies).toEqual([{type: ORD_ACCESS_STRATEGY.Basic}]);
         });
 
         it("should map CF mTLS auth type to sap:cmp-mtls:v1 strategy", () => {
-            const authConfig = { types: [AUTHENTICATION_TYPE.CfMtls] };
-            const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+            const strategies = getAccessStrategiesFromAuthConfig([ORD_ACCESS_STRATEGY.CmpMtls ]);
 
-            expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.CmpMtls }, { type: ORD_ACCESS_STRATEGY.BahMtls }]);
+            expect(strategies).toEqual([{type: ORD_ACCESS_STRATEGY.CmpMtls}]);
         });
 
         it("should map Open auth type to open strategy", () => {
-            const authConfig = { types: [AUTHENTICATION_TYPE.Open] };
+            const authConfig = { accessStrategies: [ORD_ACCESS_STRATEGY.Open] };
             const strategies = getAccessStrategiesFromAuthConfig(authConfig);
 
-            expect(strategies).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
+            expect(strategies).toEqual([{type: ORD_ACCESS_STRATEGY.Open}]);
         });
 
         it("should map multiple auth types correctly", () => {
-            const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic, AUTHENTICATION_TYPE.CfMtls],
-            };
-            const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+            const strategies = getAccessStrategiesFromAuthConfig([ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls]);
 
             expect(strategies).toEqual([
-                { type: ORD_ACCESS_STRATEGY.Basic },
-                { type: ORD_ACCESS_STRATEGY.CmpMtls },
-                { type: ORD_ACCESS_STRATEGY.BahMtls },
+                {type: ORD_ACCESS_STRATEGY.Basic},
+                {type: ORD_ACCESS_STRATEGY.CmpMtls},
             ]);
         });
 
@@ -77,15 +70,15 @@ describe("access-strategies", () => {
         });
 
         it("should filter out unknown types and keep valid ones", () => {
-            const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic, "unknown-type", AUTHENTICATION_TYPE.CfMtls],
-            };
-            const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+            const strategies = getAccessStrategiesFromAuthConfig([
+                "unknown-type",
+                ORD_ACCESS_STRATEGY.Basic,
+                ORD_ACCESS_STRATEGY.CmpMtls,
+            ]);
 
             expect(strategies).toEqual([
                 { type: ORD_ACCESS_STRATEGY.Basic },
                 { type: ORD_ACCESS_STRATEGY.CmpMtls },
-                { type: ORD_ACCESS_STRATEGY.BahMtls },
             ]);
         });
 
@@ -107,22 +100,22 @@ describe("access-strategies", () => {
         });
 
         it("should return false for only open strategy", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Open }];
+            const strategies = [{type:ORD_ACCESS_STRATEGY.Open}];
             expect(hasNonOpenStrategies(strategies)).toBe(false);
         });
 
         it("should return true for basic strategy", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }];
+            const strategies = [ORD_ACCESS_STRATEGY.Basic];
             expect(hasNonOpenStrategies(strategies)).toBe(true);
         });
 
         it("should return true for CF mTLS strategy", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.CmpMtls }];
+            const strategies = [ORD_ACCESS_STRATEGY.CmpMtls];
             expect(hasNonOpenStrategies(strategies)).toBe(true);
         });
 
         it("should return true for mixed strategies including non-open", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Open }, { type: ORD_ACCESS_STRATEGY.Basic }];
+            const strategies = [ORD_ACCESS_STRATEGY.Open, ORD_ACCESS_STRATEGY.Basic];
             expect(hasNonOpenStrategies(strategies)).toBe(true);
         });
     });
@@ -133,30 +126,30 @@ describe("access-strategies", () => {
         });
 
         it("should not throw for only open strategy", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Open }];
+            const strategies = [ORD_ACCESS_STRATEGY.Open];
             expect(() => ensureNoOpenWhenNonOpenPresent(strategies)).not.toThrow();
         });
 
         it("should not throw for only non-open strategies", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CmpMtls }];
+            const strategies = [ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls ];
             expect(() => ensureNoOpenWhenNonOpenPresent(strategies)).not.toThrow();
         });
 
         it("should throw when open coexists with basic", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Open }, { type: ORD_ACCESS_STRATEGY.Basic }];
+            const strategies = [{type: ORD_ACCESS_STRATEGY.Open}, {type:ORD_ACCESS_STRATEGY.Basic}];
             expect(() => ensureNoOpenWhenNonOpenPresent(strategies)).toThrow(/cannot coexist/);
         });
 
         it("should throw when open coexists with CF mTLS", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Open }, { type: ORD_ACCESS_STRATEGY.CmpMtls }];
+            const strategies = [{type:ORD_ACCESS_STRATEGY.Open}, {type:ORD_ACCESS_STRATEGY.CmpMtls} ];
             expect(() => ensureNoOpenWhenNonOpenPresent(strategies)).toThrow(/cannot coexist/);
         });
 
         it("should throw when open coexists with multiple non-open strategies", () => {
             const strategies = [
-                { type: ORD_ACCESS_STRATEGY.Basic },
-                { type: ORD_ACCESS_STRATEGY.Open },
-                { type: ORD_ACCESS_STRATEGY.CmpMtls },
+                {type:ORD_ACCESS_STRATEGY.Basic},
+                {type:ORD_ACCESS_STRATEGY.Open},
+                {type:ORD_ACCESS_STRATEGY.CmpMtls},
             ];
             expect(() => ensureNoOpenWhenNonOpenPresent(strategies)).toThrow(/cannot coexist/);
         });
@@ -169,7 +162,7 @@ describe("access-strategies", () => {
             });
 
             it("should return strategies if provided", () => {
-                const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }];
+                const strategies = [ORD_ACCESS_STRATEGY.Basic];
                 const result = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
                 expect(result).toEqual(strategies);
@@ -178,23 +171,23 @@ describe("access-strategies", () => {
             it("should fallback to open for undefined strategies", () => {
                 const result = ensureAccessStrategies(undefined, { resourceName: "TestAPI" });
 
-                expect(result).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
+                expect(result).toEqual([{type:ORD_ACCESS_STRATEGY.Open}]);
             });
 
             it("should fallback to open for empty array", () => {
                 const result = ensureAccessStrategies([], { resourceName: "TestAPI" });
 
-                expect(result).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
+                expect(result).toEqual([{type:ORD_ACCESS_STRATEGY.Open}]);
             });
 
             it("should fallback to open for null", () => {
                 const result = ensureAccessStrategies(null, { resourceName: "TestAPI" });
 
-                expect(result).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
+                expect(result).toEqual([{type:ORD_ACCESS_STRATEGY.Open}]);
             });
 
             it("should validate and return valid strategies", () => {
-                const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CmpMtls }];
+                const strategies = [ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls];
                 const result = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
                 expect(result).toEqual(strategies);
@@ -207,7 +200,7 @@ describe("access-strategies", () => {
             });
 
             it("should return strategies if provided", () => {
-                const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }];
+                const strategies = [ORD_ACCESS_STRATEGY.Basic];
                 const result = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
                 expect(result).toEqual(strategies);
@@ -252,13 +245,13 @@ describe("access-strategies", () => {
 
                 const result = ensureAccessStrategies(undefined, { resourceName: "TestAPI", strict: false });
 
-                expect(result).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
+                expect(result).toEqual([{type:ORD_ACCESS_STRATEGY.Open}]);
             });
         });
 
         describe("validation of strategies", () => {
             it("should throw if open coexists with non-open strategies", () => {
-                const strategies = [{ type: ORD_ACCESS_STRATEGY.Open }, { type: ORD_ACCESS_STRATEGY.Basic }];
+                const strategies = [{type:ORD_ACCESS_STRATEGY.Open}, {type:ORD_ACCESS_STRATEGY.Basic}];
 
                 expect(() => {
                     ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
@@ -266,7 +259,7 @@ describe("access-strategies", () => {
             });
 
             it("should allow multiple non-open strategies", () => {
-                const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CmpMtls }];
+                const strategies = [ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls];
 
                 const result = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
@@ -275,82 +268,26 @@ describe("access-strategies", () => {
         });
     });
 
-    describe("isValidAccessStrategies", () => {
-        it("should return false for empty array", () => {
-            expect(isValidAccessStrategies([])).toBe(false);
-        });
-
-        it("should return false for undefined", () => {
-            expect(isValidAccessStrategies(undefined)).toBe(false);
-        });
-
-        it("should return false for null", () => {
-            expect(isValidAccessStrategies(null)).toBe(false);
-        });
-
-        it("should return true for valid open strategy", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Open }];
-            expect(isValidAccessStrategies(strategies)).toBe(true);
-        });
-
-        it("should return true for valid basic strategy", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }];
-            expect(isValidAccessStrategies(strategies)).toBe(true);
-        });
-
-        it("should return true for valid CF mTLS strategy", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.CmpMtls }];
-            expect(isValidAccessStrategies(strategies)).toBe(true);
-        });
-
-        it("should return true for multiple valid strategies", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: ORD_ACCESS_STRATEGY.CmpMtls }];
-            expect(isValidAccessStrategies(strategies)).toBe(true);
-        });
-
-        it("should return false for invalid strategy type", () => {
-            const strategies = [{ type: "invalid-type" }];
-            expect(isValidAccessStrategies(strategies)).toBe(false);
-        });
-
-        it("should return false if any strategy is invalid", () => {
-            const strategies = [{ type: ORD_ACCESS_STRATEGY.Basic }, { type: "invalid-type" }];
-            expect(isValidAccessStrategies(strategies)).toBe(false);
-        });
-
-        it("should return false for strategy without type property", () => {
-            const strategies = [{ notType: "something" }];
-            expect(isValidAccessStrategies(strategies)).toBe(false);
-        });
-    });
-
     describe("Integration scenarios", () => {
         it("should handle complete flow from auth config to validated strategies", () => {
-            const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic, AUTHENTICATION_TYPE.CfMtls],
-            };
-
-            const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+            const strategies = getAccessStrategiesFromAuthConfig([ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls]);
             const validated = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
             expect(validated).toEqual([
-                { type: ORD_ACCESS_STRATEGY.Basic },
-                { type: ORD_ACCESS_STRATEGY.CmpMtls },
-                { type: ORD_ACCESS_STRATEGY.BahMtls },
+                {type:ORD_ACCESS_STRATEGY.Basic},
+                {type:ORD_ACCESS_STRATEGY.CmpMtls},
             ]);
             expect(hasNonOpenStrategies(validated)).toBe(true);
-            expect(isValidAccessStrategies(validated)).toBe(true);
         });
 
         it("should handle open-only configuration", () => {
-            const authConfig = { types: [AUTHENTICATION_TYPE.Open] };
+            const authConfig = { accessStrategies: [ORD_ACCESS_STRATEGY.Open] };
 
             const strategies = getAccessStrategiesFromAuthConfig(authConfig);
             const validated = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
-            expect(validated).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
+            expect(validated).toEqual([{type:ORD_ACCESS_STRATEGY.Open}]);
             expect(hasNonOpenStrategies(validated)).toBe(false);
-            expect(isValidAccessStrategies(validated)).toBe(true);
         });
 
         it("should handle missing config with non-strict fallback", () => {
@@ -359,8 +296,7 @@ describe("access-strategies", () => {
             const strategies = getAccessStrategiesFromAuthConfig(undefined);
             const validated = ensureAccessStrategies(strategies, { resourceName: "TestAPI" });
 
-            expect(validated).toEqual([{ type: ORD_ACCESS_STRATEGY.Open }]);
-            expect(isValidAccessStrategies(validated)).toBe(true);
+            expect(validated).toEqual([{type: ORD_ACCESS_STRATEGY.Open}]);
         });
     });
 });

--- a/__tests__/unit/authentication.test.js
+++ b/__tests__/unit/authentication.test.js
@@ -9,7 +9,7 @@ jest.mock("../../lib/logger", () => ({
 const cds = require("@sap/cds");
 const express = require("express");
 const request = require("supertest");
-const { AUTHENTICATION_TYPE, ORD_ACCESS_STRATEGY, CF_MTLS_HEADERS } = require("../../lib/constants");
+const { ORD_ACCESS_STRATEGY, CF_MTLS_HEADERS } = require("../../lib/constants");
 const { createAuthMiddleware, createAuthConfig } = require("../../lib/auth/authentication");
 const Logger = require("../../lib/logger");
 
@@ -20,7 +20,7 @@ describe("authentication", () => {
     // The bcrypt hash decrypted is: secret
     const mockValidUser = { admin: "$2a$05$cx46X.uaat9Az0XLfc8.BuijktdnHrIvtRMXnLdhozqo.1Eeo7.ZW" };
     const defaultAuthConfig = {
-        accessStrategies: [ AUTHENTICATION_TYPE.Open ],
+        accessStrategies: [ ORD_ACCESS_STRATEGY.Open ],
     };
 
     beforeEach(() => {
@@ -181,7 +181,7 @@ describe("authentication", () => {
 
         it("should not authenticate because of wrongly configured unsupported authentication type", async () => {
             const authConfig = {
-                types: "UnsupportedAuthType",
+                accessStrategies: "UnsupportedAuthType",
             };
 
             await request(createTestApp(authConfig)).get(TEST_ENDPOINT).expect(401).expect("Not authorized");

--- a/__tests__/unit/authentication.test.js
+++ b/__tests__/unit/authentication.test.js
@@ -281,7 +281,10 @@ describe("authentication", () => {
 
             const authConfig = createAuthConfig();
             expect(authConfig.types).toEqual([AUTHENTICATION_TYPE.CfMtls]);
-            expect(authConfig.accessStrategies).toEqual([{ type: ORD_ACCESS_STRATEGY.CfMtls }]);
+            expect(authConfig.accessStrategies).toEqual([
+                { type: ORD_ACCESS_STRATEGY.CmpMtls },
+                { type: ORD_ACCESS_STRATEGY.BahMtls },
+            ]);
             // Validator should be null (lazy loading)
             expect(authConfig.cfMtlsValidator).toBeNull();
             expect(authConfig._cfMtlsInitPromise).toBeNull();
@@ -524,7 +527,8 @@ describe("authentication", () => {
             expect(authConfig.types).toEqual([AUTHENTICATION_TYPE.Basic, AUTHENTICATION_TYPE.CfMtls]);
             expect(authConfig.accessStrategies).toEqual([
                 { type: ORD_ACCESS_STRATEGY.Basic },
-                { type: ORD_ACCESS_STRATEGY.CfMtls },
+                { type: ORD_ACCESS_STRATEGY.CmpMtls },
+                { type: ORD_ACCESS_STRATEGY.BahMtls },
             ]);
         });
 
@@ -540,7 +544,10 @@ describe("authentication", () => {
             const authConfig = createAuthConfig();
 
             expect(authConfig.types).toEqual([AUTHENTICATION_TYPE.CfMtls]);
-            expect(authConfig.accessStrategies).toEqual([{ type: ORD_ACCESS_STRATEGY.CfMtls }]);
+            expect(authConfig.accessStrategies).toEqual([
+                { type: ORD_ACCESS_STRATEGY.CmpMtls },
+                { type: ORD_ACCESS_STRATEGY.BahMtls },
+            ]);
         });
 
         it("should automatically filter out Open when all three auth types are combined", () => {
@@ -557,7 +564,8 @@ describe("authentication", () => {
             expect(authConfig.types).toEqual([AUTHENTICATION_TYPE.Basic, AUTHENTICATION_TYPE.CfMtls]);
             expect(authConfig.accessStrategies).toEqual([
                 { type: ORD_ACCESS_STRATEGY.Basic },
-                { type: ORD_ACCESS_STRATEGY.CfMtls },
+                { type: ORD_ACCESS_STRATEGY.CmpMtls },
+                { type: ORD_ACCESS_STRATEGY.BahMtls },
             ]);
         });
     });

--- a/__tests__/unit/authentication.test.js
+++ b/__tests__/unit/authentication.test.js
@@ -16,12 +16,11 @@ const Logger = require("../../lib/logger");
 describe("authentication", () => {
     // Constants
     const TEST_ENDPOINT = "/test";
-    
+
     // The bcrypt hash decrypted is: secret
     const mockValidUser = { admin: "$2a$05$cx46X.uaat9Az0XLfc8.BuijktdnHrIvtRMXnLdhozqo.1Eeo7.ZW" };
     const defaultAuthConfig = {
-        types: [AUTHENTICATION_TYPE.Open],
-        accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+        accessStrategies: [ AUTHENTICATION_TYPE.Open ],
     };
 
     beforeEach(() => {
@@ -81,8 +80,7 @@ describe("authentication", () => {
             cds.env.ord.authentication.basic = { credentials: mockValidUser };
             const authConfig = createAuthConfig();
             // Open should be filtered out automatically when Basic is present
-            expect(authConfig.types).toEqual([AUTHENTICATION_TYPE.Basic]);
-            expect(authConfig.accessStrategies).toEqual([{ type: ORD_ACCESS_STRATEGY.Basic }]);
+            expect(authConfig.accessStrategies).toEqual([ ORD_ACCESS_STRATEGY.Basic ]);
             expect(authConfig.credentials).toEqual(mockValidUser);
         });
 
@@ -96,8 +94,7 @@ describe("authentication", () => {
             process.env.BASIC_AUTH = JSON.stringify(mockValidUser);
             const authConfig = createAuthConfig();
             expect(authConfig).toEqual({
-                types: [AUTHENTICATION_TYPE.Basic],
-                accessStrategies: [{ type: ORD_ACCESS_STRATEGY.Basic }],
+                accessStrategies: [ ORD_ACCESS_STRATEGY.Basic ],
                 credentials: mockValidUser,
             });
         });
@@ -106,8 +103,7 @@ describe("authentication", () => {
             cds.env.ord.authentication.basic = { credentials: mockValidUser };
             const authConfig = createAuthConfig();
             expect(authConfig).toEqual({
-                types: [AUTHENTICATION_TYPE.Basic],
-                accessStrategies: [{ type: ORD_ACCESS_STRATEGY.Basic }],
+                accessStrategies: [ ORD_ACCESS_STRATEGY.Basic ],
                 credentials: mockValidUser,
             });
         });
@@ -158,14 +154,14 @@ describe("authentication", () => {
 
         it("should have access with default open authentication", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Open],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
             };
             await request(createTestApp(authConfig)).get(TEST_ENDPOINT).expect(200).expect("OK");
         });
 
         it("should not authenticate because of missing authorization header in case of any non-open authentication", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Basic],
             };
 
             await request(createTestApp(authConfig)).get(TEST_ENDPOINT).expect(401).expect("Authentication required.");
@@ -173,7 +169,7 @@ describe("authentication", () => {
 
         it("should not authenticate and set header 'WWW-Authenticate' because of missing authorization header", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Basic],
             };
 
             await request(createTestApp(authConfig))
@@ -193,7 +189,7 @@ describe("authentication", () => {
 
         it("should not authenticate because of invalid name of authentication type in the request header", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Basic],
             };
 
             await request(createTestApp(authConfig))
@@ -205,7 +201,7 @@ describe("authentication", () => {
 
         it("should authenticate with valid credentials in the request", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Basic],
                 credentials: mockValidUser,
             };
 
@@ -218,7 +214,7 @@ describe("authentication", () => {
 
         it("should not authenticate because of missing password in the request", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Basic],
                 credentials: mockValidUser,
             };
 
@@ -231,7 +227,7 @@ describe("authentication", () => {
 
         it("should not authenticate because of invalid credentials in the request", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Basic],
                 credentials: mockValidUser,
             };
 
@@ -280,10 +276,8 @@ describe("authentication", () => {
             });
 
             const authConfig = createAuthConfig();
-            expect(authConfig.types).toEqual([AUTHENTICATION_TYPE.CfMtls]);
             expect(authConfig.accessStrategies).toEqual([
-                { type: ORD_ACCESS_STRATEGY.CmpMtls },
-                { type: ORD_ACCESS_STRATEGY.BahMtls },
+                ORD_ACCESS_STRATEGY.CmpMtls,
             ]);
             // Validator should be null (lazy loading)
             expect(authConfig.cfMtlsValidator).toBeNull();
@@ -301,14 +295,14 @@ describe("authentication", () => {
             };
 
             const authConfig = createAuthConfig();
-            expect(authConfig.types).toEqual([AUTHENTICATION_TYPE.CfMtls]);
+            expect(authConfig.accessStrategies).toEqual([ORD_ACCESS_STRATEGY.CmpMtls]);
             // Validator should be null (lazy loading)
             expect(authConfig.cfMtlsValidator).toBeNull();
         });
 
         it("should authenticate with valid certificate pair and root CA", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.CfMtls],
+                accessStrategies: [ORD_ACCESS_STRATEGY.CmpMtls],
                 cfMtlsValidator: () => ({
                     ok: true,
                     issuer: "CN=SAP Cloud Platform Client CA, O=SAP SE, C=DE",
@@ -345,7 +339,7 @@ describe("authentication", () => {
 
         it("should not authenticate with missing XFCC verification headers", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.CfMtls],
+                accessStrategies: [ORD_ACCESS_STRATEGY.CmpMtls],
                 cfMtlsValidator: () => ({
                     ok: false,
                     reason: "XFCC_VERIFICATION_FAILED",
@@ -361,7 +355,7 @@ describe("authentication", () => {
 
         it("should not authenticate with missing certificate headers", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.CfMtls],
+                accessStrategies: [ORD_ACCESS_STRATEGY.CmpMtls],
                 cfMtlsValidator: () => ({
                     ok: false,
                     reason: "HEADER_MISSING",
@@ -380,7 +374,7 @@ describe("authentication", () => {
 
         it("should not authenticate with invalid base64 encoding", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.CfMtls],
+                accessStrategies: [ORD_ACCESS_STRATEGY.CmpMtls],
                 cfMtlsValidator: () => ({ ok: false, reason: "INVALID_ENCODING" }),
             };
 
@@ -396,7 +390,7 @@ describe("authentication", () => {
 
         it("should return 403 forbidden for certificate pair mismatch", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.CfMtls],
+                accessStrategies: [ORD_ACCESS_STRATEGY.CmpMtls],
                 cfMtlsValidator: () => ({
                     ok: false,
                     reason: "CERT_PAIR_MISMATCH",
@@ -419,7 +413,7 @@ describe("authentication", () => {
 
         it("should return 403 forbidden for root CA mismatch", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.CfMtls],
+                accessStrategies: [ORD_ACCESS_STRATEGY.CmpMtls],
                 cfMtlsValidator: () => ({
                     ok: false,
                     reason: "ROOT_CA_MISMATCH",
@@ -447,8 +441,8 @@ describe("authentication", () => {
             });
 
             const authConfig = createAuthConfig();
-            expect(authConfig.types).toContain(AUTHENTICATION_TYPE.Basic);
-            expect(authConfig.types).toContain(AUTHENTICATION_TYPE.CfMtls);
+            expect(authConfig.accessStrategies).toContain(ORD_ACCESS_STRATEGY.Basic);
+            expect(authConfig.accessStrategies).toContain(ORD_ACCESS_STRATEGY.CmpMtls);
             expect(authConfig.credentials).toBeDefined();
             // CF mTLS validator should be null (lazy loading)
             expect(authConfig.cfMtlsValidator).toBeNull();
@@ -456,7 +450,7 @@ describe("authentication", () => {
 
         it("should handle Basic auth when both Basic and CF mTLS are configured", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic, AUTHENTICATION_TYPE.CfMtls],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls],
                 credentials: mockValidUser,
                 cfMtlsValidator: () => ({
                     ok: true,
@@ -475,7 +469,7 @@ describe("authentication", () => {
 
         it("should handle CF mTLS when both Basic and CF mTLS are configured but no Basic header", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic, AUTHENTICATION_TYPE.CfMtls],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls],
                 credentials: mockValidUser,
                 cfMtlsValidator: () => ({
                     ok: true,
@@ -503,7 +497,7 @@ describe("authentication", () => {
 
         it("should handle Basic auth when both Basic and CF mTLS are configured with Basic header", async () => {
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Basic, AUTHENTICATION_TYPE.CfMtls],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Basic, ORD_ACCESS_STRATEGY.CmpMtls],
                 credentials: mockValidUser,
             };
 
@@ -524,11 +518,9 @@ describe("authentication", () => {
             };
             const authConfig = createAuthConfig();
 
-            expect(authConfig.types).toEqual([AUTHENTICATION_TYPE.Basic, AUTHENTICATION_TYPE.CfMtls]);
             expect(authConfig.accessStrategies).toEqual([
-                { type: ORD_ACCESS_STRATEGY.Basic },
-                { type: ORD_ACCESS_STRATEGY.CmpMtls },
-                { type: ORD_ACCESS_STRATEGY.BahMtls },
+                ORD_ACCESS_STRATEGY.Basic,
+                ORD_ACCESS_STRATEGY.CmpMtls,
             ]);
         });
 
@@ -543,10 +535,8 @@ describe("authentication", () => {
             };
             const authConfig = createAuthConfig();
 
-            expect(authConfig.types).toEqual([AUTHENTICATION_TYPE.CfMtls]);
             expect(authConfig.accessStrategies).toEqual([
-                { type: ORD_ACCESS_STRATEGY.CmpMtls },
-                { type: ORD_ACCESS_STRATEGY.BahMtls },
+                ORD_ACCESS_STRATEGY.CmpMtls,
             ]);
         });
 
@@ -561,11 +551,9 @@ describe("authentication", () => {
             const authConfig = createAuthConfig();
 
             // Open should be filtered out, Basic and CfMtls remain
-            expect(authConfig.types).toEqual([AUTHENTICATION_TYPE.Basic, AUTHENTICATION_TYPE.CfMtls]);
             expect(authConfig.accessStrategies).toEqual([
-                { type: ORD_ACCESS_STRATEGY.Basic },
-                { type: ORD_ACCESS_STRATEGY.CmpMtls },
-                { type: ORD_ACCESS_STRATEGY.BahMtls },
+                ORD_ACCESS_STRATEGY.Basic,
+                ORD_ACCESS_STRATEGY.CmpMtls,
             ]);
         });
     });

--- a/__tests__/unit/defaults.test.js
+++ b/__tests__/unit/defaults.test.js
@@ -1,5 +1,5 @@
 const defaults = require("../../lib/defaults");
-const { AUTHENTICATION_TYPE, DOCUMENT_PERSPECTIVES } = require("../../lib/constants");
+const { DOCUMENT_PERSPECTIVES, ORD_ACCESS_STRATEGY } = require("../../lib/constants");
 const cds = require("@sap/cds");
 
 jest.mock("fs", () => {
@@ -163,8 +163,7 @@ describe("defaults", () => {
             cds.env.requires.toggles = false;
             cds.env.requires.extensibility = false;
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Open],
-                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
             };
             expect(defaults.baseTemplate(authConfig, undefined)).toMatchSnapshot();
         });
@@ -173,8 +172,7 @@ describe("defaults", () => {
             cds.env.requires.toggles = true;
             cds.env.requires.extensibility = false;
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Open],
-                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
             };
             expect(defaults.baseTemplate(authConfig, undefined)).toMatchSnapshot();
         });
@@ -183,8 +181,7 @@ describe("defaults", () => {
             cds.env.requires.toggles = false;
             cds.env.requires.extensibility = true;
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Open],
-                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
             };
             expect(defaults.baseTemplate(authConfig, undefined)).toMatchSnapshot();
         });
@@ -193,8 +190,7 @@ describe("defaults", () => {
             cds.env.requires.toggles = true;
             cds.env.requires.extensibility = true;
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Open],
-                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
             };
             expect(defaults.baseTemplate(authConfig, undefined)).toMatchSnapshot();
         });
@@ -203,8 +199,7 @@ describe("defaults", () => {
             cds.env.requires.toggles = true;
             cds.env.requires.extensibility = false;
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Open],
-                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
             };
             expect(defaults.baseTemplate(authConfig, "dummy-tenant")).toMatchSnapshot();
         });
@@ -213,8 +208,7 @@ describe("defaults", () => {
             cds.env.requires.toggles = false;
             cds.env.requires.extensibility = true;
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Open],
-                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
             };
             expect(defaults.baseTemplate(authConfig, "dummy-tenant")).toMatchSnapshot();
         });
@@ -223,8 +217,7 @@ describe("defaults", () => {
             cds.env.requires.toggles = true;
             cds.env.requires.extensibility = true;
             const authConfig = {
-                types: [AUTHENTICATION_TYPE.Open],
-                accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
             };
             expect(defaults.baseTemplate(authConfig, "dummy-tenant")).toMatchSnapshot();
         });

--- a/__tests__/unit/ord.test.js
+++ b/__tests__/unit/ord.test.js
@@ -25,8 +25,7 @@ describe("ord", () => {
             // Mock createAuthConfig to return an error
             const authentication = require("../../lib/auth/authentication");
             jest.spyOn(authentication, "createAuthConfig").mockReturnValue({
-                types: ["open"],
-                accessStrategies: [{ type: "open" }],
+                accessStrategies: ["open"],
                 error: "Invalid bcrypt hash provided",
             });
 
@@ -40,8 +39,7 @@ describe("ord", () => {
             // Mock createAuthConfig to return valid config without error
             const authentication = require("../../lib/auth/authentication");
             jest.spyOn(authentication, "createAuthConfig").mockReturnValue({
-                types: ["open"],
-                accessStrategies: [{ type: "open" }],
+                accessStrategies: ["open"],
             });
 
             ord = require("../../lib/ord");

--- a/__tests__/unit/ord.test.js
+++ b/__tests__/unit/ord.test.js
@@ -1,5 +1,6 @@
 const cds = require("@sap/cds");
 const path = require("path");
+const { ORD_ACCESS_STRATEGY } = require("../../lib/constants");
 
 describe("ord", () => {
     let ord;
@@ -25,7 +26,7 @@ describe("ord", () => {
             // Mock createAuthConfig to return an error
             const authentication = require("../../lib/auth/authentication");
             jest.spyOn(authentication, "createAuthConfig").mockReturnValue({
-                accessStrategies: ["open"],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
                 error: "Invalid bcrypt hash provided",
             });
 
@@ -39,7 +40,7 @@ describe("ord", () => {
             // Mock createAuthConfig to return valid config without error
             const authentication = require("../../lib/auth/authentication");
             jest.spyOn(authentication, "createAuthConfig").mockReturnValue({
-                accessStrategies: ["open"],
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
             });
 
             ord = require("../../lib/ord");

--- a/__tests__/unit/split-up-packages-csn.test.js
+++ b/__tests__/unit/split-up-packages-csn.test.js
@@ -14,7 +14,7 @@ describe("ORD Generation for Business Accelerator Hub", () => {
 
         // Mock the createAuthConfig to return a default open configuration
         jest.spyOn(authentication, "createAuthConfig").mockReturnValue({
-            accessStrategies: [{ type: ORD_ACCESS_STRATEGY.Open }],
+            accessStrategies: [ORD_ACCESS_STRATEGY.Open],
         });
 
         jest.spyOn(require("../../lib/common/utils"), "getRFC3339Date").mockReturnValue("2024-11-04T14:33:25+01:00");

--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -4,7 +4,7 @@ const {
     ENTITY_RELATIONSHIP_ANNOTATION,
     ORD_EXTENSIONS_PREFIX,
     RESOURCE_VISIBILITY,
-    ALLOWED_VISIBILITY,
+    ALLOWED_VISIBILITY, ORD_ACCESS_STRATEGY,
 } = require("../../lib/constants");
 const {
     createEntityTypeTemplate,
@@ -412,7 +412,7 @@ describe("templates", () => {
                 `);
                 const srvDefinition = model.definitions["McpService"];
                 const packageIds = ["sap.test.cdsrc.sample:package:test-api:v1"];
-                const accessStrategies = [{ type: "open" }];
+                const accessStrategies = [{ type: ORD_ACCESS_STRATEGY.Open }];
 
                 const apiResourceTemplate = createAPIResourceTemplateMocked(
                     srvDefinition,

--- a/__tests__/unit/utils/test-helpers.js
+++ b/__tests__/unit/utils/test-helpers.js
@@ -1,4 +1,4 @@
-const { ORD_ACCESS_STRATEGY, AUTHENTICATION_TYPE } = require("../../../lib/constants");
+const { ORD_ACCESS_STRATEGY } = require("../../../lib/constants");
 
 /**
  * Create standard open authentication configuration object
@@ -6,8 +6,7 @@ const { ORD_ACCESS_STRATEGY, AUTHENTICATION_TYPE } = require("../../../lib/const
  */
 function createOpenAuthConfig() {
     return {
-        types: [AUTHENTICATION_TYPE.Open],
-        accessStrategies: [{ type: ORD_ACCESS_STRATEGY.Open }],
+        accessStrategies: [ORD_ACCESS_STRATEGY.Open],
     };
 }
 

--- a/__tests__/unit/version-suffix-extraction.test.js
+++ b/__tests__/unit/version-suffix-extraction.test.js
@@ -1,5 +1,5 @@
 const { createAPIResourceTemplate } = require("../../lib/templates");
-const { DATA_PRODUCT_ANNOTATION, DATA_PRODUCT_SIMPLE_ANNOTATION, DATA_PRODUCT_TYPE } = require("../../lib/constants");
+const { DATA_PRODUCT_ANNOTATION, DATA_PRODUCT_SIMPLE_ANNOTATION, DATA_PRODUCT_TYPE, ORD_ACCESS_STRATEGY } = require("../../lib/constants");
 
 describe("Version Suffix Extraction for Data Product Services", () => {
     const mockAppConfig = {
@@ -11,7 +11,7 @@ describe("Version Suffix Extraction for Data Product Services", () => {
     };
 
     const mockPackageIds = ["sap.test:package:test:v1"];
-    const mockAccessStrategies = [{ type: "open" }];
+    const mockAccessStrategies = [{ type: ORD_ACCESS_STRATEGY.Open }];
 
     describe("Positive Test Cases - Valid v<number> patterns", () => {
         test("should handle .v0 suffix correctly", () => {

--- a/docs/ord.md
+++ b/docs/ord.md
@@ -251,6 +251,7 @@ CF (Cloud Foundry) mTLS authentication provides secure machine-to-machine commun
 For SAP UCL (Unified Customer Landscape) integration:
 
 ```bash
+# Example configuration of the CF_MTLS_TRUSTED_CERTS environment variable
 export CF_MTLS_TRUSTED_CERTS='{
   "configEndpoints": ["https://your-ucl-endpoint/v1/info"],
   "rootCaDn": ["CN=SAP Cloud Root CA,O=SAP SE,L=Walldorf,C=DE"]
@@ -262,11 +263,14 @@ export CF_MTLS_TRUSTED_CERTS='{
 For custom certificates without UCL:
 
 ```bash
+# Example configuration of the CF_MTLS_TRUSTED_CERTS environment variable
 export CF_MTLS_TRUSTED_CERTS='{
   "certs": [{"issuer": "CN=My CA,O=MyOrg", "subject": "CN=my-service,O=MyOrg"}],
   "rootCaDn": ["CN=My Root CA,O=MyOrg"]
 }'
 ```
+
+Via CF_MTLS_TRUSTED_CERTS you can set the `accessStrategies` property, in order to explicitly define an array of mTLS access strategies to be used. The current list of supported values includes `sap:cmp-mtls:v1` (for UCL) and `sap.businesshub:mtls:v1` (for BAH). If not configured, the plugin defaults to `["sap:cmp-mtls:v1"]`.
 
 ---
 

--- a/lib/access-strategies.js
+++ b/lib/access-strategies.js
@@ -1,18 +1,6 @@
 const cds = require("@sap/cds");
-const { AUTHENTICATION_TYPE, ORD_ACCESS_STRATEGY } = require("./constants");
+const { ORD_ACCESS_STRATEGY, AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP } = require("./constants");
 const Logger = require("./logger");
-
-/**
- * Mapping from internal authentication types to ORD access strategy values.
- * This is the single source of truth for auth type to ORD document mapping.
- *
- * @private
- */
-const AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP = Object.freeze({
-    [AUTHENTICATION_TYPE.Open]: ORD_ACCESS_STRATEGY.Open,
-    [AUTHENTICATION_TYPE.Basic]: ORD_ACCESS_STRATEGY.Basic,
-    [AUTHENTICATION_TYPE.CfMtls]: ORD_ACCESS_STRATEGY.CfMtls,
-});
 
 /**
  * Derives ORD access strategies from authentication configuration.
@@ -41,13 +29,14 @@ function getAccessStrategiesFromAuthConfig(authConfig) {
     }
 
     const strategies = authConfig.types
-        .map((type) => {
-            const ordType = AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP[type];
-            if (!ordType) {
+        .flatMap((type) => {
+            const ordTypes = AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP[type];
+            if (!ordTypes) {
                 Logger.warn("getAccessStrategiesFromAuthConfig:", `Unknown auth type '${type}', skipping`);
                 return null;
             }
-            return { type: ordType };
+
+            return ordTypes.map((ordType) => ({ type: ordType }));
         })
         .filter(Boolean); // Remove null entries
 

--- a/lib/access-strategies.js
+++ b/lib/access-strategies.js
@@ -6,37 +6,38 @@ const Logger = require("./logger");
  * Derives ORD access strategies from authentication configuration.
  * This function is the main entry point for converting auth config to ORD document format.
  *
- * @param {Object} authConfig - Authentication configuration object
- * @param {string[]} authConfig.types - Array of authentication types (from AUTHENTICATION_TYPE)
+ * @param {string[]} accessStrategies - Array of access strategies (from ORD_ACCESS_STRATEGY)
  * @returns {Array<{type: string}>} Array of access strategy objects for ORD document
  *
  * @example
  * // With Basic auth configured
- * const authConfig = { types: ['basic'] };
- * const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+ * const accessStrategies = ['basic-auth'];
+ * const strategies = getAccessStrategiesFromAuthConfig(accessStrategies);
  * // Returns: [{ type: 'basic-auth' }]
  *
  * @example
- * // With multiple auth types
- * const authConfig = { types: ['basic', 'cf-mtls'] };
- * const strategies = getAccessStrategiesFromAuthConfig(authConfig);
+ * // With multiple access strategies
+ * const accessStrategies = ['basic-auth', 'sap:cmp-mtls:v1'];
+ * const strategies = getAccessStrategiesFromAuthConfig(accessStrategies);
  * // Returns: [{ type: 'basic-auth' }, { type: 'sap:cmp-mtls:v1' }]
  */
-function getAccessStrategiesFromAuthConfig(authConfig) {
-    if (!authConfig || !Array.isArray(authConfig.types)) {
+function getAccessStrategiesFromAuthConfig(accessStrategies) {
+    if (!accessStrategies || !Array.isArray(accessStrategies)) {
         Logger.warn("getAccessStrategiesFromAuthConfig:", "Invalid authConfig, defaulting to 'open'");
         return [{ type: ORD_ACCESS_STRATEGY.Open }];
     }
 
-    const strategies = authConfig.types
-        .flatMap((type) => {
-            const ordTypes = AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP[type];
-            if (!ordTypes) {
-                Logger.warn("getAccessStrategiesFromAuthConfig:", `Unknown auth type '${type}', skipping`);
+    const strategies = accessStrategies
+        .flatMap((strategy) => {
+            if (!Object.values(ORD_ACCESS_STRATEGY).includes(strategy)) {
+                Logger.warn(
+                    "getAccessStrategiesFromAuthConfig:",
+                    `Unknown access strategy type '${strategy}', skipping`,
+                );
                 return null;
             }
 
-            return ordTypes.map((ordType) => ({ type: ordType }));
+            return { type: strategy };
         })
         .filter(Boolean); // Remove null entries
 
@@ -55,10 +56,9 @@ function getAccessStrategiesFromAuthConfig(authConfig) {
  * @returns {boolean} True if any non-open strategy is present
  */
 function hasNonOpenStrategies(accessStrategies) {
-    if (!Array.isArray(accessStrategies)) {
-        return false;
-    }
-    return accessStrategies.some((s) => s.type !== ORD_ACCESS_STRATEGY.Open);
+    return (
+        Array.isArray(accessStrategies) && accessStrategies.some((strategy) => strategy.type !== ORD_ACCESS_STRATEGY.Open)
+    );
 }
 
 /**
@@ -73,7 +73,7 @@ function ensureNoOpenWhenNonOpenPresent(accessStrategies) {
         return;
     }
 
-    const hasOpen = accessStrategies.some((s) => s.type === ORD_ACCESS_STRATEGY.Open);
+    const hasOpen = accessStrategies.some((strategy) => strategy.type === ORD_ACCESS_STRATEGY.Open);
     const hasNonOpen = hasNonOpenStrategies(accessStrategies);
 
     if (hasOpen && hasNonOpen) {
@@ -131,21 +131,6 @@ function ensureAccessStrategies(accessStrategies, options = {}) {
     return accessStrategies;
 }
 
-/**
- * Validates that access strategies array contains only known ORD access strategy types.
- *
- * @param {Array<{type: string}>} accessStrategies - Array of access strategy objects
- * @returns {boolean} True if all strategies are valid
- */
-function isValidAccessStrategies(accessStrategies) {
-    if (!Array.isArray(accessStrategies) || accessStrategies.length === 0) {
-        return false;
-    }
-
-    const validTypes = Object.values(ORD_ACCESS_STRATEGY);
-    return accessStrategies.every((s) => s.type && validTypes.includes(s.type));
-}
-
 module.exports = {
     // Main API
     getAccessStrategiesFromAuthConfig,
@@ -154,7 +139,6 @@ module.exports = {
     // Helper functions
     hasNonOpenStrategies,
     ensureNoOpenWhenNonOpenPresent,
-    isValidAccessStrategies,
 
     // Constants (re-exported for convenience)
     AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP,

--- a/lib/access-strategies.js
+++ b/lib/access-strategies.js
@@ -1,5 +1,5 @@
 const cds = require("@sap/cds");
-const { ORD_ACCESS_STRATEGY, AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP } = require("./constants");
+const { ORD_ACCESS_STRATEGY } = require("./constants");
 const Logger = require("./logger");
 
 /**
@@ -139,7 +139,4 @@ module.exports = {
     // Helper functions
     hasNonOpenStrategies,
     ensureNoOpenWhenNonOpenPresent,
-
-    // Constants (re-exported for convenience)
-    AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP,
 };

--- a/lib/auth/authentication.js
+++ b/lib/auth/authentication.js
@@ -23,9 +23,14 @@
  */
 
 const cds = require("@sap/cds");
-const { AUTHENTICATION_TYPE, BASIC_AUTH_HEADER_KEY, AUTH_STRINGS, CF_MTLS_HEADERS } = require("../constants");
+const {
+    ORD_ACCESS_STRATEGY,
+    AUTHENTICATION_TYPE,
+    BASIC_AUTH_HEADER_KEY,
+    AUTH_STRINGS,
+    CF_MTLS_HEADERS,
+} = require("../constants");
 const Logger = require("../logger");
-const { getAccessStrategiesFromAuthConfig } = require("../access-strategies");
 const bcrypt = require("bcryptjs");
 const { createCfMtlsConfig, handleCfMtlsAuthentication } = require("./cf-mtls");
 
@@ -102,10 +107,10 @@ async function ensureCfMtlsValidator(authConfig) {
  * 1. Environment variables (BASIC_AUTH, CF_MTLS_TRUSTED_CERTS) - for production deployments
  * 2. .cdsrc.json settings (cds.env.ord.authentication.basic, cds.env.ord.authentication.cfMtls) - for development and testing
  *
- * Authentication types are automatically detected based on the presence of configuration:
- * - If cds.env.ord.authentication.basic exists → Basic authentication enabled
+ * Access strategies are automatically detected based on the presence of configuration:
+ * - If cds.env.ord.authentication.basic exists → 'basic-auth' is enabled
  * - If cds.env.ord.authentication.cfMtls exists → CF mTLS authentication enabled
- * - Multiple authentication types can coexist and are tried in order
+ * - Multiple access strategies can coexist and are tried in order
  * - Open authentication is the default when no secure authentication is configured
  *
  * This approach follows the 12-Factor App principles where environment variables
@@ -118,12 +123,11 @@ async function ensureCfMtlsValidator(authConfig) {
  */
 function createAuthConfig() {
     const defaultAuthConfig = {
-        types: [AUTHENTICATION_TYPE.Open],
-        accessStrategies: [{ type: AUTHENTICATION_TYPE.Open }],
+        accessStrategies: [ ORD_ACCESS_STRATEGY.Open ],
     };
 
     try {
-        const authConfig = { types: [] };
+        const authConfig = { accessStrategies: [] };
         const ordAuth = cds.env.ord?.authentication || {};
 
         // Detect Basic authentication by checking for credentials
@@ -145,30 +149,26 @@ function createAuthConfig() {
                 }
             }
 
-            authConfig.types.push(AUTHENTICATION_TYPE.Basic);
+            authConfig.accessStrategies.push(ORD_ACCESS_STRATEGY.Basic);
             authConfig.credentials = credentials;
         }
 
         // Detect CF mTLS authentication by checking for cfMtls config
         if (process.env.CF_MTLS_TRUSTED_CERTS || ordAuth.cfMtls) {
-            authConfig.types.push(AUTHENTICATION_TYPE.CfMtls);
+            const { accessStrategies } = JSON.parse(process.env.CF_MTLS_TRUSTED_CERTS || "{}");
             // Mark for lazy initialization - validator will be loaded on first use
             authConfig.cfMtlsValidator = null;
             authConfig._cfMtlsInitPromise = null;
+            authConfig.accessStrategies.push(...(accessStrategies || [ORD_ACCESS_STRATEGY.CmpMtls]));
         }
 
-        // If no authentication types detected, default to Open
-        if (authConfig.types.length === 0) {
+        // If no access strategies detected, default to Open
+        if (authConfig.accessStrategies.length === 0) {
             Logger.info("createAuthConfig:", 'No authentication configured. Defaulting to "Open" authentication');
             return defaultAuthConfig;
         }
 
-        // Build accessStrategies for ORD document using centralized mapping logic
-        // This ensures consistent mapping between auth types and ORD access strategies
-        // All mapping logic is centralized in lib/access-strategies.js
-        authConfig.accessStrategies = getAccessStrategiesFromAuthConfig(authConfig);
-
-        Logger.info("createAuthConfig:", `Configured authentication types: ${authConfig.types.join(", ")}`);
+        Logger.info("createAuthConfig:", `Configured access strategies: ${authConfig.accessStrategies.join(", ")}`);
         return authConfig;
     } catch (error) {
         Logger.error("createAuthConfig:", `Configuration error: ${error.message}`);
@@ -264,9 +264,10 @@ async function openAuthStrategy() {
  * Strategy registry mapping authentication types to their handlers
  */
 const AUTH_STRATEGIES = {
-    [AUTHENTICATION_TYPE.Basic]: basicAuthStrategy,
-    [AUTHENTICATION_TYPE.CfMtls]: cfMtlsAuthStrategy,
-    [AUTHENTICATION_TYPE.Open]: openAuthStrategy,
+    [ORD_ACCESS_STRATEGY.Open]: openAuthStrategy,
+    [ORD_ACCESS_STRATEGY.Basic]: basicAuthStrategy,
+    [ORD_ACCESS_STRATEGY.CmpMtls]: cfMtlsAuthStrategy,
+    [ORD_ACCESS_STRATEGY.BahMtls]: cfMtlsAuthStrategy,
 };
 
 /**
@@ -279,13 +280,13 @@ const AUTH_STRATEGIES = {
 function createAuthMiddleware(authConfig) {
     return async function authenticate(req, res, next) {
         // Handle invalid configuration
-        if (!authConfig || !authConfig.types || !Array.isArray(authConfig.types)) {
+        if (!authConfig || !authConfig.accessStrategies || !Array.isArray(authConfig.accessStrategies)) {
             Logger.error("Invalid auth configuration:", authConfig);
             return res.status(401).send("Not authorized");
         }
 
         // If open authentication, allow immediately
-        if (authConfig.types.includes(AUTHENTICATION_TYPE.Open)) {
+        if (authConfig.accessStrategies.includes(ORD_ACCESS_STRATEGY.Open)) {
             res.status(200);
             return next();
         }
@@ -293,17 +294,15 @@ function createAuthMiddleware(authConfig) {
         // Try each registered authentication strategy
         const results = [];
 
-        for (const authType of authConfig.types) {
-            const strategy = AUTH_STRATEGIES[authType];
-
-            if (!strategy) {
-                Logger.warn(`Unknown authentication type: ${authType}`);
+        for (const strategy of authConfig.accessStrategies) {
+            if (!Object.values(ORD_ACCESS_STRATEGY).includes(strategy)) {
+                Logger.warn(`Unknown access strategy: ${strategy}`);
                 continue;
             }
 
             try {
-                const result = await strategy(req, res, authConfig);
-                results.push({ type: authType, ...result });
+                const result = await AUTH_STRATEGIES[strategy](req, res, authConfig);
+                results.push({ type: strategy, ...result });
 
                 if (result.success) {
                     res.status(200);
@@ -315,8 +314,8 @@ function createAuthMiddleware(authConfig) {
                     return;
                 }
             } catch (error) {
-                Logger.error(`Error in ${authType} authentication:`, error.message);
-                results.push({ type: authType, success: false, handled: true, error: error.message });
+                Logger.error(`Error in ${strategy} authentication:`, error.message);
+                results.push({ type: strategy, success: false, handled: true, error: error.message });
             }
         }
 
@@ -328,7 +327,7 @@ function createAuthMiddleware(authConfig) {
             // No authentication method was attempted
             const wwwAuthHeaders = [];
 
-            if (authConfig.types.includes(AUTHENTICATION_TYPE.Basic)) {
+            if (authConfig.accessStrategies.includes(ORD_ACCESS_STRATEGY.Basic)) {
                 wwwAuthHeaders.push(AUTH_STRINGS.WWW_AUTHENTICATE_REALM);
             }
 

--- a/lib/auth/authentication.js
+++ b/lib/auth/authentication.js
@@ -25,7 +25,6 @@
 const cds = require("@sap/cds");
 const {
     ORD_ACCESS_STRATEGY,
-    AUTHENTICATION_TYPE,
     BASIC_AUTH_HEADER_KEY,
     AUTH_STRINGS,
     CF_MTLS_HEADERS,

--- a/lib/auth/authentication.js
+++ b/lib/auth/authentication.js
@@ -23,12 +23,7 @@
  */
 
 const cds = require("@sap/cds");
-const {
-    ORD_ACCESS_STRATEGY,
-    BASIC_AUTH_HEADER_KEY,
-    AUTH_STRINGS,
-    CF_MTLS_HEADERS,
-} = require("../constants");
+const { ORD_ACCESS_STRATEGY, BASIC_AUTH_HEADER_KEY, AUTH_STRINGS, CF_MTLS_HEADERS } = require("../constants");
 const Logger = require("../logger");
 const bcrypt = require("bcryptjs");
 const { createCfMtlsConfig, handleCfMtlsAuthentication } = require("./cf-mtls");
@@ -122,7 +117,7 @@ async function ensureCfMtlsValidator(authConfig) {
  */
 function createAuthConfig() {
     const defaultAuthConfig = {
-        accessStrategies: [ ORD_ACCESS_STRATEGY.Open ],
+        accessStrategies: [ORD_ACCESS_STRATEGY.Open],
     };
 
     try {
@@ -154,11 +149,15 @@ function createAuthConfig() {
 
         // Detect CF mTLS authentication by checking for cfMtls config
         if (process.env.CF_MTLS_TRUSTED_CERTS || ordAuth.cfMtls) {
-            const { accessStrategies } = JSON.parse(process.env.CF_MTLS_TRUSTED_CERTS || "{}");
+            const { accessStrategies } = JSON.parse(
+                process.env.CF_MTLS_TRUSTED_CERTS ??
+                    JSON.stringify(typeof ordAuth.cfMtls === "object" ? ordAuth.cfMtls : {}),
+            );
+
             // Mark for lazy initialization - validator will be loaded on first use
             authConfig.cfMtlsValidator = null;
             authConfig._cfMtlsInitPromise = null;
-            authConfig.accessStrategies.push(...(accessStrategies || [ORD_ACCESS_STRATEGY.CmpMtls]));
+            authConfig.accessStrategies.push(...(accessStrategies ?? [ORD_ACCESS_STRATEGY.CmpMtls]));
         }
 
         // If no access strategies detected, default to Open

--- a/lib/auth/cf-mtls.js
+++ b/lib/auth/cf-mtls.js
@@ -1,3 +1,4 @@
+const { ORD_ACCESS_STRATEGY } = require("../constants");
 /**
  * CF mTLS Subject Validation Module
  *
@@ -341,12 +342,12 @@ async function createCfMtlsConfig(cds, Logger) {
  * @param {Object} res - Express response object
  * @param {Object} authConfig - Authentication configuration
  * @param {Function} authConfig.cfMtlsValidator - CF mTLS validator function
- * @param {Array} authConfig.types - Array of enabled authentication types
+ * @param {Array<string>} authConfig.accessStrategies - Array of enabled access strategies
  * @param {Object} Logger - Logger instance for error messages
  * @returns {Object} Result object with success flag and optional next() call
  */
 function handleCfMtlsAuthentication(req, res, authConfig, Logger) {
-    const { AUTHENTICATION_TYPE, CF_MTLS_ERROR_REASON, AUTH_STRINGS } = require("../constants");
+    const { CF_MTLS_ERROR_REASON, AUTH_STRINGS } = require("../constants");
     const result = authConfig.cfMtlsValidator(req);
 
     if (result.ok) {
@@ -361,7 +362,7 @@ function handleCfMtlsAuthentication(req, res, authConfig, Logger) {
     if (result.reason === CF_MTLS_ERROR_REASON.XFCC_VERIFICATION_FAILED) {
         Logger.error("CF mTLS authentication failed: Missing proxy verification");
         // If Basic auth is also configured, provide fallback
-        if (authConfig.types.includes(AUTHENTICATION_TYPE.Basic)) {
+        if (authConfig.accessStrategies.includes(ORD_ACCESS_STRATEGY.Basic)) {
             res.status(401)
                 .setHeader("WWW-Authenticate", AUTH_STRINGS.WWW_AUTHENTICATE_REALM)
                 .send("Authentication required.");
@@ -373,7 +374,7 @@ function handleCfMtlsAuthentication(req, res, authConfig, Logger) {
 
     if (result.reason === CF_MTLS_ERROR_REASON.NO_HEADERS) {
         // If Basic auth is also configured, provide a more informative message
-        if (authConfig.types.includes(AUTHENTICATION_TYPE.Basic)) {
+        if (authConfig.accessStrategies.includes(ORD_ACCESS_STRATEGY.Basic)) {
             res.status(401)
                 .setHeader("WWW-Authenticate", AUTH_STRINGS.WWW_AUTHENTICATE_REALM)
                 .send("Authentication required.");
@@ -386,7 +387,7 @@ function handleCfMtlsAuthentication(req, res, authConfig, Logger) {
     if (result.reason === CF_MTLS_ERROR_REASON.HEADER_MISSING) {
         Logger.error(`CF mTLS authentication failed: Missing header ${result.missing}`);
         // If Basic auth is also configured, provide fallback
-        if (authConfig.types.includes(AUTHENTICATION_TYPE.Basic)) {
+        if (authConfig.accessStrategies.includes(ORD_ACCESS_STRATEGY.Basic)) {
             res.status(401)
                 .setHeader("WWW-Authenticate", AUTH_STRINGS.WWW_AUTHENTICATE_REALM)
                 .send("Authentication required.");

--- a/lib/auth/cf-mtls.js
+++ b/lib/auth/cf-mtls.js
@@ -1,4 +1,3 @@
-const { ORD_ACCESS_STRATEGY } = require("../constants");
 /**
  * CF mTLS Subject Validation Module
  *
@@ -347,7 +346,7 @@ async function createCfMtlsConfig(cds, Logger) {
  * @returns {Object} Result object with success flag and optional next() call
  */
 function handleCfMtlsAuthentication(req, res, authConfig, Logger) {
-    const { CF_MTLS_ERROR_REASON, AUTH_STRINGS } = require("../constants");
+    const { ORD_ACCESS_STRATEGY, CF_MTLS_ERROR_REASON, AUTH_STRINGS } = require("../constants");
     const result = authConfig.cfMtlsValidator(req);
 
     if (result.ok) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,9 +1,3 @@
-const AUTHENTICATION_TYPE = Object.freeze({
-    Open: "open",
-    Basic: "basic",
-    CfMtls: "cf-mtls",
-});
-
 const BASIC_AUTH_HEADER_KEY = "authorization";
 
 const BUILD_DEFAULT_PATH = "gen/ord";
@@ -13,12 +7,6 @@ const ORD_ACCESS_STRATEGY = Object.freeze({
     Basic: "basic-auth",
     CmpMtls: "sap:cmp-mtls:v1",
     BahMtls: "sap.businesshub:mtls:v1",
-});
-
-const AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP = Object.freeze({
-    [AUTHENTICATION_TYPE.Open]: [ORD_ACCESS_STRATEGY.Open],
-    [AUTHENTICATION_TYPE.Basic]: [ORD_ACCESS_STRATEGY.Basic],
-    [AUTHENTICATION_TYPE.CfMtls]: [ORD_ACCESS_STRATEGY.CmpMtls, ORD_ACCESS_STRATEGY.BahMtls],
 });
 
 // CF mTLS default header names
@@ -184,8 +172,6 @@ const DOCUMENT_PERSPECTIVES = Object.freeze({
 const LOCAL_TENANT_ID_HEADER_KEY = "local-tenant-id";
 
 module.exports = {
-    AUTHENTICATION_TYPE,
-    AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP,
     BASIC_AUTH_HEADER_KEY,
     BUILD_DEFAULT_PATH,
     CAP_TO_ORD_PROTOCOL_MAP,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -11,13 +11,14 @@ const BUILD_DEFAULT_PATH = "gen/ord";
 const ORD_ACCESS_STRATEGY = Object.freeze({
     Open: "open",
     Basic: "basic-auth",
-    CfMtls: "sap:cmp-mtls:v1",
+    CmpMtls: "sap:cmp-mtls:v1",
+    BahMtls: "sap.businesshub:mtls:v1",
 });
 
 const AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP = Object.freeze({
-    [AUTHENTICATION_TYPE.Open]: ORD_ACCESS_STRATEGY.Open,
-    [AUTHENTICATION_TYPE.Basic]: ORD_ACCESS_STRATEGY.Basic,
-    [AUTHENTICATION_TYPE.CfMtls]: ORD_ACCESS_STRATEGY.CfMtls,
+    [AUTHENTICATION_TYPE.Open]: [ORD_ACCESS_STRATEGY.Open],
+    [AUTHENTICATION_TYPE.Basic]: [ORD_ACCESS_STRATEGY.Basic],
+    [AUTHENTICATION_TYPE.CfMtls]: [ORD_ACCESS_STRATEGY.CmpMtls, ORD_ACCESS_STRATEGY.BahMtls],
 });
 
 // CF mTLS default header names

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,6 +3,7 @@ const _ = require("lodash");
 const cds = require("@sap/cds");
 const { join } = require("path");
 
+const { getAccessStrategiesFromAuthConfig } = require("./access-strategies");
 const {
     ORD_RESOURCE_TYPE,
     SHORT_DESCRIPTION_PREFIX,
@@ -127,7 +128,7 @@ module.exports = {
         // If auth config is not available, fall back to empty array
         const toggles = cds.env.requires.toggles;
         const extensibility = cds.env.requires.extensibility;
-        const accessStrategies = authConfig?.accessStrategies || [];
+        const accessStrategies = getAccessStrategiesFromAuthConfig(authConfig?.accessStrategies || []);
 
         return {
             openResourceDiscoveryV1: {

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -6,6 +6,7 @@ const defaults = require("./defaults");
 const { createAuthConfig } = require("./auth/authentication");
 const Configuration = require("./configuration");
 const { getIntegrationDependencies } = require("./integration-dependency");
+const { getAccessStrategiesFromAuthConfig } = require("./access-strategies");
 const {
     getCustomORDContent,
     compareAndHandleCustomORDContentWithExistingContent,
@@ -60,8 +61,9 @@ const _createDefaultORDDocument = (linkedCsn, appConfig, authConfig) => {
     const packageIds = packages?.map((pkg) => pkg.ordId) || [];
     const entityTypes = _getEntityTypes(appConfig, packageIds);
     const integrationDependencies = getIntegrationDependencies(linkedCsn, appConfig, packageIds);
-    const apiResources = _getAPIResources(linkedCsn, appConfig, packageIds, authConfig.accessStrategies);
-    const eventResources = _getEventResources(linkedCsn, appConfig, packageIds, authConfig.accessStrategies);
+    const accessStrategies = getAccessStrategiesFromAuthConfig(authConfig.accessStrategies || []);
+    const apiResources = _getAPIResources(linkedCsn, appConfig, packageIds, accessStrategies);
+    const eventResources = _getEventResources(linkedCsn, appConfig, packageIds, accessStrategies);
 
     return {
         // Unconditionally added top-level properties

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -119,7 +119,7 @@ function _getEntityVersion(entity) {
  * @param {string} ordId The ordId of the resource.
  * @param {string} serviceName The name of the service.
  * @param {string} fileExtension The file extension of the resource.
- * @param {Array} accessStrategies The array of accessStrategies objects (required, no default)
+ * @param {Array<{type: string}>} accessStrategies The array of accessStrategies objects (required, no default)
  * @returns {Object} A resource definition object.
  * @private
  */
@@ -256,7 +256,7 @@ function _handleVisibility(ordExtensions, definition, defaultVisibility = RESOUR
  * @param {object} srvDefinition The definition of the service
  * @param {object} appConfig - The application configuration.
  * @param {Array} packageIds - The available package identifiers.
- * @param {Array} accessStrategies The array of accessStrategies objects
+ * @param {Array<{type: string}>} accessStrategies The array of accessStrategies objects
  * @returns {Array} An array of objects for the API Resources.
  */
 const createAPIResourceTemplate = (srvDefinition, appConfig, packageIds, accessStrategies) => {
@@ -423,7 +423,7 @@ const createAPIResourceTemplate = (srvDefinition, appConfig, packageIds, accessS
  * @param {object} srvDefinition The definition of the service
  * @param {object} appConfig - The application configuration.
  * @param {Array} packageIds - The available package identifiers.
- * @param {Array} accessStrategies The array of accessStrategies objects
+ * @param {Array<{type: string}>} accessStrategies The array of accessStrategies objects
  * @returns {Array} An single-item array of objects for the Event Resources.
  */
 const createEventResourceTemplate = (srvDefinition, appConfig, packageIds, accessStrategies) => {

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -138,9 +138,10 @@ isPrimaryDataProduct → "internal"
 
 ```javascript
 const AUTH_STRATEGIES = {
-    [AUTHENTICATION_TYPE.Basic]:  basicAuthStrategy,   // bcrypt compare
-    [AUTHENTICATION_TYPE.CfMtls]: cfMtlsAuthStrategy,  // lazy-init CF mTLS validator
-    [AUTHENTICATION_TYPE.Open]:   openAuthStrategy,    // always success
+    [ORD_ACCESS_STRATEGY.Open]:   openAuthStrategy,    // always success
+    [ORD_ACCESS_STRATEGY.Basic]:  basicAuthStrategy,   // bcrypt compare
+    [ORD_ACCESS_STRATEGY.CmpMtls]: cfMtlsAuthStrategy,  // lazy-init CF mTLS validator
+    [ORD_ACCESS_STRATEGY.BahMtls]: cfMtlsAuthStrategy,  // lazy-init CF mTLS validator
 };
 
 function createAuthMiddleware(authConfig) {


### PR DESCRIPTION
# Add Support for `sap.businesshub:mtls:v1` mTLS Access Strategy

### New Features

✨ Extended mTLS access strategy support by adding `BahMtls` (`sap.businesshub:mtls:v1`) alongside the existing `CmpMtls` (`sap:cmp-mtls:v1`) strategy. When CF mTLS authentication is configured, ORD documents now expose both strategies simultaneously, ensuring broader compatibility with SAP Business Hub's mTLS authentication expectations.

As part of this change, the internal `AUTHENTICATION_TYPE` enum and `AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP` have been removed in favor of a simplified, unified `ORD_ACCESS_STRATEGY`-based approach. The `authConfig.types` field has been eliminated — auth configuration now only carries a flat `accessStrategies` string array.

### Changes

* `lib/constants.js`: Removed `AUTHENTICATION_TYPE` and `AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP`. Renamed `CfMtls` → `CmpMtls` in `ORD_ACCESS_STRATEGY` and added `BahMtls: "sap.businesshub:mtls:v1"`.
* `lib/auth/authentication.js`: Replaced `authConfig.types` with `authConfig.accessStrategies` throughout. CF mTLS config now reads `accessStrategies` from `CF_MTLS_TRUSTED_CERTS` env var, falling back to `[ORD_ACCESS_STRATEGY.CmpMtls]`. Both `CmpMtls` and `BahMtls` are mapped to the same `cfMtlsAuthStrategy` handler.
* `lib/access-strategies.js`: Removed `AUTH_TYPE_ORD_ACCESS_STRATEGY_MAP` and `isValidAccessStrategies`. Refactored `getAccessStrategiesFromAuthConfig` to accept a plain `string[]` of `ORD_ACCESS_STRATEGY` values and simplified `hasNonOpenStrategies`.
* `lib/defaults.js` / `lib/ord.js`: Now call `getAccessStrategiesFromAuthConfig` to convert raw `accessStrategies` strings to `{ type }` objects before building ORD documents.
* `lib/auth/cf-mtls.js`: Updated JSDoc and replaced `AUTHENTICATION_TYPE` references with `ORD_ACCESS_STRATEGY`.
* `lib/templates.js`: Updated JSDoc type annotations for `accessStrategies` parameters.
* `README.md` / `docs/ord.md`: Updated configuration examples to include `accessStrategies` field and document the new `sap.businesshub:mtls:v1` strategy option.
* `__tests__/unit/access-strategies.test.js`: Removed `isValidAccessStrategies` tests; updated all references from `AUTHENTICATION_TYPE`/`CfMtls` to `ORD_ACCESS_STRATEGY`/`CmpMtls`.
* `__tests__/unit/authentication.test.js`: Removed `authConfig.types` assertions; updated all CF mTLS tests to use `ORD_ACCESS_STRATEGY.CmpMtls`.
* `__tests__/unit/defaults.test.js`, `ord.test.js`, `split-up-packages-csn.test.js`, `utils/test-helpers.js`: Aligned mock `authConfig` objects to the new flat `accessStrategies` shape.
* `__tests__/integration/__snapshots__/mtls-auth.test.js.snap`: Updated snapshots to include `{ type: "sap.businesshub:mtls:v1" }` in all `accessStrategies` arrays.
* `__tests__/integration/mtls-auth.test.js`: Added both `sap:cmp-mtls:v1` and `sap.businesshub:mtls:v1` to the mTLS test configuration.
* `memory-bank/systemPatterns.md`: Updated `AUTH_STRATEGIES` registry documentation to reflect the new `ORD_ACCESS_STRATEGY`-keyed entries.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Correlation ID: `f0d29724-e24e-4cfe-96d7-b8ffff4aafb4`
- Event Trigger: `issue_comment.edited`
</details>
