### PR TITLE
chore: Simplify 'lib/protocol-resolver.js'

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -127,9 +127,6 @@ const ORD_ONLY_PROTOCOLS = Object.freeze({
     },
 });
 
-// Protocols that the ORD plugin cannot currently generate definitions for
-const PLUGIN_UNSUPPORTED_PROTOCOLS = Object.freeze([]);
-
 // CF mTLS Error Reasons
 const CF_MTLS_ERROR_REASON = Object.freeze({
     NO_HEADERS: "NO_HEADERS",
@@ -186,7 +183,6 @@ module.exports = {
     ORD_ONLY_PROTOCOLS,
     ORD_RESOURCE_TYPE,
     ORD_SERVICE_NAME,
-    PLUGIN_UNSUPPORTED_PROTOCOLS,
     RESOURCE_VISIBILITY,
     ALLOWED_VISIBILITY,
     IMPLEMENTATIONSTANDARD_VERSIONS,

--- a/lib/protocol-resolver.js
+++ b/lib/protocol-resolver.js
@@ -2,12 +2,7 @@ const cds = require("@sap/cds");
 
 const Logger = require("./logger");
 const { isPrimaryDataProductService } = require("./common/utils");
-const {
-    CAP_TO_ORD_PROTOCOL_MAP,
-    ORD_ONLY_PROTOCOLS,
-    ORD_API_PROTOCOL,
-    PLUGIN_UNSUPPORTED_PROTOCOLS,
-} = require("./constants");
+const { CAP_TO_ORD_PROTOCOL_MAP, ORD_ONLY_PROTOCOLS, ORD_API_PROTOCOL } = require("./constants");
 
 /**
  * Resolves protocol for ORD API Resource generation.
@@ -26,57 +21,38 @@ function resolveApiResourceProtocol(srvDefinition) {
     if (isPrimaryDataProductService(srvDefinition)) {
         return [
             {
-                apiProtocol: ORD_API_PROTOCOL.SAP_DATA_SUBSCRIPTION,
                 entryPoints: [],
                 hasResourceDefinitions: true,
+                apiProtocol: ORD_API_PROTOCOL.SAP_DATA_SUBSCRIPTION,
             },
         ];
     }
 
-    const capEndpoints = cds.service.protocols.endpoints4({ name: srvDefinition.name, definition: srvDefinition });
-    const ordProtocols = [];
-    for (const endpoint of capEndpoints) {
-        if (PLUGIN_UNSUPPORTED_PROTOCOLS.includes(endpoint.kind)) {
-            Logger.warn(
-                `Protocol '${endpoint.kind}' is supported by ORD but this plugin cannot generate its resource definitions yet.`,
-            );
-            continue;
-        }
-
-        const apiProtocol = CAP_TO_ORD_PROTOCOL_MAP[endpoint.kind] ?? endpoint.kind;
-        if (apiProtocol) {
-            ordProtocols.push({
-                apiProtocol,
-                entryPoints: endpoint.path ? [endpoint.path] : [],
-                hasResourceDefinitions: true,
-            });
-        }
-    }
+    const ordProtocols = cds.service.protocols
+        .endpoints4({ name: srvDefinition.name, definition: srvDefinition })
+        .filter((endpoint) => Boolean(CAP_TO_ORD_PROTOCOL_MAP[endpoint.kind] ?? endpoint.kind))
+        .map((endpoint) => ({
+            hasResourceDefinitions: true,
+            entryPoints: endpoint.path ? [endpoint.path] : [],
+            apiProtocol: CAP_TO_ORD_PROTOCOL_MAP[endpoint.kind] ?? endpoint.kind,
+        }));
 
     const cdsProtocols = Object.keys(cds.service.protocols.for(srvDefinition));
     for (const protocol of cdsProtocols) {
-        // 2. Handle explicit protocol
-        // 2a. Check if it's an ORD-only protocol (e.g., INA)
+        // 2. Handle explicit protocol - check if it's an ORD-only protocol (e.g., INA)
         if (ORD_ONLY_PROTOCOLS[protocol]) {
-            const config = ORD_ONLY_PROTOCOLS[protocol];
-            const path = config.hasEntryPoints ? cds.service.protocols.path4(srvDefinition) : null;
+            const { apiProtocol, hasEntryPoints, hasResourceDefinitions } = ORD_ONLY_PROTOCOLS[protocol];
+            const path = hasEntryPoints ? cds.service.protocols.path4(srvDefinition) : null;
+
             ordProtocols.push({
-                apiProtocol: config.apiProtocol,
+                apiProtocol: apiProtocol,
                 entryPoints: path ? [path] : [],
-                hasResourceDefinitions: config.hasResourceDefinitions,
+                hasResourceDefinitions: hasResourceDefinitions,
             });
             continue;
         }
 
-        // 2b. Check if it's a plugin-unsupported protocol
-        if (PLUGIN_UNSUPPORTED_PROTOCOLS.includes(protocol)) {
-            Logger.warn(
-                `Protocol '${protocol}' is supported by ORD but this plugin cannot generate its resource definitions yet.`,
-            );
-            continue;
-        }
-
-        // 4. Handle explicit protocol with no CAP endpoint (Rule A)
+        // 3. Handle explicit protocol with no CAP endpoint (Rule A)
         if (!ordProtocols.some((p) => p.apiProtocol === protocol) && !CAP_TO_ORD_PROTOCOL_MAP[protocol]) {
             Logger.warn(
                 `Unknown protocol '${protocol}' is not supported, and skipped for service '${srvDefinition.name}'.`,


### PR DESCRIPTION
# Simplify `lib/protocol-resolver.js` by Removing Unused Dead Code

♻️ **Refactor**: Cleaned up `protocol-resolver.js` and `constants.js` by removing the unused `PLUGIN_UNSUPPORTED_PROTOCOLS` constant and its associated handling logic, and refactored the endpoint mapping loop into a cleaner functional style.

### Changes

* `lib/constants.js`: Removed the unused `PLUGIN_UNSUPPORTED_PROTOCOLS` constant (an empty frozen array) and its export.
* `lib/protocol-resolver.js`:
  - Removed the `PLUGIN_UNSUPPORTED_PROTOCOLS` import since it no longer exists.
  - Replaced the imperative `for` loop that iterated over CAP endpoints with a concise `.filter().map()` chain for building `ordProtocols`.
  - Removed the now-dead code block (step 2b) that checked for plugin-unsupported protocols and emitted a warning — since `PLUGIN_UNSUPPORTED_PROTOCOLS` was an empty array, this branch could never be reached.
  - Destructured `ORD_ONLY_PROTOCOLS[protocol]` directly into `{ apiProtocol, hasEntryPoints, hasResourceDefinitions }` instead of assigning to a `config` variable.
  - Collapsed two-line comment `// 2. Handle explicit protocol` / `// 2a. Check if it's an ORD-only protocol` into a single comment, and renumbered subsequent step from 4 to 3.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.1`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `37a525a3-b622-4e39-9c51-a907bccd6113`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
</details>
