### PR TITLE
chore: Extract 'createGroupsTemplateForService'

### DIFF
--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -1,6 +1,7 @@
 const cds = require("@sap/cds");
 
 const { createEntityTypeTemplate } = require("../../lib/templates/entity-type");
+const { createGroupsTemplateForService } = require("../../lib/templates/group");
 const {
     ORD_ODM_ENTITY_NAME_ANNOTATION,
     ENTITY_RELATIONSHIP_ANNOTATION,
@@ -10,7 +11,6 @@ const {
 } = require("../../lib/constants");
 const {
     createEntityTypeMappingsItemTemplate,
-    createGroupsTemplateForService,
     createAPIResourceTemplate,
     createEventResourceTemplate,
     _getExposedEntityTypes,
@@ -107,15 +107,6 @@ describe("visibility handling", () => {
         const definition = {};
         expect(_handleVisibility(ordExtensions, definition, "private")).toBe("private");
         expect(_handleVisibility(ordExtensions, definition, "internal")).toBe("internal");
-    });
-
-    it("returns undefined if ORD.Extensions.visibility is private", () => {
-        const serviceDefinition = {
-            "name": "customer.testNamespace.MyService",
-            "@ORD.Extensions.visibility": "private",
-        };
-
-        expect(createGroupsTemplateForService(serviceDefinition, appConfig)).toBeUndefined();
     });
 
     it("returns group object if ORD.Extensions.visibility is internal", () => {

--- a/__tests__/unit/templates/group.test.js
+++ b/__tests__/unit/templates/group.test.js
@@ -1,0 +1,86 @@
+const { createGroupsTemplateForService, RESOLVERS } = require("../../../lib/templates/group");
+const defaults = require("../../../lib/defaults");
+
+const BASE_SERVICE = {
+    name: "sap.test.BusinessPartnerService",
+};
+
+const BASE_APP_CONFIG = {
+    ordNamespace: "sap.test",
+    appName: "TestApp",
+};
+
+describe("RESOLVERS.title", () => {
+    it("strips namespace segments and 'Service' suffix", () => {
+        expect(RESOLVERS.title(BASE_SERVICE)).toBe("BusinessPartner Service");
+    });
+
+    it("works for a plain service name without dots", () => {
+        expect(RESOLVERS.title({ name: "OrderService" })).toBe("Order Service");
+    });
+
+    it("strips 'Service' suffix followed by extra characters", () => {
+        expect(RESOLVERS.title({ name: "OrderServiceV2" })).toBe("Order Service");
+    });
+
+    it("returns the name as-is (last segment) when it does not end with 'Service'", () => {
+        expect(RESOLVERS.title({ name: "sap.test.Orders" })).toBe("Orders Service");
+    });
+
+    it("prefers @ORD.Extensions.title when set", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.title": "Custom Title" };
+        expect(RESOLVERS.title(service)).toBe("Custom Title");
+    });
+});
+
+describe("RESOLVERS.groupId", () => {
+    it("builds groupId from groupTypeId, namespace, and service name", () => {
+        expect(RESOLVERS.groupId(BASE_SERVICE, BASE_APP_CONFIG)).toBe(
+            `${defaults.groupTypeId}:sap.test:BusinessPartnerService`,
+        );
+    });
+
+    it("strips the ordNamespace prefix from the service name", () => {
+        const service = { name: "sap.test.BusinessPartnerService" };
+        expect(RESOLVERS.groupId(service, BASE_APP_CONFIG)).toBe(
+            `${defaults.groupTypeId}:sap.test:BusinessPartnerService`,
+        );
+    });
+
+    it("uses the full service name when it does not match any namespace", () => {
+        const service = { name: "com.external.SomeService" };
+        expect(RESOLVERS.groupId(service, BASE_APP_CONFIG)).toBe(
+            `${defaults.groupTypeId}:sap.test:com.external.SomeService`,
+        );
+    });
+
+    it("uses internalNamespace prefix when it matches service name", () => {
+        const appConfig = { ...BASE_APP_CONFIG, internalNamespace: "sap.internal" };
+        const service = { name: "sap.internal.MyService" };
+        expect(RESOLVERS.groupId(service, appConfig)).toBe(
+            `${defaults.groupTypeId}:sap.test:MyService`,
+        );
+    });
+});
+
+describe("createGroupsTemplateForService", () => {
+    it("produces a complete group object with defaults", () => {
+        const result = createGroupsTemplateForService(BASE_SERVICE, BASE_APP_CONFIG);
+        expect(result).toEqual({
+            groupTypeId: defaults.groupTypeId,
+            title: "BusinessPartner Service",
+            groupId: `${defaults.groupTypeId}:sap.test:BusinessPartnerService`,
+        });
+    });
+
+    it("uses @ORD.Extensions.title when set", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.title": "My Group" };
+        const result = createGroupsTemplateForService(service, BASE_APP_CONFIG);
+        expect(result.title).toBe("My Group");
+    });
+
+    it("always uses the canonical groupTypeId from defaults", () => {
+        const result = createGroupsTemplateForService(BASE_SERVICE, BASE_APP_CONFIG);
+        expect(result.groupTypeId).toBe(defaults.groupTypeId);
+    });
+});

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -3,31 +3,80 @@ const {
     DATA_PRODUCT_TYPE,
     DATA_PRODUCT_SIMPLE_ANNOTATION,
     ORD_EXTENSIONS_PREFIX,
+    RESOURCE_VISIBILITY,
+    ALLOWED_VISIBILITY,
+    SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS,
 } = require("../constants");
 const _ = require("lodash");
+const Logger = require("../logger");
+
+function getRFC3339Date() {
+    const now = new Date();
+    const year = now.getUTCFullYear();
+    const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(now.getUTCDate()).padStart(2, "0");
+    const hours = String(now.getUTCHours()).padStart(2, "0");
+    const minutes = String(now.getUTCMinutes()).padStart(2, "0");
+    const seconds = String(now.getUTCSeconds()).padStart(2, "0");
+
+    return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}+01:00`;
+}
+
+function isPrimaryDataProductService(service) {
+    return service[DATA_PRODUCT_ANNOTATION] === DATA_PRODUCT_TYPE.primary || !!service[DATA_PRODUCT_SIMPLE_ANNOTATION];
+}
+
+function resolveVisibility(appConfig, service) {
+    const explicit = service["@ORD.Extensions.visibility"];
+    const standard = service["@ORD.Extensions.implementationStandard"];
+    let defaultVisibility = appConfig.env?.defaultVisibility ?? RESOURCE_VISIBILITY.public;
+
+    //check for supported custom visibility value in defaultVisibility variable
+    if (!ALLOWED_VISIBILITY.includes(defaultVisibility)) {
+        Logger.warn(
+            `Default visibility ${defaultVisibility} is not supported. Using ${RESOURCE_VISIBILITY.public} as fallback`,
+        );
+        defaultVisibility = RESOURCE_VISIBILITY.public;
+    }
+
+    // Determine visibility
+    if (isPrimaryDataProductService(service)) {
+        return RESOURCE_VISIBILITY.internal;
+    } else if (explicit) {
+        return service["@ORD.Extensions.visibility"];
+    } else if (SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS.includes(standard)) {
+        // if the implementationStandard is for example sap:ord-document-api:v1, it should be public by default
+        return RESOURCE_VISIBILITY.public;
+    }
+
+    return defaultVisibility;
+}
+
+function resolveServiceName(appConfig, { name }) {
+    return (
+        [
+            appConfig.internalNamespace, //
+            appConfig.ordNamespace, //
+        ]
+            .filter(Boolean)
+            .filter((namespace) => name === namespace || name.startsWith(`${namespace}.`))
+            .map((namespace) => name.substring(namespace.length))
+            .pop()
+            ?.replace(/^\./, "") ?? name
+    );
+}
+
+function readORDExtensions(model, prefix = ORD_EXTENSIONS_PREFIX) {
+    return Object.entries(model) //
+        .filter(([key]) => key.startsWith(prefix))
+        .map(([key, value]) => [key.substring(prefix.length), value])
+        .reduce((result, [key, value]) => _.set(result, key, value), {});
+}
 
 module.exports = {
-    isPrimaryDataProductService: (srvDefinition) => {
-        return (
-            srvDefinition[DATA_PRODUCT_ANNOTATION] === DATA_PRODUCT_TYPE.primary ||
-            !!srvDefinition[DATA_PRODUCT_SIMPLE_ANNOTATION]
-        );
-    },
-    readORDExtensions: (model, prefix = ORD_EXTENSIONS_PREFIX) => {
-        return Object.entries(model) //
-            .filter(([key]) => key.startsWith(prefix))
-            .map(([key, value]) => [key.substring(prefix.length), value])
-            .reduce((result, [key, value]) => _.set(result, key, value), {});
-    },
-    getRFC3339Date: () => {
-        const now = new Date();
-        const year = now.getUTCFullYear();
-        const month = String(now.getUTCMonth() + 1).padStart(2, "0");
-        const day = String(now.getUTCDate()).padStart(2, "0");
-        const hours = String(now.getUTCHours()).padStart(2, "0");
-        const minutes = String(now.getUTCMinutes()).padStart(2, "0");
-        const seconds = String(now.getUTCSeconds()).padStart(2, "0");
-
-        return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}+01:00`;
-    },
+    getRFC3339Date,
+    readORDExtensions,
+    resolveVisibility,
+    resolveServiceName,
+    isPrimaryDataProductService,
 };

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -4,8 +4,10 @@ const cds = require("@sap/cds");
 const Logger = require("./logger");
 const defaults = require("./defaults");
 const { createAuthConfig } = require("./auth/authentication");
+const { resolveVisibility } = require("./common/utils");
 const Configuration = require("./configuration");
 const { RESOURCE_VISIBILITY } = require("./constants");
+const { createGroupsTemplateForService } = require("./templates/group");
 const { createEntityTypeTemplate } = require("./templates/entity-type");
 const { getIntegrationDependencies } = require("./integration-dependency");
 const { getAccessStrategiesFromAuthConfig } = require("./access-strategies");
@@ -16,15 +18,14 @@ const {
 const {
     createAPIResourceTemplate,
     createEventResourceTemplate,
-    createGroupsTemplateForService,
     _propagateORDVisibility,
 } = require("./templates");
 
 const _getGroups = (csn, appConfig) => {
     return appConfig.serviceNames
         .map((name) => csn.definitions[name])
-        .flatMap((srvDefinition) => createGroupsTemplateForService(srvDefinition, appConfig))
-        .filter((resource) => !!resource);
+        .filter((srvDefinition) => resolveVisibility(appConfig, srvDefinition) !== RESOURCE_VISIBILITY.private)
+        .flatMap((srvDefinition) => createGroupsTemplateForService(srvDefinition, appConfig));
 };
 
 const _getAPIResources = (csn, appConfig, packageIds, accessStrategies) => {

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -76,22 +76,6 @@ function _getCleanServiceName(name, appConfig) {
 }
 
 /**
- * This is a function to resolve the title of the service group.
- *
- * @param {string} srv The name of the service.
- * @returns {string} The title of the service group.
- */
-function _getTitleFromServiceName(srv) {
-    let serviceName = srv.substring(srv.lastIndexOf(".") + 1);
-    let index = serviceName.indexOf("Service");
-    if (index >= 0) {
-        return `${serviceName.substring(0, index)} Service`;
-    } else {
-        return `${serviceName} Service`;
-    }
-}
-
-/**
  * Pure template function for creating ORD resource definitions.
  * This function does not make assumptions about access strategies - they must be provided explicitly.
  * Access strategies are validated and will fallback to 'open' in non-strict mode if missing.
@@ -120,30 +104,6 @@ function _getResourceDefinition(resourceType, mediaType, ordId, serviceName, fil
         accessStrategies: validatedStrategies,
     };
 }
-
-/**
- * This is a template function to create group object of a service for groups array in ORD doc.
- *
- * @param {object} srvDefinition The definition of the service
- * @param {object} appConfig - The application configuration.
- * @returns {Object} A group object.
- */
-const createGroupsTemplateForService = (srvDefinition, appConfig) => {
-    const ordExtensions = readORDExtensions(srvDefinition);
-    const visibility = _handleVisibility(ordExtensions, srvDefinition, appConfig.env?.defaultVisibility);
-
-    if (visibility === RESOURCE_VISIBILITY.private) {
-        // If the visibility of the service is private, do not create a group
-        Logger.info("Skipping group creation for private service:", srvDefinition.name);
-        return undefined;
-    }
-
-    return {
-        groupId: _getGroupID(appConfig, srvDefinition),
-        groupTypeId: defaults.groupTypeId,
-        title: ordExtensions.title ?? _getTitleFromServiceName(srvDefinition.name),
-    };
-};
 
 /**
  * Determines the visibility of a resource based on provided extensions, definition, and default visibility.
@@ -520,7 +480,6 @@ function _propagateORDVisibility(model) {
 
 module.exports = {
     createEntityTypeMappingsItemTemplate,
-    createGroupsTemplateForService,
     createAPIResourceTemplate,
     createEventResourceTemplate,
     _getPackageID,

--- a/lib/templates/group.js
+++ b/lib/templates/group.js
@@ -1,0 +1,41 @@
+const defaults = require("../defaults");
+const { resolveServiceName } = require("../common/utils");
+
+const RESOLVERS = Object.freeze({
+    title: (service) => {
+        return (
+            service["@ORD.Extensions.title"] ??
+            `${service.name
+                .split(".")
+                .pop()
+                .replace(/Service(.*)$/, "")} Service`
+        );
+    },
+    groupId: (service, appConfig) => {
+        const namespace = appConfig.ordNamespace;
+        const name = resolveServiceName(appConfig, service);
+
+        return `${defaults.groupTypeId}:${namespace}:${name}`;
+    },
+});
+
+/**
+ * This is a template function to create group object of a service for groups array in ORD doc.
+ *
+ * @param {object} service The definition of the service
+ * @param {object} appConfig - The application configuration.
+ * @returns {Object} A group object.
+ */
+const createGroupsTemplateForService = (service, appConfig) => {
+    return {
+        groupTypeId: defaults.groupTypeId,
+
+        title: RESOLVERS.title(service),
+        groupId: RESOLVERS.groupId(service, appConfig),
+    };
+};
+
+module.exports = {
+    createGroupsTemplateForService,
+    RESOLVERS,
+};


### PR DESCRIPTION
# Extract `createGroupsTemplateForService` into Dedicated Module

♻️ **Refactor**: Extracted the `createGroupsTemplateForService` function from `lib/templates.js` into its own dedicated module at `lib/templates/group.js`, improving separation of concerns and testability.

### Changes

* `lib/templates/group.js` *(new)*: New dedicated module containing `createGroupsTemplateForService` and an exported `RESOLVERS` object with individual resolver functions for `title` and `groupId`. Logic is simplified — visibility filtering is no longer handled inside the template function.
* `lib/templates.js`: Removed `createGroupsTemplateForService`, `_getTitleFromServiceName`, and the related group creation logic. No longer exports `createGroupsTemplateForService`.
* `lib/common/utils.js`: Refactored from a single `module.exports` object literal to individual named function declarations. Added new utility functions `resolveVisibility`, `resolveServiceName`, and `isPrimaryDataProductService`, which were previously spread across other modules. Improved readability and reusability.
* `lib/ord.js`: Updated to import `createGroupsTemplateForService` from the new `lib/templates/group.js` and `resolveVisibility` from `lib/common/utils`. The `_getGroups` function now filters out private services before mapping, eliminating the need for null-checks afterwards.
* `__tests__/unit/templates/group.test.js` *(new)*: Dedicated unit tests for the new `group.js` module, covering `RESOLVERS.title`, `RESOLVERS.groupId`, and `createGroupsTemplateForService`.
* `__tests__/unit/templates.test.js`: Removed the test for private visibility (now handled upstream in `ord.js`) and updated imports to pull `createGroupsTemplateForService` from `lib/templates/group` instead of `lib/templates`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `ec38bd2a-8f00-4fdb-83ee-0ff686b7250a`
- Event Trigger: `pull_request.opened`
</details>
