### PR TITLE
chore: clean up internal entityTypeMappings naming

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,7 @@ Data product services may carry a suffixed name `.vN`; `_extractVersionFromServi
 
 ## 7. Entity Type Mapping
 
-ODM or relationship annotations (`@ODM.entityName`, `@EntityRelationship.entityType`) generate entityTypeMappings/exposedEntityTypes. ODM mappings flagged `isODMMapping` are NOT emitted as entityTypes (only referenced). SAP policy levels (e.g. `sap:core:v1`) suppress entity type emission (central registry expectation).
+ODM or relationship annotations (`@ODM.entityName`, `@EntityRelationship.entityType`) generate entity type targets and `exposedEntityTypes` references. ODM targets flagged `isODMMapping` are NOT emitted as entityTypes (only referenced). SAP policy levels (e.g. `sap:core:v1`) suppress entity type emission (central registry expectation).
 
 ## 8. Authentication Layer
 

--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -8,7 +8,7 @@ const {
     ORD_ACCESS_STRATEGY,
 } = require("../../lib/constants");
 const {
-    createEntityTypeMappingsItemTemplate,
+    createEntityTypeTargetTemplate,
     createAPIResourceTemplate,
     _getExposedEntityTypes,
     _propagateORDVisibility,
@@ -37,10 +37,10 @@ describe("templates", () => {
         `);
     });
 
-    describe("createEntityTypeMappingsItemTemplate", () => {
+    describe("createEntityTypeTargetTemplate", () => {
         it("should return default value", () => {
             expect(
-                createEntityTypeMappingsItemTemplate(linkedModel.definitions["customer.testNamespace123.Books"]),
+                createEntityTypeTargetTemplate(linkedModel.definitions["customer.testNamespace123.Books"]),
             ).toBeUndefined();
         });
 
@@ -52,7 +52,7 @@ describe("templates", () => {
                     entity DualEntity { key ID: UUID; name: String; }
                 `);
             const entityDef = model.definitions["customer.dual.DualEntity"];
-            const mappings = createEntityTypeMappingsItemTemplate(entityDef);
+            const mappings = createEntityTypeTargetTemplate(entityDef);
             expect(mappings).toHaveLength(2);
             expect(mappings.map((m) => m.ordId)).toEqual(
                 expect.arrayContaining(["sap.odm:entityType:DualEntity:v1", "customer.dual:entityType:DualEntity:v1"]),

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -6,7 +6,7 @@ const { readFileSync } = require("fs");
 const Logger = require("./logger");
 const defaults = require("./defaults");
 const { createAuthConfig } = require("./auth/authentication");
-const { createEntityTypeMappingsItemTemplate } = require("./templates");
+const { createEntityTypeTargetTemplate } = require("./templates");
 const { getRFC3339Date, isExternalDataProduct } = require("./common/utils");
 const { CONTENT_MERGE_KEY, CDS_ELEMENT_KIND, EXTERNAL_DP_ORD_ID_ANNOTATION } = require("./constants");
 
@@ -141,7 +141,7 @@ module.exports = class Configuration {
                 .filter((name) => !this._isBlockedServiceName(name))
                 .filter((name) => csn.definitions[name].kind === CDS_ELEMENT_KIND.entity)
                 .filter((name) => csn.definitions[name]["_service"]?.["@protocol"] !== "none")
-                .flatMap((name) => createEntityTypeMappingsItemTemplate(csn.definitions[name]) || []),
+                .flatMap((name) => createEntityTypeTargetTemplate(csn.definitions[name]) || []),
             CONTENT_MERGE_KEY,
         );
     }

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -21,12 +21,12 @@ const {
 } = require("./constants");
 
 /**
- * This is a template function to create item of entityTypeMappings array.
+ * This is a template function to create an entity type target item.
  *
  * @param {string} entity The entity definition.
- * @returns {Object} An entry of the entityTypeMappings array.
+ * @returns {Object} An entry of the entityTypeTargets array.
  */
-const createEntityTypeMappingsItemTemplate = (entity) => {
+const createEntityTypeTargetTemplate = (entity) => {
     const results = [];
     if (entity[ORD_ODM_ENTITY_NAME_ANNOTATION]) {
         results.push({
@@ -255,7 +255,7 @@ function _getExposedEntityTypes(definitionObj) {
         return;
     }
     const entities = Object.values(definitionObj.entities).flatMap((entity) => {
-        const entityData = flattenEntityGraph(entity).flatMap(createEntityTypeMappingsItemTemplate).filter(Boolean);
+        const entityData = flattenEntityGraph(entity).flatMap(createEntityTypeTargetTemplate).filter(Boolean);
         return _.uniqBy(entityData, CONTENT_MERGE_KEY);
     });
     const exposedEntityTypes = _.uniqBy(entities, CONTENT_MERGE_KEY)
@@ -332,7 +332,7 @@ function _propagateORDVisibility(model) {
 }
 
 module.exports = {
-    createEntityTypeMappingsItemTemplate,
+    createEntityTypeTargetTemplate,
     createAPIResourceTemplate,
     _getPackageID,
     _getExposedEntityTypes,


### PR DESCRIPTION
## Summary

I want to cleanup legacy entityTypeMappings name in our codebase


