### PR TITLE
chore: Extract 'createEventResourceTemplate'

### DIFF
--- a/__tests__/unit/__snapshots__/namespace.test.js.snap
+++ b/__tests__/unit/__snapshots__/namespace.test.js.snap
@@ -49,37 +49,35 @@ exports[`namespace local and global should not strip a different local namespace
 `;
 
 exports[`namespace local and global should not strip a different local namespace 2`] = `
-[
-  {
-    "description": "CAP Event resource describing events / messages.",
-    "extensible": {
-      "supported": "no",
-    },
-    "lastUpdate": "2022-12-19T15:47:04+00:00",
-    "ordId": "customer.testNamespace:eventResource:other.namespace.MyService:v1",
-    "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:other.namespace.MyService",
-    ],
-    "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
-    "releaseStatus": "active",
-    "resourceDefinitions": [
-      {
-        "accessStrategies": [
-          {
-            "type": "open",
-          },
-        ],
-        "mediaType": "application/json",
-        "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:other.namespace.MyService:v1/other.namespace.MyService.asyncapi2.json",
-      },
-    ],
-    "shortDescription": "other.namespace.MyService event resource",
-    "title": "ODM testAppName Events",
-    "version": "1.0.0",
-    "visibility": "public",
+{
+  "description": "CAP Event resource describing events / messages.",
+  "extensible": {
+    "supported": "no",
   },
-]
+  "lastUpdate": "2022-12-19T15:47:04+00:00",
+  "ordId": "customer.testNamespace:eventResource:other.namespace.MyService:v1",
+  "partOfGroups": [
+    "sap.cds:service:customer.testNamespace:other.namespace.MyService",
+  ],
+  "partOfPackage": "customer.testNamespace:package:testAppName:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "open",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "asyncapi-v2",
+      "url": "/ord/v1/customer.testNamespace:eventResource:other.namespace.MyService:v1/other.namespace.MyService.asyncapi2.json",
+    },
+  ],
+  "shortDescription": "other.namespace.MyService event resource",
+  "title": "ODM testAppName Events",
+  "version": "1.0.0",
+  "visibility": "public",
+}
 `;
 
 exports[`namespace local and global should strip application namespace from local namespace 1`] = `
@@ -131,37 +129,35 @@ exports[`namespace local and global should strip application namespace from loca
 `;
 
 exports[`namespace local and global should strip application namespace from local namespace 2`] = `
-[
-  {
-    "description": "CAP Event resource describing events / messages.",
-    "extensible": {
-      "supported": "no",
-    },
-    "lastUpdate": "2022-12-19T15:47:04+00:00",
-    "ordId": "customer.testNamespace:eventResource:nested.MyService:v1",
-    "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:nested.MyService",
-    ],
-    "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
-    "releaseStatus": "active",
-    "resourceDefinitions": [
-      {
-        "accessStrategies": [
-          {
-            "type": "open",
-          },
-        ],
-        "mediaType": "application/json",
-        "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:nested.MyService:v1/customer.testNamespace.nested.MyService.asyncapi2.json",
-      },
-    ],
-    "shortDescription": "customer.testNamespace.nested.MyService event resource",
-    "title": "ODM testAppName Events",
-    "version": "1.0.0",
-    "visibility": "public",
+{
+  "description": "CAP Event resource describing events / messages.",
+  "extensible": {
+    "supported": "no",
   },
-]
+  "lastUpdate": "2022-12-19T15:47:04+00:00",
+  "ordId": "customer.testNamespace:eventResource:nested.MyService:v1",
+  "partOfGroups": [
+    "sap.cds:service:customer.testNamespace:nested.MyService",
+  ],
+  "partOfPackage": "customer.testNamespace:package:testAppName:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "open",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "asyncapi-v2",
+      "url": "/ord/v1/customer.testNamespace:eventResource:nested.MyService:v1/customer.testNamespace.nested.MyService.asyncapi2.json",
+    },
+  ],
+  "shortDescription": "customer.testNamespace.nested.MyService event resource",
+  "title": "ODM testAppName Events",
+  "version": "1.0.0",
+  "visibility": "public",
+}
 `;
 
 exports[`namespace local and global should strip application namespace if its the same as local namespace 1`] = `
@@ -213,35 +209,33 @@ exports[`namespace local and global should strip application namespace if its th
 `;
 
 exports[`namespace local and global should strip application namespace if its the same as local namespace 2`] = `
-[
-  {
-    "description": "CAP Event resource describing events / messages.",
-    "extensible": {
-      "supported": "no",
-    },
-    "lastUpdate": "2022-12-19T15:47:04+00:00",
-    "ordId": "customer.testNamespace:eventResource:MyService:v1",
-    "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:MyService",
-    ],
-    "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
-    "releaseStatus": "active",
-    "resourceDefinitions": [
-      {
-        "accessStrategies": [
-          {
-            "type": "open",
-          },
-        ],
-        "mediaType": "application/json",
-        "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v1/customer.testNamespace.MyService.asyncapi2.json",
-      },
-    ],
-    "shortDescription": "customer.testNamespace.MyService event resource",
-    "title": "ODM testAppName Events",
-    "version": "1.0.0",
-    "visibility": "public",
+{
+  "description": "CAP Event resource describing events / messages.",
+  "extensible": {
+    "supported": "no",
   },
-]
+  "lastUpdate": "2022-12-19T15:47:04+00:00",
+  "ordId": "customer.testNamespace:eventResource:MyService:v1",
+  "partOfGroups": [
+    "sap.cds:service:customer.testNamespace:MyService",
+  ],
+  "partOfPackage": "customer.testNamespace:package:testAppName:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "open",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "asyncapi-v2",
+      "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v1/customer.testNamespace.MyService.asyncapi2.json",
+    },
+  ],
+  "shortDescription": "customer.testNamespace.MyService event resource",
+  "title": "ODM testAppName Events",
+  "version": "1.0.0",
+  "visibility": "public",
+}
 `;

--- a/__tests__/unit/__snapshots__/templates.test.js.snap
+++ b/__tests__/unit/__snapshots__/templates.test.js.snap
@@ -330,71 +330,67 @@ exports[`templates createEntityTypeTemplate should return entity type with incor
 `;
 
 exports[`templates createEventResourceTemplate should create event resource template correctly 1`] = `
-[
-  {
-    "description": "CAP Event resource describing events / messages.",
-    "extensible": {
-      "supported": "no",
-    },
-    "lastUpdate": "2022-12-19T15:47:04+00:00",
-    "ordId": "customer.testNamespace:eventResource:MyService:v1",
-    "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:MyService",
-    ],
-    "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
-    "releaseStatus": "active",
-    "resourceDefinitions": [
-      {
-        "accessStrategies": [
-          {
-            "type": "open",
-          },
-        ],
-        "mediaType": "application/json",
-        "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v1/MyService.asyncapi2.json",
-      },
-    ],
-    "shortDescription": "MyService event resource",
-    "title": "ODM testAppName Events",
-    "version": "1.0.0",
-    "visibility": "public",
+{
+  "description": "CAP Event resource describing events / messages.",
+  "extensible": {
+    "supported": "no",
   },
-]
+  "lastUpdate": "2022-12-19T15:47:04+00:00",
+  "ordId": "customer.testNamespace:eventResource:MyService:v1",
+  "partOfGroups": [
+    "sap.cds:service:customer.testNamespace:MyService",
+  ],
+  "partOfPackage": "customer.testNamespace:package:testAppName:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "open",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "asyncapi-v2",
+      "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v1/MyService.asyncapi2.json",
+    },
+  ],
+  "shortDescription": "MyService event resource",
+  "title": "ODM testAppName Events",
+  "version": "1.0.0",
+  "visibility": "public",
+}
 `;
 
 exports[`templates createEventResourceTemplate should create event resource template correctly with packageIds including namespace 1`] = `
-[
-  {
-    "description": "CAP Event resource describing events / messages.",
-    "extensible": {
-      "supported": "no",
-    },
-    "lastUpdate": "2022-12-19T15:47:04+00:00",
-    "ordId": "customer.testNamespace:eventResource:MyService:v1",
-    "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:MyService",
-    ],
-    "partOfPackage": "customer.testNamespace:package:test:v1",
-    "releaseStatus": "active",
-    "resourceDefinitions": [
-      {
-        "accessStrategies": [
-          {
-            "type": "open",
-          },
-        ],
-        "mediaType": "application/json",
-        "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v1/MyService.asyncapi2.json",
-      },
-    ],
-    "shortDescription": "MyService event resource",
-    "title": "ODM testAppName Events",
-    "version": "1.0.0",
-    "visibility": "public",
+{
+  "description": "CAP Event resource describing events / messages.",
+  "extensible": {
+    "supported": "no",
   },
-]
+  "lastUpdate": "2022-12-19T15:47:04+00:00",
+  "ordId": "customer.testNamespace:eventResource:MyService:v1",
+  "partOfGroups": [
+    "sap.cds:service:customer.testNamespace:MyService",
+  ],
+  "partOfPackage": "customer.testNamespace:package:testAppName:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "open",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "asyncapi-v2",
+      "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v1/MyService.asyncapi2.json",
+    },
+  ],
+  "shortDescription": "MyService event resource",
+  "title": "ODM testAppName Events",
+  "version": "1.0.0",
+  "visibility": "public",
+}
 `;
 
 exports[`templates getExposedEntityTypes should clean up duplicates 1`] = `
@@ -462,37 +458,35 @@ exports[`templates ordExtension should add apiResources with ORD Extension "visi
 `;
 
 exports[`templates ordExtension should add events with ORD Extension "visibility=public" 1`] = `
-[
-  {
-    "description": "CAP Event resource describing events / messages.",
-    "extensible": {
-      "supported": "yes",
-    },
-    "lastUpdate": "2022-12-19T15:47:04+00:00",
-    "ordId": "customer.testNamespace:eventResource:MyService:v2",
-    "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:MyService",
-    ],
-    "partOfPackage": "sap.test.cdsrc.sample:package:test-event:v1",
-    "releaseStatus": "active",
-    "resourceDefinitions": [
-      {
-        "accessStrategies": [
-          {
-            "type": "open",
-          },
-        ],
-        "mediaType": "application/json",
-        "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v2/MyService.asyncapi2.json",
-      },
-    ],
-    "shortDescription": "short description for test MyService event",
-    "title": "This is test MyService event title",
-    "version": "2.0.0",
-    "visibility": "public",
+{
+  "description": "CAP Event resource describing events / messages.",
+  "extensible": {
+    "supported": "yes",
   },
-]
+  "lastUpdate": "2022-12-19T15:47:04+00:00",
+  "ordId": "customer.testNamespace:eventResource:MyService:v2",
+  "partOfGroups": [
+    "sap.cds:service:customer.testNamespace:MyService",
+  ],
+  "partOfPackage": "customer.testNamespace:package:testAppName:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "open",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "asyncapi-v2",
+      "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v2/MyService.asyncapi2.json",
+    },
+  ],
+  "shortDescription": "short description for test MyService event",
+  "title": "This is test MyService event title",
+  "version": "2.0.0",
+  "visibility": "public",
+}
 `;
 
 exports[`templates ordExtension should find association on nested entities for related service 1`] = `
@@ -773,39 +767,35 @@ exports[`templates ordExtension should include internal API resources but ensure
 `;
 
 exports[`templates ordExtension should include internal events but ensure they appear in a separate package 1`] = `
-[
-  {
-    "description": "CAP Event resource describing events / messages.",
-    "extensible": {
-      "supported": "yes",
-    },
-    "lastUpdate": "2022-12-19T15:47:04+00:00",
-    "ordId": "customer.testNamespace:eventResource:MyService:v2",
-    "partOfGroups": [
-      "sap.cds:service:customer.testNamespace:MyService",
-    ],
-    "partOfPackage": "sap.test.cdsrc.sample:package:test-event-internal:v1",
-    "releaseStatus": "active",
-    "resourceDefinitions": [
-      {
-        "accessStrategies": [
-          {
-            "type": "open",
-          },
-        ],
-        "mediaType": "application/json",
-        "type": "asyncapi-v2",
-        "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v2/MyService.asyncapi2.json",
-      },
-    ],
-    "shortDescription": "short description for test MyService event",
-    "title": "This is test MyService event title",
-    "version": "2.0.0",
-    "visibility": "internal",
+{
+  "description": "CAP Event resource describing events / messages.",
+  "extensible": {
+    "supported": "yes",
   },
-]
+  "lastUpdate": "2022-12-19T15:47:04+00:00",
+  "ordId": "customer.testNamespace:eventResource:MyService:v2",
+  "partOfGroups": [
+    "sap.cds:service:customer.testNamespace:MyService",
+  ],
+  "partOfPackage": "customer.testNamespace:package:testAppName:v1",
+  "releaseStatus": "active",
+  "resourceDefinitions": [
+    {
+      "accessStrategies": [
+        {
+          "type": "open",
+        },
+      ],
+      "mediaType": "application/json",
+      "type": "asyncapi-v2",
+      "url": "/ord/v1/customer.testNamespace:eventResource:MyService:v2/MyService.asyncapi2.json",
+    },
+  ],
+  "shortDescription": "short description for test MyService event",
+  "title": "This is test MyService event title",
+  "version": "2.0.0",
+  "visibility": "internal",
+}
 `;
 
 exports[`templates ordExtension should not add apiResources with ORD Extension "visibility=private" 1`] = `[]`;
-
-exports[`templates ordExtension should not add events with ORD Extension "visibility=private" 1`] = `[]`;

--- a/__tests__/unit/common/utils.test.js
+++ b/__tests__/unit/common/utils.test.js
@@ -1,4 +1,13 @@
-const { getRFC3339Date, isPrimaryDataProductService } = require("../../../lib/common/utils");
+const {
+    getRFC3339Date,
+    isPrimaryDataProductService,
+    resolveVisibility,
+    resolveServiceName,
+    flattenEntityGraph,
+    readORDExtensions,
+} = require("../../../lib/common/utils");
+const { RESOURCE_VISIBILITY } = require("../../../lib/constants");
+const Logger = require("../../../lib/logger");
 
 const RFC3339_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
@@ -76,5 +85,155 @@ describe("date", () => {
 
         lastUpdate = "1937-01-01T12:00:27.87+00:20";
         expect(lastUpdate).toMatch(RFC3339_REGEX);
+    });
+});
+
+describe("resolveVisibility", () => {
+    const BASE_APP_CONFIG = { env: { defaultVisibility: RESOURCE_VISIBILITY.public } };
+
+    it("returns public by default", () => {
+        expect(resolveVisibility(BASE_APP_CONFIG, {})).toBe(RESOURCE_VISIBILITY.public);
+    });
+
+    it("returns public when appConfig.env is absent", () => {
+        expect(resolveVisibility({}, {})).toBe(RESOURCE_VISIBILITY.public);
+    });
+
+    it("uses appConfig.env.defaultVisibility when no service override", () => {
+        const appConfig = { env: { defaultVisibility: RESOURCE_VISIBILITY.internal } };
+        expect(resolveVisibility(appConfig, {})).toBe(RESOURCE_VISIBILITY.internal);
+    });
+
+    it("returns internal for a primary data product regardless of default", () => {
+        const service = { "@DataIntegration.dataProduct.type": "primary" };
+        const appConfig = { env: { defaultVisibility: RESOURCE_VISIBILITY.public } };
+        expect(resolveVisibility(appConfig, service)).toBe(RESOURCE_VISIBILITY.internal);
+    });
+
+    it("prefers @ORD.Extensions.visibility over defaultVisibility", () => {
+        const service = { "@ORD.Extensions.visibility": RESOURCE_VISIBILITY.private };
+        expect(resolveVisibility(BASE_APP_CONFIG, service)).toBe(RESOURCE_VISIBILITY.private);
+    });
+
+    it("returns public when @ORD.Extensions.implementationStandard is a supported ORD document standard", () => {
+        const service = { "@ORD.Extensions.implementationStandard": "sap:ord-document-api:v1" };
+        const appConfig = { env: { defaultVisibility: RESOURCE_VISIBILITY.internal } };
+        expect(resolveVisibility(appConfig, service)).toBe(RESOURCE_VISIBILITY.public);
+    });
+
+    it("warns and falls back to public when defaultVisibility is unsupported", () => {
+        const warnSpy = jest.spyOn(Logger, "warn").mockImplementation(() => {});
+        const appConfig = { env: { defaultVisibility: "unsupported" } };
+        expect(resolveVisibility(appConfig, {})).toBe(RESOURCE_VISIBILITY.public);
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+
+    it("primary data product visibility takes precedence over @ORD.Extensions.visibility", () => {
+        const service = {
+            "@DataIntegration.dataProduct.type": "primary",
+            "@ORD.Extensions.visibility": RESOURCE_VISIBILITY.public,
+        };
+        expect(resolveVisibility(BASE_APP_CONFIG, service)).toBe(RESOURCE_VISIBILITY.internal);
+    });
+});
+
+describe("resolveServiceName", () => {
+    it("returns the name unchanged when it matches no namespace", () => {
+        const appConfig = { ordNamespace: "sap.test" };
+        expect(resolveServiceName(appConfig, { name: "com.other.MyService" })).toBe("com.other.MyService");
+    });
+
+    it("strips ordNamespace prefix from service name", () => {
+        const appConfig = { ordNamespace: "sap.test" };
+        expect(resolveServiceName(appConfig, { name: "sap.test.MyService" })).toBe("MyService");
+    });
+
+    it("returns empty string when name equals the namespace exactly", () => {
+        const appConfig = { ordNamespace: "sap.test" };
+        expect(resolveServiceName(appConfig, { name: "sap.test" })).toBe("");
+    });
+
+    it("prefers internalNamespace over ordNamespace when both match", () => {
+        const appConfig = { internalNamespace: "sap.internal", ordNamespace: "sap.internal" };
+        expect(resolveServiceName(appConfig, { name: "sap.internal.MyService" })).toBe("MyService");
+    });
+
+    it("falls back to ordNamespace when internalNamespace does not match", () => {
+        const appConfig = { internalNamespace: "sap.internal", ordNamespace: "sap.test" };
+        expect(resolveServiceName(appConfig, { name: "sap.test.MyService" })).toBe("MyService");
+    });
+
+    it("does not strip a partial namespace prefix", () => {
+        const appConfig = { ordNamespace: "sap.test" };
+        expect(resolveServiceName(appConfig, { name: "sap.testing.MyService" })).toBe("sap.testing.MyService");
+    });
+});
+
+describe("flattenEntityGraph", () => {
+    it("returns a single-element array for an entity with no associations", () => {
+        const entity = { name: "Root" };
+        expect(flattenEntityGraph(entity)).toEqual([entity]);
+    });
+
+    it("includes directly associated entities", () => {
+        const child = { name: "Child" };
+        const root = { name: "Root", associations: { toChild: { target: "Child", _target: child } } };
+        const result = flattenEntityGraph(root);
+        expect(result).toHaveLength(2);
+        expect(result).toContain(root);
+        expect(result).toContain(child);
+    });
+
+    it("flattens a multi-level association chain", () => {
+        const grandchild = { name: "GrandChild" };
+        const child = { name: "Child", associations: { toGrand: { target: "GrandChild", _target: grandchild } } };
+        const root = { name: "Root", associations: { toChild: { target: "Child", _target: child } } };
+        const result = flattenEntityGraph(root);
+        expect(result).toHaveLength(3);
+        expect(result).toContain(grandchild);
+    });
+
+    it("does not follow already-visited targets (cycle guard)", () => {
+        const child = { name: "Child", associations: {} };
+        const grandchild = { name: "GrandChild" };
+        child.associations.toGrand = { target: "GrandChild", _target: grandchild };
+        // back-edge to GrandChild — already in processed, must not be followed again
+        grandchild.associations = { back: { target: "GrandChild", _target: grandchild } };
+        const root = { name: "Root", associations: { toChild: { target: "Child", _target: child } } };
+        const result = flattenEntityGraph(root);
+        expect(result).toHaveLength(3);
+        expect(result).toContain(root);
+        expect(result).toContain(child);
+        expect(result).toContain(grandchild);
+    });
+});
+
+describe("readORDExtensions", () => {
+    it("returns an empty object when no @ORD.Extensions keys are present", () => {
+        expect(readORDExtensions({ "@title": "Test", name: "svc" })).toEqual({});
+    });
+
+    it("extracts a single extension key", () => {
+        expect(readORDExtensions({ "@ORD.Extensions.title": "My Title" })).toEqual({ title: "My Title" });
+    });
+
+    it("extracts multiple extension keys", () => {
+        const model = {
+            "@ORD.Extensions.title": "T",
+            "@ORD.Extensions.version": "2.0.0",
+            "@title": "ignored",
+        };
+        expect(readORDExtensions(model)).toEqual({ title: "T", version: "2.0.0" });
+    });
+
+    it("supports nested keys via lodash set", () => {
+        const model = { "@ORD.Extensions.extensible.supported": "yes" };
+        expect(readORDExtensions(model)).toEqual({ extensible: { supported: "yes" } });
+    });
+
+    it("respects a custom prefix", () => {
+        const model = { "@Custom.foo": "bar", "@ORD.Extensions.ignored": "x" };
+        expect(readORDExtensions(model, "@Custom.")).toEqual({ foo: "bar" });
     });
 });

--- a/__tests__/unit/common/utils.test.js
+++ b/__tests__/unit/common/utils.test.js
@@ -155,7 +155,7 @@ describe("resolveServiceName", () => {
     });
 
     it("prefers internalNamespace over ordNamespace when both match", () => {
-        const appConfig = { internalNamespace: "sap.internal", ordNamespace: "sap.internal" };
+        const appConfig = { internalNamespace: "sap.internal", ordNamespace: "sap" };
         expect(resolveServiceName(appConfig, { name: "sap.internal.MyService" })).toBe("MyService");
     });
 

--- a/__tests__/unit/namespace.test.js
+++ b/__tests__/unit/namespace.test.js
@@ -1,5 +1,7 @@
 const cds = require("@sap/cds");
-const { createAPIResourceTemplate, createEventResourceTemplate } = require("../../lib/templates");
+const { ORD_ACCESS_STRATEGY } = require("../../lib/constants");
+const { createAPIResourceTemplate } = require("../../lib/templates");
+const { createEventResourceTemplate } = require("../../lib/templates/event-resource");
 
 describe("namespace local and global", () => {
     it("should strip application namespace from local namespace", () => {
@@ -7,6 +9,9 @@ describe("namespace local and global", () => {
             ordNamespace: "customer.testNamespace",
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
+            authConfig: {
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
+            },
         };
         const model = cds.linked(`
                 namespace customer.testNamespace.nested;
@@ -24,7 +29,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["customer.testNamespace.nested.MyService"];
         expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
-        expect(createEventResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(srvDefinition, appConfig)).toMatchSnapshot();
     });
 
     it("should strip application namespace if its the same as local namespace", () => {
@@ -32,6 +37,9 @@ describe("namespace local and global", () => {
             ordNamespace: "customer.testNamespace",
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
+            authConfig: {
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
+            }
         };
         const model = cds.linked(`
                 namespace customer.testNamespace;
@@ -49,7 +57,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["customer.testNamespace.MyService"];
         expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
-        expect(createEventResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(srvDefinition, appConfig)).toMatchSnapshot();
     });
 
     it("should not strip a different local namespace", () => {
@@ -57,6 +65,9 @@ describe("namespace local and global", () => {
             ordNamespace: "customer.testNamespace",
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
+            authConfig: {
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
+            }
         };
         const model = cds.linked(`
                 namespace other.namespace;
@@ -74,7 +85,7 @@ describe("namespace local and global", () => {
         const packageIds = ["sap.test.cdsrc.sample:package:test-event:v1", "sap.test.cdsrc.sample:package:test-api:v1"];
         const srvDefinition = model.definitions["other.namespace.MyService"];
         expect(createAPIResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
-        expect(createEventResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+        expect(createEventResourceTemplate(srvDefinition, appConfig)).toMatchSnapshot();
     });
 
     it("should strip internalNamespace when it differs from ordNamespace", () => {
@@ -83,6 +94,9 @@ describe("namespace local and global", () => {
             internalNamespace: "com.sap.sourcing.api.v1",
             appName: "testAppName",
             lastUpdate: "2022-12-19T15:47:04+00:00",
+            authConfig: {
+                accessStrategies: [ORD_ACCESS_STRATEGY.Open],
+            }
         };
         const model = cds.linked(`
             namespace com.sap.sourcing.api.v1;
@@ -98,9 +112,9 @@ describe("namespace local and global", () => {
         expect(apiResult[0].ordId).toBe("sap.sourcing:apiResource:SourcingService:v1");
         expect(apiResult[0].partOfGroups[0]).toBe("sap.cds:service:sap.sourcing:SourcingService");
 
-        const eventResult = createEventResourceTemplate(srvDefinition, appConfig, packageIds);
+        const eventResult = createEventResourceTemplate(srvDefinition, appConfig);
 
-        expect(eventResult[0].ordId).toBe("sap.sourcing:eventResource:SourcingService:v1");
+        expect(eventResult.ordId).toBe("sap.sourcing:eventResource:SourcingService:v1");
     });
 
     it("should strip internalNamespace and handle leading dot for sub-namespaces", () => {

--- a/__tests__/unit/ord-visibility-split.test.js
+++ b/__tests__/unit/ord-visibility-split.test.js
@@ -1,5 +1,7 @@
+const { ORD_ACCESS_STRATEGY } = require("../../lib/constants");
 const { createEntityTypeTemplate } = require("../../lib/templates/entity-type");
-const { createAPIResourceTemplate, createEventResourceTemplate, _getPackageID } = require("../../lib/templates");
+const { createAPIResourceTemplate, _getPackageID } = require("../../lib/templates");
+const { createEventResourceTemplate } = require("../../lib/templates/event-resource");
 
 describe("templates", () => {
     const appConfig = {
@@ -7,6 +9,9 @@ describe("templates", () => {
         appName: "testAppName",
         lastUpdate: "2022-12-19T15:47:04+00:00",
         policyLevels: ["none"],
+        authConfig: {
+            accessStrategies: [ORD_ACCESS_STRATEGY.Open],
+        },
     };
 
     describe("createEntityTypeTemplate", () => {
@@ -106,19 +111,12 @@ describe("templates", () => {
     });
 
     describe("createEventResourceTemplate", () => {
-        const packageIds = [
-            "sap.test.cdsrc.sample:package:test-event:v1",
-            "sap.test.cdsrc.sample:package:test-event-private:v1",
-            "sap.test.cdsrc.sample:package:test-event-internal:v1",
-        ];
-
         it("should assign the correct partOfPackage for public Event", () => {
             const serviceDefinition = { "@ORD.Extensions.visibility": "public", "entities": [], "name": "PublicEvent" };
 
-            const eventResource = createEventResourceTemplate(serviceDefinition, appConfig, packageIds, {});
+            const eventResource = createEventResourceTemplate(serviceDefinition, appConfig);
 
-            expect(eventResource).not.toHaveLength(0);
-            expect(eventResource[0].partOfPackage).toBe("sap.test.cdsrc.sample:package:test-event:v1");
+            expect(eventResource.partOfPackage).toBe("sap.test.cdsrc.sample:package:test-event:v1");
         });
 
         it("should assign the correct partOfPackage for internal Event", () => {
@@ -128,22 +126,9 @@ describe("templates", () => {
                 "name": "InternalEvent",
             };
 
-            const eventResource = createEventResourceTemplate(serviceDefinition, appConfig, packageIds, {});
+            const eventResource = createEventResourceTemplate(serviceDefinition, appConfig);
 
-            expect(eventResource).not.toHaveLength(0);
-            expect(eventResource[0].partOfPackage).toBe("sap.test.cdsrc.sample:package:test-event-internal:v1");
-        });
-
-        it("should return an empty array for private Event", () => {
-            const serviceDefinition = {
-                "@ORD.Extensions.visibility": "private",
-                "entities": [],
-                "name": "PrivateEvent",
-            };
-
-            const eventResource = createEventResourceTemplate(serviceDefinition, appConfig, packageIds, {});
-
-            expect(eventResource).toHaveLength(0);
+            expect(eventResource.partOfPackage).toBe("sap.test.cdsrc.sample:package:test-event-internal:v1");
         });
     });
     describe("_getPackageID", () => {

--- a/__tests__/unit/ord-visibility-split.test.js
+++ b/__tests__/unit/ord-visibility-split.test.js
@@ -116,7 +116,7 @@ describe("templates", () => {
 
             const eventResource = createEventResourceTemplate(serviceDefinition, appConfig);
 
-            expect(eventResource.partOfPackage).toBe("sap.test.cdsrc.sample:package:test-event:v1");
+            expect(eventResource.partOfPackage).toBe("customer.testNamespace:package:testAppName:v1");
         });
 
         it("should assign the correct partOfPackage for internal Event", () => {
@@ -128,7 +128,7 @@ describe("templates", () => {
 
             const eventResource = createEventResourceTemplate(serviceDefinition, appConfig);
 
-            expect(eventResource.partOfPackage).toBe("sap.test.cdsrc.sample:package:test-event-internal:v1");
+            expect(eventResource.partOfPackage).toBe("customer.testNamespace:package:testAppName:v1");
         });
     });
     describe("_getPackageID", () => {

--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -1,6 +1,7 @@
 const cds = require("@sap/cds");
 
 const { createEntityTypeTemplate } = require("../../lib/templates/entity-type");
+const { createGroupsTemplateForService } = require("../../lib/templates/group");
 const { createEventResourceTemplate } = require("../../lib/templates/event-resource");
 const {
     ORD_ODM_ENTITY_NAME_ANNOTATION,
@@ -11,7 +12,6 @@ const {
 } = require("../../lib/constants");
 const {
     createEntityTypeMappingsItemTemplate,
-    createGroupsTemplateForService,
     createAPIResourceTemplate,
     _getExposedEntityTypes,
     _propagateORDVisibility,
@@ -107,15 +107,6 @@ describe("visibility handling", () => {
         const definition = {};
         expect(_handleVisibility(ordExtensions, definition, "private")).toBe("private");
         expect(_handleVisibility(ordExtensions, definition, "internal")).toBe("internal");
-    });
-
-    it("returns undefined if ORD.Extensions.visibility is private", () => {
-        const serviceDefinition = {
-            "name": "customer.testNamespace.MyService",
-            "@ORD.Extensions.visibility": "private",
-        };
-
-        expect(createGroupsTemplateForService(serviceDefinition, appConfig)).toBeUndefined();
     });
 
     it("returns group object if ORD.Extensions.visibility is internal", () => {

--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -1,6 +1,7 @@
 const cds = require("@sap/cds");
 
 const { createEntityTypeTemplate } = require("../../lib/templates/entity-type");
+const { createEventResourceTemplate } = require("../../lib/templates/event-resource");
 const {
     ORD_ODM_ENTITY_NAME_ANNOTATION,
     ENTITY_RELATIONSHIP_ANNOTATION,
@@ -12,7 +13,6 @@ const {
     createEntityTypeMappingsItemTemplate,
     createGroupsTemplateForService,
     createAPIResourceTemplate,
-    createEventResourceTemplate,
     _getExposedEntityTypes,
     _propagateORDVisibility,
     _handleVisibility,
@@ -151,6 +151,9 @@ describe("templates", () => {
         appName: "testAppName",
         lastUpdate: "2022-12-19T15:47:04+00:00",
         policyLevels: ["none"],
+        authConfig: {
+            accessStrategies: [ ORD_ACCESS_STRATEGY.Open ]
+        }
     };
 
     beforeAll(() => {
@@ -427,11 +430,8 @@ describe("templates", () => {
                 };
             `);
             const srvDefinition = model.definitions["MyService"];
-            const packageIds = [
-                "sap.test.cdsrc.sample:package:test-event:v1",
-                "sap.test.cdsrc.sample:package:test-api:v1",
-            ];
-            expect(createEventResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+
+            expect(createEventResourceTemplate(srvDefinition, appConfig)).toMatchSnapshot();
         });
 
         it("should create event resource template correctly with packageIds including namespace", () => {
@@ -444,8 +444,8 @@ describe("templates", () => {
                 };
             `);
             const srvDefinition = model.definitions["MyService"];
-            const packageIds = ["customer.testNamespace:package:test:v1"];
-            expect(createEventResourceTemplate(srvDefinition, appConfig, packageIds)).toMatchSnapshot();
+
+            expect(createEventResourceTemplate(srvDefinition, appConfig)).toMatchSnapshot();
         });
     });
 
@@ -552,13 +552,9 @@ describe("templates", () => {
                 @EndUserText.label: 'This is test MyService event title'
                 service MyService { }
             `);
-            const eventResourceTemplate = createEventResourceTemplate(linkedModel.definitions[serviceName], appConfig, [
-                "sap.test.cdsrc.sample:package:test-event:v1",
-                "sap.test.cdsrc.sample:package:test-api:v1",
-            ]);
+            const eventResourceTemplate = createEventResourceTemplate(linkedModel.definitions[serviceName], appConfig);
 
-            expect(eventResourceTemplate).toBeInstanceOf(Array);
-            expect(eventResourceTemplate[0].title).toEqual("This is test MyService event title");
+            expect(eventResourceTemplate.title).toEqual("This is test MyService event title");
         });
 
         it('should add events with ORD Extension "visibility=public"', () => {
@@ -580,13 +576,8 @@ describe("templates", () => {
                 };
             `);
             const srvDefinition = linkedModel.definitions["MyService"];
-            const packageIds = [
-                "sap.test.cdsrc.sample:package:test-event:v1",
-                "sap.test.cdsrc.sample:package:test-api:v1",
-            ];
-            const eventResourceTemplate = createEventResourceTemplate(srvDefinition, appConfig, packageIds);
+            const eventResourceTemplate = createEventResourceTemplate(srvDefinition, appConfig);
 
-            expect(eventResourceTemplate).toBeInstanceOf(Array);
             expect(eventResourceTemplate).toMatchSnapshot();
         });
 
@@ -609,46 +600,11 @@ describe("templates", () => {
                 };
             `);
             const srvDefinition = linkedModel.definitions["MyService"];
-            const packageIds = [
-                "sap.test.cdsrc.sample:package:test-event-internal:v1",
-                "sap.test.cdsrc.sample:package:test-api:v1",
-            ];
-            const eventResourceTemplate = createEventResourceTemplate(srvDefinition, appConfig, packageIds);
+            const eventResourceTemplate = createEventResourceTemplate(srvDefinition, appConfig);
 
-            expect(eventResourceTemplate).toBeInstanceOf(Array);
             expect(eventResourceTemplate).toMatchSnapshot();
 
-            expect(eventResourceTemplate[0].visibility).toEqual("internal");
-        });
-
-        it('should not add events with ORD Extension "visibility=private"', () => {
-            linkedModel = cds.linked(`
-                service MyService {
-                    entity Books {
-                        key ID: UUID;
-                        title: String;
-                    }
-                }
-                annotate MyService with @ORD.Extensions : {
-                    title           : 'This is test MyService event title',
-                    shortDescription: 'short description for test MyService event',
-                    visibility : 'private',
-                    version : '2.0.0',
-                    extensible : {
-                        supported : 'yes'
-                    }
-                };
-            `);
-            const srvDefinition = linkedModel.definitions["MyService"];
-            const packageIds = [
-                "sap.test.cdsrc.sample:package:test-event:v1",
-                "sap.test.cdsrc.sample:package:test-api:v1",
-            ];
-            const eventResourceTemplate = createEventResourceTemplate(srvDefinition, appConfig, packageIds);
-
-            expect(eventResourceTemplate).toBeInstanceOf(Array);
-            expect(eventResourceTemplate).toMatchSnapshot();
-            expect(eventResourceTemplate).toEqual([]);
+            expect(eventResourceTemplate.visibility).toEqual("internal");
         });
 
         it("should find composition and association entities for related service", () => {

--- a/__tests__/unit/templates/event-resource.test.js
+++ b/__tests__/unit/templates/event-resource.test.js
@@ -1,0 +1,296 @@
+const { createEventResourceTemplate, RESOLVERS } = require("../../../lib/templates/event-resource");
+const { RESOURCE_VISIBILITY, ENTITY_RELATIONSHIP_ANNOTATION, ORD_ODM_ENTITY_NAME_ANNOTATION } = require("../../../lib/constants");
+
+const BASE_SERVICE = {
+    name: "TestEventService",
+    entities: {},
+};
+
+const BASE_APP_CONFIG = {
+    ordNamespace: "sap.test",
+    appName: "TestApp",
+    lastUpdate: "2024-01-01T00:00:00+00:00",
+    env: { defaultVisibility: RESOURCE_VISIBILITY.public },
+    authConfig: { accessStrategies: ["open"] },
+};
+
+describe("RESOLVERS.version", () => {
+    it("defaults to 1.0.0 when no extension is set", () => {
+        expect(RESOLVERS.version(BASE_SERVICE)).toBe("1.0.0");
+    });
+
+    it("uses @ORD.Extensions.version when set", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.version": "3.2.1" };
+        expect(RESOLVERS.version(service)).toBe("3.2.1");
+    });
+});
+
+describe("RESOLVERS.description", () => {
+    it("returns the default description when no annotation is present", () => {
+        expect(RESOLVERS.description(BASE_SERVICE)).toBe("CAP Event resource describing events / messages.");
+    });
+
+    it("prefers @ORD.Extensions.description", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.description": "Custom description" };
+        expect(RESOLVERS.description(service)).toBe("Custom description");
+    });
+
+    it("prefers @description over @Core.Description", () => {
+        const service = { ...BASE_SERVICE, "@description": "Desc Ann", "@Core.Description": "Core" };
+        expect(RESOLVERS.description(service)).toBe("Desc Ann");
+    });
+
+    it("uses @Core.Description when it is the only description annotation", () => {
+        const service = { ...BASE_SERVICE, "@Core.Description": "Core description" };
+        expect(RESOLVERS.description(service)).toBe("Core description");
+    });
+});
+
+describe("RESOLVERS.ordId", () => {
+    it("builds ordId from namespace, resource type, and service name", () => {
+        expect(RESOLVERS.ordId(BASE_SERVICE, BASE_APP_CONFIG)).toBe("sap.test:eventResource:TestEventService:v1");
+    });
+
+    it("uses major version from @ORD.Extensions.version", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.version": "3.2.1" };
+        expect(RESOLVERS.ordId(service, BASE_APP_CONFIG)).toBe("sap.test:eventResource:TestEventService:v3");
+    });
+
+    it("strips namespace prefix from service name when it matches ordNamespace", () => {
+        const service = { ...BASE_SERVICE, name: "sap.test.TestEventService" };
+        expect(RESOLVERS.ordId(service, BASE_APP_CONFIG)).toBe("sap.test:eventResource:TestEventService:v1");
+    });
+
+    it("prefers @ORD.Extensions.ordId when set", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.ordId": "sap.test:eventResource:custom:v2" };
+        expect(RESOLVERS.ordId(service, BASE_APP_CONFIG)).toBe("sap.test:eventResource:custom:v2");
+    });
+});
+
+describe("RESOLVERS.title", () => {
+    it("falls back to a generated title using appName when no annotation is present", () => {
+        expect(RESOLVERS.title(BASE_SERVICE, BASE_APP_CONFIG)).toBe("ODM TestApp Events");
+    });
+
+    it("strips non-alphanumeric characters from appName in fallback title", () => {
+        const appConfig = { ...BASE_APP_CONFIG, appName: "My App-Name!" };
+        expect(RESOLVERS.title(BASE_SERVICE, appConfig)).toBe("ODM MyAppName Events");
+    });
+
+    it("prefers @ORD.Extensions.title", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.title": "My Events" };
+        expect(RESOLVERS.title(service, BASE_APP_CONFIG)).toBe("My Events");
+    });
+
+    it("prefers @title over @Common.Label", () => {
+        const service = { ...BASE_SERVICE, "@title": "Title Ann", "@Common.Label": "Common" };
+        expect(RESOLVERS.title(service, BASE_APP_CONFIG)).toBe("Title Ann");
+    });
+
+    it("uses @Common.Label when @title is absent", () => {
+        const service = { ...BASE_SERVICE, "@Common.Label": "Common Label" };
+        expect(RESOLVERS.title(service, BASE_APP_CONFIG)).toBe("Common Label");
+    });
+
+    it("uses @EndUserText.label when it is the only title annotation", () => {
+        const service = { ...BASE_SERVICE, "@EndUserText.label": "End User" };
+        expect(RESOLVERS.title(service, BASE_APP_CONFIG)).toBe("End User");
+    });
+});
+
+describe("RESOLVERS.exposedEntityTypes", () => {
+    it("returns empty array when service has no entities", () => {
+        expect(RESOLVERS.exposedEntityTypes(BASE_SERVICE)).toEqual([]);
+    });
+
+    it("includes ODM entity type ordId when @ODM.entityName is set", () => {
+        const service = {
+            ...BASE_SERVICE,
+            entities: {
+                BPEntity: { [ORD_ODM_ENTITY_NAME_ANNOTATION]: "BusinessPartner" },
+            },
+        };
+        expect(RESOLVERS.exposedEntityTypes(service)).toEqual([
+            { ordId: "sap.odm:entityType:BusinessPartner:v1" },
+        ]);
+    });
+
+    it("includes entity type ordId when @EntityRelationship.entityType is set", () => {
+        const service = {
+            ...BASE_SERVICE,
+            entities: {
+                BPEntity: { [ENTITY_RELATIONSHIP_ANNOTATION]: "sap.test:BusinessPartner:v1" },
+            },
+        };
+        expect(RESOLVERS.exposedEntityTypes(service)).toEqual([
+            { ordId: "sap.test:entityType:BusinessPartner:v1" },
+        ]);
+    });
+
+    it("deduplicates ordIds across entities", () => {
+        const entity = { [ORD_ODM_ENTITY_NAME_ANNOTATION]: "BusinessPartner" };
+        const service = {
+            ...BASE_SERVICE,
+            entities: { E1: entity, E2: entity },
+        };
+        expect(RESOLVERS.exposedEntityTypes(service)).toEqual([
+            { ordId: "sap.odm:entityType:BusinessPartner:v1" },
+        ]);
+    });
+
+    it("includes both ODM and entity relationship ordIds when both annotations are present", () => {
+        const service = {
+            ...BASE_SERVICE,
+            entities: {
+                BPEntity: {
+                    [ORD_ODM_ENTITY_NAME_ANNOTATION]: "BusinessPartner",
+                    [ENTITY_RELATIONSHIP_ANNOTATION]: "sap.test:BusinessPartner:v1",
+                },
+            },
+        };
+        const result = RESOLVERS.exposedEntityTypes(service);
+        expect(result).toEqual(
+            expect.arrayContaining([
+                { ordId: "sap.odm:entityType:BusinessPartner:v1" },
+                { ordId: "sap.test:entityType:BusinessPartner:v1" },
+            ]),
+        );
+        expect(result).toHaveLength(2);
+    });
+});
+
+describe("RESOLVERS.visibility", () => {
+    it("defaults to public from appConfig env", () => {
+        expect(RESOLVERS.visibility(BASE_SERVICE, BASE_APP_CONFIG)).toBe(RESOURCE_VISIBILITY.public);
+    });
+
+    it("defaults to public when appConfig.env is absent", () => {
+        expect(RESOLVERS.visibility(BASE_SERVICE, { ...BASE_APP_CONFIG, env: undefined })).toBe(
+            RESOURCE_VISIBILITY.public,
+        );
+    });
+
+    it("uses appConfig.env.defaultVisibility when no entity override", () => {
+        const appConfig = { ...BASE_APP_CONFIG, env: { defaultVisibility: RESOURCE_VISIBILITY.internal } };
+        expect(RESOLVERS.visibility(BASE_SERVICE, appConfig)).toBe(RESOURCE_VISIBILITY.internal);
+    });
+
+    it("prefers @ORD.Extensions.visibility over appConfig default", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.visibility": RESOURCE_VISIBILITY.private };
+        expect(RESOLVERS.visibility(service, BASE_APP_CONFIG)).toBe(RESOURCE_VISIBILITY.private);
+    });
+});
+
+describe("RESOLVERS.partOfGroups", () => {
+    it("builds group id from groupTypeId, namespace, and service name", () => {
+        expect(RESOLVERS.partOfGroups(BASE_SERVICE, BASE_APP_CONFIG)).toEqual([
+            "sap.cds:service:sap.test:TestEventService",
+        ]);
+    });
+
+    it("strips namespace prefix from service name", () => {
+        const service = { ...BASE_SERVICE, name: "sap.test.TestEventService" };
+        expect(RESOLVERS.partOfGroups(service, BASE_APP_CONFIG)).toEqual([
+            "sap.cds:service:sap.test:TestEventService",
+        ]);
+    });
+});
+
+describe("RESOLVERS.partOfPackage", () => {
+    it("resolves to the general package for a public service without SAP policy level", () => {
+        const result = RESOLVERS.partOfPackage(BASE_SERVICE, BASE_APP_CONFIG);
+        expect(result).toBe("sap.test:package:TestApp:v1");
+    });
+
+    it("resolves to the event-specific package when hasSAPPolicyLevel is true", () => {
+        const appConfig = { ...BASE_APP_CONFIG, hasSAPPolicyLevel: true };
+        const result = RESOLVERS.partOfPackage(BASE_SERVICE, appConfig);
+        expect(result).toBe("sap.test:package:TestApp-event:v1");
+    });
+
+    it("strips non-alphanumeric characters from appName", () => {
+        const appConfig = { ...BASE_APP_CONFIG, hasSAPPolicyLevel: true, appName: "My App-Name!" };
+        const result = RESOLVERS.partOfPackage(BASE_SERVICE, appConfig);
+        expect(result).toBe("sap.test:package:MyAppName-event:v1");
+    });
+
+    it("prefers @ORD.Extensions.partOfPackage when set", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.partOfPackage": "sap.test:package:custom:v1" };
+        expect(RESOLVERS.partOfPackage(service, BASE_APP_CONFIG)).toBe("sap.test:package:custom:v1");
+    });
+});
+
+describe("RESOLVERS.resourceDefinitions", () => {
+    it("returns a single asyncapi-v2 resource definition", () => {
+        const result = RESOLVERS.resourceDefinitions(BASE_SERVICE, BASE_APP_CONFIG);
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe("asyncapi-v2");
+        expect(result[0].mediaType).toBe("application/json");
+    });
+
+    it("builds url from ordId and service name", () => {
+        const ordId = RESOLVERS.ordId(BASE_SERVICE, BASE_APP_CONFIG);
+        const result = RESOLVERS.resourceDefinitions(BASE_SERVICE, BASE_APP_CONFIG);
+        expect(result[0].url).toBe(`/ord/v1/${ordId}/${BASE_SERVICE.name}.asyncapi2.json`);
+    });
+
+    it("includes accessStrategies from authConfig", () => {
+        const appConfig = { ...BASE_APP_CONFIG, authConfig: { accessStrategies: ["open"] } };
+        const result = RESOLVERS.resourceDefinitions(BASE_SERVICE, appConfig);
+        expect(result[0].accessStrategies).toEqual([{ type: "open" }]);
+    });
+});
+
+describe("createEventResourceTemplate", () => {
+    it("produces a complete event resource object with defaults", () => {
+        const result = createEventResourceTemplate(BASE_SERVICE, BASE_APP_CONFIG);
+        expect(result).toEqual({
+            ordId: "sap.test:eventResource:TestEventService:v1",
+            title: "ODM TestApp Events",
+            version: "1.0.0",
+            description: "CAP Event resource describing events / messages.",
+            shortDescription: "TestEventService event resource",
+            releaseStatus: "active",
+            extensible: { supported: "no" },
+            lastUpdate: "2024-01-01T00:00:00+00:00",
+            visibility: RESOURCE_VISIBILITY.public,
+            partOfGroups: ["sap.cds:service:sap.test:TestEventService"],
+            partOfPackage: "sap.test:package:TestApp:v1",
+            resourceDefinitions: [
+                {
+                    type: "asyncapi-v2",
+                    mediaType: "application/json",
+                    url: "/ord/v1/sap.test:eventResource:TestEventService:v1/TestEventService.asyncapi2.json",
+                    accessStrategies: [{ type: "open" }],
+                },
+            ],
+        });
+    });
+
+    it("omits exposedEntityTypes when service has no entities with annotations", () => {
+        const result = createEventResourceTemplate(BASE_SERVICE, BASE_APP_CONFIG);
+        expect(result).not.toHaveProperty("exposedEntityTypes");
+    });
+
+    it("includes exposedEntityTypes when entities carry ODM annotations", () => {
+        const service = {
+            ...BASE_SERVICE,
+            entities: {
+                BPEntity: { [ORD_ODM_ENTITY_NAME_ANNOTATION]: "BusinessPartner" },
+            },
+        };
+        const result = createEventResourceTemplate(service, BASE_APP_CONFIG);
+        expect(result.exposedEntityTypes).toEqual([{ ordId: "sap.odm:entityType:BusinessPartner:v1" }]);
+    });
+
+    it("merges ORD extensions onto the result", () => {
+        const service = {
+            ...BASE_SERVICE,
+            "@ORD.Extensions.title": "My Events",
+            "@ORD.Extensions.releaseStatus": "beta",
+        };
+        const result = createEventResourceTemplate(service, BASE_APP_CONFIG);
+        expect(result.title).toBe("My Events");
+        expect(result.releaseStatus).toBe("beta");
+    });
+});

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -61,7 +61,7 @@ function resolveServiceName(appConfig, { name }) {
             .filter(Boolean)
             .filter((namespace) => name === namespace || name.startsWith(`${namespace}.`))
             .map((namespace) => name.substring(namespace.length))
-            .pop()
+            .shift()
             ?.replace(/^\./, "") ?? name
     );
 }

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -3,8 +3,12 @@ const {
     DATA_PRODUCT_TYPE,
     DATA_PRODUCT_SIMPLE_ANNOTATION,
     ORD_EXTENSIONS_PREFIX,
+    RESOURCE_VISIBILITY,
+    ALLOWED_VISIBILITY,
+    SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS,
 } = require("../constants");
 const _ = require("lodash");
+const Logger = require("../logger");
 
 function getRFC3339Date() {
     const now = new Date();
@@ -20,6 +24,46 @@ function getRFC3339Date() {
 
 function isPrimaryDataProductService(service) {
     return service[DATA_PRODUCT_ANNOTATION] === DATA_PRODUCT_TYPE.primary || !!service[DATA_PRODUCT_SIMPLE_ANNOTATION];
+}
+
+function resolveVisibility(appConfig, service) {
+    const explicit = service["@ORD.Extensions.visibility"];
+    const standard = service["@ORD.Extensions.implementationStandard"];
+    let defaultVisibility = appConfig.env?.defaultVisibility ?? RESOURCE_VISIBILITY.public;
+
+    //check for supported custom visibility value in defaultVisibility variable
+    if (!ALLOWED_VISIBILITY.includes(defaultVisibility)) {
+        Logger.warn(
+            `Default visibility ${defaultVisibility} is not supported. Using ${RESOURCE_VISIBILITY.public} as fallback`,
+        );
+        defaultVisibility = RESOURCE_VISIBILITY.public;
+    }
+
+    // Determine visibility
+    if (isPrimaryDataProductService(service)) {
+        return RESOURCE_VISIBILITY.internal;
+    } else if (explicit) {
+        return service["@ORD.Extensions.visibility"];
+    } else if (SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS.includes(standard)) {
+        // if the implementationStandard is for example sap:ord-document-api:v1, it should be public by default
+        return RESOURCE_VISIBILITY.public;
+    }
+
+    return defaultVisibility;
+}
+
+function resolveServiceName(appConfig, { name }) {
+    return (
+        [
+            appConfig.internalNamespace, //
+            appConfig.ordNamespace, //
+        ]
+            .filter(Boolean)
+            .filter((namespace) => name === namespace || name.startsWith(`${namespace}.`))
+            .map((namespace) => name.substring(namespace.length))
+            .pop()
+            ?.replace(/^\./, "") ?? name
+    );
 }
 
 function flattenEntityGraph(current, processed = []) {
@@ -44,6 +88,8 @@ function readORDExtensions(model, prefix = ORD_EXTENSIONS_PREFIX) {
 module.exports = {
     getRFC3339Date,
     readORDExtensions,
+    resolveVisibility,
     flattenEntityGraph,
+    resolveServiceName,
     isPrimaryDataProductService,
 };

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -6,28 +6,44 @@ const {
 } = require("../constants");
 const _ = require("lodash");
 
-module.exports = {
-    isPrimaryDataProductService: (srvDefinition) => {
-        return (
-            srvDefinition[DATA_PRODUCT_ANNOTATION] === DATA_PRODUCT_TYPE.primary ||
-            !!srvDefinition[DATA_PRODUCT_SIMPLE_ANNOTATION]
-        );
-    },
-    readORDExtensions: (model, prefix = ORD_EXTENSIONS_PREFIX) => {
-        return Object.entries(model) //
-            .filter(([key]) => key.startsWith(prefix))
-            .map(([key, value]) => [key.substring(prefix.length), value])
-            .reduce((result, [key, value]) => _.set(result, key, value), {});
-    },
-    getRFC3339Date: () => {
-        const now = new Date();
-        const year = now.getUTCFullYear();
-        const month = String(now.getUTCMonth() + 1).padStart(2, "0");
-        const day = String(now.getUTCDate()).padStart(2, "0");
-        const hours = String(now.getUTCHours()).padStart(2, "0");
-        const minutes = String(now.getUTCMinutes()).padStart(2, "0");
-        const seconds = String(now.getUTCSeconds()).padStart(2, "0");
+function getRFC3339Date() {
+    const now = new Date();
+    const year = now.getUTCFullYear();
+    const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(now.getUTCDate()).padStart(2, "0");
+    const hours = String(now.getUTCHours()).padStart(2, "0");
+    const minutes = String(now.getUTCMinutes()).padStart(2, "0");
+    const seconds = String(now.getUTCSeconds()).padStart(2, "0");
 
-        return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}+01:00`;
-    },
+    return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}+01:00`;
+}
+
+function isPrimaryDataProductService(service) {
+    return service[DATA_PRODUCT_ANNOTATION] === DATA_PRODUCT_TYPE.primary || !!service[DATA_PRODUCT_SIMPLE_ANNOTATION];
+}
+
+function flattenEntityGraph(current, processed = []) {
+    return [
+        current, //
+        ...Object.values(current.associations ?? []) //
+            .filter(({ target }) => !processed.includes(target))
+            .flatMap(({ target, _target }) => {
+                processed.push(target);
+                return flattenEntityGraph(_target, processed);
+            }),
+    ];
+}
+
+function readORDExtensions(model, prefix = ORD_EXTENSIONS_PREFIX) {
+    return Object.entries(model) //
+        .filter(([key]) => key.startsWith(prefix))
+        .map(([key, value]) => [key.substring(prefix.length), value])
+        .reduce((result, [key, value]) => _.set(result, key, value), {});
+}
+
+module.exports = {
+    getRFC3339Date,
+    readORDExtensions,
+    flattenEntityGraph,
+    isPrimaryDataProductService,
 };

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -8,24 +8,30 @@ const { getRFC3339Date } = require("./common/utils");
 const defaults = require("./defaults");
 const { createEntityTypeMappingsItemTemplate } = require("./templates");
 const { CONTENT_MERGE_KEY, CDS_ELEMENT_KIND } = require("./constants");
+const { createAuthConfig } = require("./auth/authentication");
 
 module.exports = class Configuration {
     constructor(csn) {
         const env = cds.env["ord"];
+        const authConfig = createAuthConfig();
         const packageName = this._loadNameFromPackageJson();
         const eventApplicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
         const ordNamespace = cds.env["ord"]?.namespace || `customer.${packageName.replace(/[^a-zA-Z0-9]/g, "")}`;
-        const internalNamespace = env?.internalNamespace;
 
         if (eventApplicationNamespace && ordNamespace !== eventApplicationNamespace) {
             Logger.warn("ORD and AsyncAPI namespaces should be the same.");
         }
 
+        if (authConfig.error) {
+            throw new Error(`Authentication configuration error: ${authConfig.error}`);
+        }
+
         this._env = env;
+        this._authConfig = authConfig;
         this._packageName = packageName;
         this._ordNamespace = ordNamespace;
-        this._internalNamespace = internalNamespace;
         this._lastUpdate = getRFC3339Date();
+        this._internalNamespace = env?.internalNamespace;
         this._serviceNames = this._resolveServiceNames(csn);
         this._existingProductORDId = env?.existingProductORDId;
         this._apiResourceNames = this._resolveApiResourceNames(csn);
@@ -33,6 +39,10 @@ module.exports = class Configuration {
         this._eventServiceNames = this._resolveEventServiceNames(csn);
         this._appName = packageName.replace(/^@/, "").replace(/[@/]/g, "-");
         this._policyLevels = env?.policyLevels || (env?.policyLevel && [env?.policyLevel]) || defaults.policyLevels;
+    }
+
+    get authConfig() {
+        return this._authConfig;
     }
 
     get env() {

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -3,13 +3,15 @@ const cds = require("@sap/cds");
 
 const Logger = require("./logger");
 const defaults = require("./defaults");
+const { resolveVisibility } = require("./common/utils");
 const Configuration = require("./configuration");
 const { RESOURCE_VISIBILITY } = require("./constants");
+const { createGroupsTemplateForService } = require("./templates/group");
 const { createEntityTypeTemplate } = require("./templates/entity-type");
 const { getIntegrationDependencies } = require("./integration-dependency");
 const { getAccessStrategiesFromAuthConfig } = require("./access-strategies");
 const { createEventResourceTemplate } = require("./templates/event-resource");
-const { createAPIResourceTemplate, createGroupsTemplateForService, _propagateORDVisibility } = require("./templates");
+const { createAPIResourceTemplate, _propagateORDVisibility } = require("./templates");
 const {
     getCustomORDContent,
     compareAndHandleCustomORDContentWithExistingContent,
@@ -18,8 +20,8 @@ const {
 const _getGroups = (csn, appConfig) => {
     return appConfig.serviceNames
         .map((name) => csn.definitions[name])
-        .flatMap((srvDefinition) => createGroupsTemplateForService(srvDefinition, appConfig))
-        .filter((resource) => !!resource);
+        .filter((srvDefinition) => resolveVisibility(appConfig, srvDefinition) !== RESOURCE_VISIBILITY.private)
+        .flatMap((srvDefinition) => createGroupsTemplateForService(srvDefinition, appConfig));
 };
 
 const _getAPIResources = (csn, appConfig, packageIds, accessStrategies) => {

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -3,22 +3,17 @@ const cds = require("@sap/cds");
 
 const Logger = require("./logger");
 const defaults = require("./defaults");
-const { createAuthConfig } = require("./auth/authentication");
 const Configuration = require("./configuration");
 const { RESOURCE_VISIBILITY } = require("./constants");
 const { createEntityTypeTemplate } = require("./templates/entity-type");
 const { getIntegrationDependencies } = require("./integration-dependency");
 const { getAccessStrategiesFromAuthConfig } = require("./access-strategies");
+const { createEventResourceTemplate } = require("./templates/event-resource");
+const { createAPIResourceTemplate, createGroupsTemplateForService, _propagateORDVisibility } = require("./templates");
 const {
     getCustomORDContent,
     compareAndHandleCustomORDContentWithExistingContent,
 } = require("./extend-ord-with-custom");
-const {
-    createAPIResourceTemplate,
-    createEventResourceTemplate,
-    createGroupsTemplateForService,
-    _propagateORDVisibility,
-} = require("./templates");
 
 const _getGroups = (csn, appConfig) => {
     return appConfig.serviceNames
@@ -33,12 +28,11 @@ const _getAPIResources = (csn, appConfig, packageIds, accessStrategies) => {
         .flatMap((srvDefinition) => createAPIResourceTemplate(srvDefinition, appConfig, packageIds, accessStrategies));
 };
 
-const _getEventResources = (csn, appConfig, packageIds, accessStrategies) => {
+const _getEventResources = (csn, appConfig) => {
     return appConfig.eventServiceNames
         .map((name) => csn.definitions[name])
-        .flatMap((srvDefinition) =>
-            createEventResourceTemplate(srvDefinition, appConfig, packageIds, accessStrategies),
-        );
+        .map((srvDefinition) => createEventResourceTemplate(srvDefinition, appConfig))
+        .filter((resource) => resource.visibility !== RESOURCE_VISIBILITY.private);
 };
 
 const _getProducts = (appConfig) => {
@@ -58,15 +52,15 @@ const _getProducts = (appConfig) => {
     return productsObj;
 };
 
-const _createDefaultORDDocument = (linkedCsn, appConfig, authConfig) => {
+const _createDefaultORDDocument = (linkedCsn, appConfig) => {
     const products = _getProducts(appConfig);
     const packages = defaults.packages(appConfig, products);
     const packageIds = packages?.map((pkg) => pkg.ordId) || [];
     const entityTypes = _getEntityTypes(appConfig);
+    const eventResources = _getEventResources(linkedCsn, appConfig);
     const integrationDependencies = getIntegrationDependencies(linkedCsn, appConfig, packageIds);
-    const accessStrategies = getAccessStrategiesFromAuthConfig(authConfig.accessStrategies || []);
+    const accessStrategies = getAccessStrategiesFromAuthConfig(appConfig.authConfig.accessStrategies || []);
     const apiResources = _getAPIResources(linkedCsn, appConfig, packageIds, accessStrategies);
-    const eventResources = _getEventResources(linkedCsn, appConfig, packageIds, accessStrategies);
 
     return {
         // Unconditionally added top-level properties
@@ -114,26 +108,14 @@ const _getEntityTypes = (appConfig) => {
               .filter((entity) => entity.visibility !== RESOURCE_VISIBILITY.private);
 };
 
-const _createAuthConfig = () => {
-    const authConfig = createAuthConfig();
-
-    // Create auth config and fail-closed on configuration errors
-    if (authConfig.error) {
-        throw new Error(`Authentication configuration error: ${authConfig.error}`);
-    }
-
-    return authConfig;
-};
-
 module.exports = (csn, extensions = []) => {
-    const authConfig = _createAuthConfig();
     const linkedCsn = _propagateORDVisibility(cds.linked(csn));
     const appConfig = new Configuration(linkedCsn);
     const ordDocument = [...(extensions || []), getCustomORDContent(appConfig)]
         .filter((extension) => !!extension)
         .reduce(
             (document, extension) => compareAndHandleCustomORDContentWithExistingContent(document, extension),
-            _createDefaultORDDocument(linkedCsn, appConfig, authConfig),
+            _createDefaultORDDocument(linkedCsn, appConfig),
         );
 
     return Object.assign(ordDocument, { packages: _filterUnusedPackages(ordDocument) });

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -351,64 +351,6 @@ const createAPIResourceTemplate = (srvDefinition, appConfig, packageIds, accessS
     return apiResources;
 };
 
-/**
- * This is a template function to create Event Resource object for Event Resource Array.
- * There can be only one event resource per service because all events are using the same protocol, they are always Cloud Events.
- * Properties of an event resource can be overwritten by the ORD extensions. Example: visibility.
- * Ensures proper visibility compliance by checking associated EntityTypes.
- *
- * @param {object} srvDefinition The definition of the service
- * @param {object} appConfig - The application configuration.
- * @param {Array} packageIds - The available package identifiers.
- * @param {Array<{type: string}>} accessStrategies The array of accessStrategies objects
- * @returns {Array} An single-item array of objects for the Event Resources.
- */
-const createEventResourceTemplate = (srvDefinition, appConfig, packageIds, accessStrategies) => {
-    const ordExtensions = readORDExtensions(srvDefinition);
-    const visibility = _handleVisibility(ordExtensions, srvDefinition, appConfig.env?.defaultVisibility);
-    const version = ordExtensions.version || "1.0.0";
-    const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.event, visibility);
-    const ordId = `${appConfig.ordNamespace}:eventResource:${_getCleanServiceName(srvDefinition.name, appConfig)}:v${version.split(".")[0]}`;
-    const exposedEntityTypes = _getExposedEntityTypes(srvDefinition);
-
-    let obj = {
-        ordId,
-        title:
-            srvDefinition["@title"] ??
-            srvDefinition["@Common.Label"] ??
-            srvDefinition["@EndUserText.label"] ??
-            `ODM ${appConfig.appName.replace(/[^a-zA-Z0-9]/g, "")} Events`,
-        shortDescription: `${srvDefinition.name} event resource`,
-        description:
-            srvDefinition["@description"] ??
-            srvDefinition["@Core.Description"] ??
-            "CAP Event resource describing events / messages.",
-        version: version,
-        lastUpdate: appConfig.lastUpdate,
-        releaseStatus: "active",
-        partOfPackage: packageId,
-        partOfGroups: [_getGroupID(appConfig, srvDefinition)],
-        visibility,
-        resourceDefinitions: [
-            _getResourceDefinition(
-                "asyncapi-v2",
-                "json",
-                ordId,
-                srvDefinition.name,
-                "asyncapi2.json",
-                accessStrategies,
-            ),
-        ],
-        extensible: { supported: "no" },
-        ...(exposedEntityTypes ? { exposedEntityTypes } : []),
-        ...ordExtensions,
-    };
-
-    return obj.visibility === RESOURCE_VISIBILITY.public || obj.visibility === RESOURCE_VISIBILITY.internal
-        ? [obj]
-        : [];
-};
-
 function _getExposedEntityTypes(definitionObj) {
     if (!definitionObj.entities) {
         return;
@@ -522,7 +464,6 @@ module.exports = {
     createEntityTypeMappingsItemTemplate,
     createGroupsTemplateForService,
     createAPIResourceTemplate,
-    createEventResourceTemplate,
     _getPackageID,
     _getExposedEntityTypes,
     _propagateORDVisibility,

--- a/lib/templates/entity-type.js
+++ b/lib/templates/entity-type.js
@@ -5,11 +5,11 @@ const { LEVEL, SEM_VERSION_REGEX, RESOURCE_VISIBILITY, ENTITY_RELATIONSHIP_ANNOT
 
 const RESOLVERS = Object.freeze({
     ordId: (entity) => {
-        const [namespace, name, version] = entity[ENTITY_RELATIONSHIP_ANNOTATION].split(":");
+        const [namespace, name, version = "v1"] = entity[ENTITY_RELATIONSHIP_ANNOTATION].split(":");
 
         return (
             entity["@ORD.Extensions.ordId"] ??
-            `${namespace}:entityType:${name}:v${(entity["@ORD.Extensions.version"] ?? version?.substring(1) ?? "1").split(".")[0]}`
+            `${namespace}:entityType:${name}:v${(entity["@ORD.Extensions.version"] ?? version.substring(1)).split(".")[0]}`
         );
     },
     title: (entity) => {
@@ -69,6 +69,10 @@ const RESOLVERS = Object.freeze({
  */
 const createEntityTypeTemplate = (appConfig, entity) => {
     return {
+        releaseStatus: "active",
+        extensible: { supported: "no" },
+        lastUpdate: appConfig.lastUpdate,
+
         ordId: RESOLVERS.ordId(entity),
         title: RESOLVERS.title(entity),
         level: RESOLVERS.level(entity),
@@ -76,10 +80,6 @@ const createEntityTypeTemplate = (appConfig, entity) => {
         version: RESOLVERS.version(entity),
         visibility: RESOLVERS.visibility(entity, appConfig),
         partOfPackage: RESOLVERS.partOfPackage(entity, appConfig),
-
-        releaseStatus: "active",
-        extensible: { supported: "no" },
-        lastUpdate: appConfig.lastUpdate,
         description: `Description for ${RESOLVERS.localId(entity)}`,
         shortDescription: `Short description of ${RESOLVERS.localId(entity)}`,
 

--- a/lib/templates/event-resource.js
+++ b/lib/templates/event-resource.js
@@ -1,0 +1,173 @@
+const Logger = require("../logger");
+const defaults = require("../defaults");
+const entityTypeTemplate = require("./entity-type");
+const { ensureAccessStrategies, getAccessStrategiesFromAuthConfig } = require("../access-strategies");
+const { readORDExtensions, flattenEntityGraph, isPrimaryDataProductService } = require("../common/utils");
+const {
+    ALLOWED_VISIBILITY,
+    RESOURCE_VISIBILITY,
+    ENTITY_RELATIONSHIP_ANNOTATION,
+    ORD_ODM_ENTITY_NAME_ANNOTATION,
+    SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS,
+} = require("../constants");
+
+function _getCleanServiceName(name, appConfig) {
+    return (
+        [
+            appConfig.internalNamespace, //
+            appConfig.ordNamespace, //
+        ]
+            .filter(Boolean)
+            .filter((namespace) => name === namespace || name.startsWith(`${namespace}.`))
+            .map((namespace) => name.substring(namespace.length))
+            .pop()
+            ?.replace(/^\./, "") ?? name
+    );
+}
+
+const RESOLVERS = Object.freeze({
+    version: (service) => {
+        return service["@ORD.Extensions.version"] ?? "1.0.0";
+    },
+    description: (service) => {
+        return (
+            service["@ORD.Extensions.description"] ??
+            service["@description"] ??
+            service["@Core.Description"] ??
+            "CAP Event resource describing events / messages."
+        );
+    },
+    ordId: (service, appConfig) => {
+        const namespace = appConfig.ordNamespace;
+        const name = _getCleanServiceName(service.name, appConfig);
+        const version = `v${RESOLVERS.version(service).split(".")[0]}`;
+
+        return service["@ORD.Extensions.ordId"] ?? `${namespace}:eventResource:${name}:${version}`;
+    },
+    title: (service, appConfig) => {
+        return (
+            service["@ORD.Extensions.title"] ??
+            service["@title"] ??
+            service["@Common.Label"] ??
+            service["@EndUserText.label"] ??
+            `ODM ${appConfig.appName.replace(/[^a-zA-Z0-9]/g, "")} Events`
+        );
+    },
+    exposedEntityTypes: (service) => {
+        const ordIds = new Set(
+            Object.values(service.entities ?? {})
+                .flatMap((entity) => flattenEntityGraph(entity))
+                .flatMap((entity) => {
+                    return [
+                        ...(!entity[ORD_ODM_ENTITY_NAME_ANNOTATION]
+                            ? []
+                            : [`sap.odm:entityType:${entity[ORD_ODM_ENTITY_NAME_ANNOTATION]}:v1`]),
+                        ...(!entity[ENTITY_RELATIONSHIP_ANNOTATION]
+                            ? []
+                            : [entityTypeTemplate.RESOLVERS.ordId(entity)]),
+                    ];
+                }),
+        );
+
+        return [...ordIds].map((ordId) => ({ ordId: ordId }));
+    },
+    visibility: (service, appConfig) => {
+        const explicit = service["@ORD.Extensions.visibility"];
+        const standard = service["@ORD.Extensions.implementationStandard"];
+        let defaultVisibility = appConfig.env?.defaultVisibility ?? RESOURCE_VISIBILITY.public;
+
+        //check for supported custom visibility value in defaultVisibility variable
+        if (!ALLOWED_VISIBILITY.includes(defaultVisibility)) {
+            Logger.warn(
+                `Default visibility ${defaultVisibility} is not supported. Using ${RESOURCE_VISIBILITY.public} as fallback`,
+            );
+            defaultVisibility = RESOURCE_VISIBILITY.public;
+        }
+
+        // Determine visibility
+        if (isPrimaryDataProductService(service)) {
+            return RESOURCE_VISIBILITY.internal;
+        } else if (explicit) {
+            return service["@ORD.Extensions.visibility"];
+        } else if (SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS.includes(standard)) {
+            // if the implementationStandard is for example sap:ord-document-api:v1, it should be public by default
+            return RESOURCE_VISIBILITY.public;
+        }
+
+        return defaultVisibility;
+    },
+    partOfGroups: (service, appConfig) => {
+        const namespace = appConfig.ordNamespace;
+        const name = _getCleanServiceName(service.name, appConfig);
+
+        return [`${defaults.groupTypeId}:${namespace}:${name}`];
+    },
+    partOfPackage: (service, appConfig) => {
+        const visibility = RESOLVERS.visibility(service, appConfig);
+        const name = appConfig.appName?.replace(/[^a-zA-Z0-9]/g, "");
+        const packages = defaults.packages(appConfig).map((pkg) => pkg.ordId);
+        const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
+
+        return (
+            service["@ORD.Extensions.partOfPackage"] ??
+            [
+                `${appConfig.ordNamespace}:package:${name}-event${suffix}:v1`,
+                `${appConfig.ordNamespace}:package:${name}:v1`,
+            ].find((candidate) => packages.includes(candidate))
+        );
+    },
+    resourceDefinitions: (service, appConfig) => {
+        const name = service.name;
+        const ordId = RESOLVERS.ordId(service, appConfig);
+        const accessStrategies = getAccessStrategiesFromAuthConfig(appConfig.authConfig.accessStrategies);
+
+        return [
+            {
+                type: "asyncapi-v2",
+                mediaType: `application/json`,
+                url: `/ord/v1/${ordId}/${name}.asyncapi2.json`,
+                accessStrategies: ensureAccessStrategies(accessStrategies, {
+                    resourceName: `${name} (asyncapi-v2)`,
+                }),
+            },
+        ];
+    },
+});
+
+/**
+ * This is a template function to create Event Resource object for Event Resource Array.
+ * There can be only one event resource per service because all events are using the same protocol, they are always Cloud Events.
+ * Properties of an event resource can be overwritten by the ORD extensions. Example: visibility.
+ * Ensures proper visibility compliance by checking associated EntityTypes.
+ *
+ * @param {object} service The definition of the service
+ * @param {object} appConfig - The application configuration.
+ * @returns {object} An single-item array of objects for the Event Resources.
+ */
+const createEventResourceTemplate = (service, appConfig) => {
+    const exposedEntityTypes = RESOLVERS.exposedEntityTypes(service);
+
+    return {
+        releaseStatus: "active",
+        extensible: { supported: "no" },
+        lastUpdate: appConfig.lastUpdate,
+        shortDescription: `${service.name} event resource`,
+
+        version: RESOLVERS.version(service),
+        ordId: RESOLVERS.ordId(service, appConfig),
+        title: RESOLVERS.title(service, appConfig),
+        description: RESOLVERS.description(service),
+        visibility: RESOLVERS.visibility(service, appConfig),
+        partOfGroups: RESOLVERS.partOfGroups(service, appConfig),
+        partOfPackage: RESOLVERS.partOfPackage(service, appConfig),
+        resourceDefinitions: RESOLVERS.resourceDefinitions(service, appConfig),
+
+        ...(exposedEntityTypes.length && { exposedEntityTypes }),
+
+        ...readORDExtensions(service),
+    };
+};
+
+module.exports = {
+    createEventResourceTemplate,
+};

--- a/lib/templates/event-resource.js
+++ b/lib/templates/event-resource.js
@@ -92,14 +92,14 @@ const RESOLVERS = Object.freeze({
 });
 
 /**
- * This is a template function to create Event Resource object for Event Resource Array.
+ * This is a template function to create Event Resource object.
  * There can be only one event resource per service because all events are using the same protocol, they are always Cloud Events.
  * Properties of an event resource can be overwritten by the ORD extensions. Example: visibility.
  * Ensures proper visibility compliance by checking associated EntityTypes.
  *
  * @param {object} service The definition of the service
  * @param {object} appConfig - The application configuration.
- * @returns {object} An single-item array of objects for the Event Resources.
+ * @returns {object} An object representing the Event Resource.
  */
 const createEventResourceTemplate = (service, appConfig) => {
     const exposedEntityTypes = RESOLVERS.exposedEntityTypes(service);

--- a/lib/templates/event-resource.js
+++ b/lib/templates/event-resource.js
@@ -1,29 +1,8 @@
-const Logger = require("../logger");
 const defaults = require("../defaults");
 const entityTypeTemplate = require("./entity-type");
 const { ensureAccessStrategies, getAccessStrategiesFromAuthConfig } = require("../access-strategies");
-const { readORDExtensions, flattenEntityGraph, isPrimaryDataProductService } = require("../common/utils");
-const {
-    ALLOWED_VISIBILITY,
-    RESOURCE_VISIBILITY,
-    ENTITY_RELATIONSHIP_ANNOTATION,
-    ORD_ODM_ENTITY_NAME_ANNOTATION,
-    SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS,
-} = require("../constants");
-
-function _getCleanServiceName(name, appConfig) {
-    return (
-        [
-            appConfig.internalNamespace, //
-            appConfig.ordNamespace, //
-        ]
-            .filter(Boolean)
-            .filter((namespace) => name === namespace || name.startsWith(`${namespace}.`))
-            .map((namespace) => name.substring(namespace.length))
-            .pop()
-            ?.replace(/^\./, "") ?? name
-    );
-}
+const { readORDExtensions, resolveVisibility, flattenEntityGraph, resolveServiceName } = require("../common/utils");
+const { RESOURCE_VISIBILITY, ENTITY_RELATIONSHIP_ANNOTATION, ORD_ODM_ENTITY_NAME_ANNOTATION } = require("../constants");
 
 const RESOLVERS = Object.freeze({
     version: (service) => {
@@ -39,7 +18,7 @@ const RESOLVERS = Object.freeze({
     },
     ordId: (service, appConfig) => {
         const namespace = appConfig.ordNamespace;
-        const name = _getCleanServiceName(service.name, appConfig);
+        const name = resolveServiceName(appConfig, service);
         const version = `v${RESOLVERS.version(service).split(".")[0]}`;
 
         return service["@ORD.Extensions.ordId"] ?? `${namespace}:eventResource:${name}:${version}`;
@@ -72,33 +51,11 @@ const RESOLVERS = Object.freeze({
         return [...ordIds].map((ordId) => ({ ordId: ordId }));
     },
     visibility: (service, appConfig) => {
-        const explicit = service["@ORD.Extensions.visibility"];
-        const standard = service["@ORD.Extensions.implementationStandard"];
-        let defaultVisibility = appConfig.env?.defaultVisibility ?? RESOURCE_VISIBILITY.public;
-
-        //check for supported custom visibility value in defaultVisibility variable
-        if (!ALLOWED_VISIBILITY.includes(defaultVisibility)) {
-            Logger.warn(
-                `Default visibility ${defaultVisibility} is not supported. Using ${RESOURCE_VISIBILITY.public} as fallback`,
-            );
-            defaultVisibility = RESOURCE_VISIBILITY.public;
-        }
-
-        // Determine visibility
-        if (isPrimaryDataProductService(service)) {
-            return RESOURCE_VISIBILITY.internal;
-        } else if (explicit) {
-            return service["@ORD.Extensions.visibility"];
-        } else if (SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS.includes(standard)) {
-            // if the implementationStandard is for example sap:ord-document-api:v1, it should be public by default
-            return RESOURCE_VISIBILITY.public;
-        }
-
-        return defaultVisibility;
+        return resolveVisibility(appConfig, service);
     },
     partOfGroups: (service, appConfig) => {
         const namespace = appConfig.ordNamespace;
-        const name = _getCleanServiceName(service.name, appConfig);
+        const name = resolveServiceName(appConfig, service);
 
         return [`${defaults.groupTypeId}:${namespace}:${name}`];
     },
@@ -170,4 +127,5 @@ const createEventResourceTemplate = (service, appConfig) => {
 
 module.exports = {
     createEventResourceTemplate,
+    RESOLVERS,
 };


### PR DESCRIPTION
# Refactor: Extract `createEventResourceTemplate` into Dedicated Module

♻️ **Refactor**: Extracted `createEventResourceTemplate` from `lib/templates.js` into a new dedicated module `lib/templates/event-resource.js`, simplifying its function signature and improving code organization. The function now returns a plain object instead of an array, with `accessStrategies` and `visibility` resolved internally.

### Changes

* `lib/templates/event-resource.js` *(new)*: Dedicated module for event resource template creation. Introduces a `RESOLVERS` object pattern (consistent with `entity-type.js`). Resolves `accessStrategies`, `partOfPackage`, and `visibility` internally using `appConfig`. Returns a plain object instead of an array. Private resource filtering is now the caller's responsibility.
* `lib/templates.js`: Removed `createEventResourceTemplate` and its export.
* `lib/ord.js`: Updated `_getEventResources` to use the new module path and explicitly filter out private resources. Removed the local `_createAuthConfig` helper — auth config is now accessed via `appConfig.authConfig`.
* `lib/configuration.js`: Added `authConfig` initialization via `createAuthConfig()` and a new `authConfig` getter, centralizing authentication configuration in the `Configuration` class.
* `lib/common/utils.js`: Refactored from an inline object export to named function declarations. Extracts and exports `flattenEntityGraph`, `resolveVisibility`, `resolveServiceName`, `isPrimaryDataProductService`, `readORDExtensions`, and `getRFC3339Date`.
* `lib/templates/entity-type.js`: Minor cleanup — simplified version destructuring with a default value and reordered property declarations.
* `__tests__/unit/templates/event-resource.test.js` *(new)*: Added unit tests for all `RESOLVERS` and `createEventResourceTemplate`, covering default behavior and annotation overrides.
* `__tests__/unit/templates.test.js`, `__tests__/unit/namespace.test.js`, `__tests__/unit/ord-visibility-split.test.js`: Updated imports, call sites, and assertions to use the new module path and simplified signature (no `packageIds`/`accessStrategies` args). Added `authConfig` to test `appConfig` fixtures. Removed tests for private visibility array behavior.
* `__tests__/unit/__snapshots__/templates.test.js.snap`, `__tests__/unit/__snapshots__/namespace.test.js.snap`: Updated snapshots to reflect the new plain object return type instead of a single-element array.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `314e9a42-7029-4a22-bea1-53d2ceafbcf5`
</details>
