### PR TITLE
feat: Allow for using '{namespace}' and '{type}' placeholders for 'ordId' and 'partOfPackage'

### DIFF
--- a/__tests__/bookshop/srv/admin-service.cds
+++ b/__tests__/bookshop/srv/admin-service.cds
@@ -24,6 +24,7 @@ service AdminService @(requires: 'authenticated-user') {
 }
 
 annotate AdminService with @ORD.Extensions: {
+    ordId             : '{namespace}:{type}:AdminService:v2',
     title             : 'This is test AdminService title',
     shortDescription  : 'short description for test AdminService',
     visibility        : 'public',

--- a/__tests__/unit/common/placeholders.test.js
+++ b/__tests__/unit/common/placeholders.test.js
@@ -1,0 +1,43 @@
+const { replace } = require("../../../lib/common/placeholders");
+
+describe("placeholders.replace", () => {
+    it("replaces a single placeholder", () => {
+        expect(replace("{namespace}:package:myPkg:v1", { namespace: "customer.ns" })).toBe(
+            "customer.ns:package:myPkg:v1"
+        );
+    });
+
+    it("replaces multiple distinct placeholders", () => {
+        expect(replace("{namespace}:apiResource:{type}:v1", { namespace: "my.ns", type: "apiResource" })).toBe(
+            "my.ns:apiResource:apiResource:v1"
+        );
+    });
+
+    it("replaces all occurrences when the same placeholder appears more than once", () => {
+        expect(replace("{namespace}:{namespace}:pkg:v1", { namespace: "x.ns" })).toBe("x.ns:x.ns:pkg:v1");
+    });
+
+    it("leaves unrecognised placeholders untouched", () => {
+        expect(replace("{namespace}:{unknown}:v1", { namespace: "x.ns" })).toBe("x.ns:{unknown}:v1");
+    });
+
+    it("returns the value unchanged when the context has no matching keys", () => {
+        expect(replace("static:ordId:v1", { namespace: "x.ns" })).toBe("static:ordId:v1");
+    });
+
+    it("returns undefined when value is undefined", () => {
+        expect(replace(undefined, { namespace: "x.ns" })).toBeUndefined();
+    });
+
+    it("returns undefined when value is null", () => {
+        expect(replace(null, { namespace: "x.ns" })).toBeUndefined();
+    });
+
+    it("returns an empty string when value is an empty string", () => {
+        expect(replace("", { namespace: "x.ns" })).toBe("");
+    });
+
+    it("returns the value unchanged when the context is empty", () => {
+        expect(replace("{namespace}:pkg:v1", {})).toBe("{namespace}:pkg:v1");
+    });
+});

--- a/__tests__/unit/templates/__snapshots__/product.test.js.snap
+++ b/__tests__/unit/templates/__snapshots__/product.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`createProducts correctly replaces placeholders for namespace and type in product ordId 1`] = `
+[
+  {
+    "ordId": "sap.test:product:A:",
+    "shortDescription": "Short description of MyPackage",
+    "title": "MyPackage",
+    "vendor": "customer:vendor:Customer:",
+  },
+]
+`;

--- a/__tests__/unit/templates/api-resource.test.js
+++ b/__tests__/unit/templates/api-resource.test.js
@@ -685,11 +685,6 @@ describe("createAPIResourceTemplate", () => {
             const result = _getPackageID("customer.testNamespace", packageIds);
             expect(result).toBe("customer.testNamespace:package:fallback-package:v1");
         });
-
-        it("should return undefined when no packageIds are provided", () => {
-            const result = _getPackageID("customer.testNamespace");
-            expect(result).toBeUndefined();
-        });
     });
 
     describe("Version Suffix Extraction for Data Product Services", () => {

--- a/__tests__/unit/templates/api-resource.test.js
+++ b/__tests__/unit/templates/api-resource.test.js
@@ -1073,6 +1073,49 @@ describe("createAPIResourceTemplate", () => {
 
             expect(result).toEqual([]);
         });
+
+        it("should properly replace placeholders in @ORD.Extensions.ordId", () => {
+            const result = createAPIResources({
+                ...appConfig,
+                csn: cds.linked(`
+                @ORD.Extensions.ordId: '{namespace}:{type}:MyService:v1'
+                service MyService {
+                    entity Books {
+                        key ID: UUID;
+                        title: String;
+                    }
+                };
+            `),
+            });
+
+            expect(result).toHaveLength(1);
+            expect(result[0].resourceDefinitions).toHaveLength(2);
+            expect(result[0].ordId).toBe("customer.testNamespace:apiResource:MyService:v1");
+            expect(result[0].resourceDefinitions[0].url).toBe(
+                "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.oas3.json",
+            );
+            expect(result[0].resourceDefinitions[1].url).toBe(
+                "/ord/v1/customer.testNamespace:apiResource:MyService:v1/MyService.edmx",
+            );
+        });
+
+        it("should properly replace placeholders in @ORD.Extensions.partOfPackage", () => {
+            const result = createAPIResources({
+                ...appConfig,
+                csn: cds.linked(`
+                @ORD.Extensions.partOfPackage: '{namespace}:{type}:Services:v1'
+                service MyService {
+                    entity Books {
+                        key ID: UUID;
+                        title: String;
+                    }
+                };
+            `),
+            });
+
+            expect(result).toHaveLength(1);
+            expect(result[0].partOfPackage).toBe("customer.testNamespace:package:Services:v1");
+        });
     });
 
     describe("getExposedEntityTypes", () => {

--- a/__tests__/unit/templates/entity-type.test.js
+++ b/__tests__/unit/templates/entity-type.test.js
@@ -21,7 +21,7 @@ const BASE_APP_CONFIG = {
 
 describe("RESOLVERS.ordId", () => {
     it("builds ordId from entity relationship annotation", () => {
-        expect(RESOLVERS.ordId(BASE_ENTITY)).toBe("sap.test:entityType:BusinessPartner:v1");
+        expect(RESOLVERS.ordId(BASE_ENTITY, BASE_APP_CONFIG)).toBe("sap.test:entityType:BusinessPartner:v1");
     });
 
     it("uses @ORD.Extensions.version major over annotation version", () => {
@@ -29,12 +29,26 @@ describe("RESOLVERS.ordId", () => {
             [ENTITY_RELATIONSHIP_ANNOTATION]: "sap.test:BusinessPartner:v1",
             "@ORD.Extensions.version": "3.2.1",
         };
-        expect(RESOLVERS.ordId(entity)).toBe("sap.test:entityType:BusinessPartner:v3");
+        expect(RESOLVERS.ordId(entity, BASE_APP_CONFIG)).toBe("sap.test:entityType:BusinessPartner:v3");
     });
 
     it("falls back to '1' when annotation has no version segment", () => {
         const entity = { [ENTITY_RELATIONSHIP_ANNOTATION]: "sap.test:BusinessPartner" };
-        expect(RESOLVERS.ordId(entity)).toBe("sap.test:entityType:BusinessPartner:v1");
+        expect(RESOLVERS.ordId(entity, BASE_APP_CONFIG)).toBe("sap.test:entityType:BusinessPartner:v1");
+    });
+
+    it("prefers @ORD.Extensions.ordId when set", () => {
+        const entity = {
+            ...BASE_ENTITY,
+            "@ORD.Extensions.ordId": "sap.test:entityType:custom:v1",
+            [ENTITY_RELATIONSHIP_ANNOTATION]: "sap.test:BusinessPartner:v1",
+        };
+        expect(RESOLVERS.ordId(entity, BASE_APP_CONFIG)).toBe("sap.test:entityType:custom:v1");
+    });
+
+    it("correctly replaces placeholders in @ORD.Extensions.partOfPackage when set", () => {
+        const entity = { ...BASE_ENTITY, "@ORD.Extensions.ordId": "{namespace}:{type}:custom:v1" };
+        expect(RESOLVERS.ordId(entity, BASE_APP_CONFIG)).toBe("sap.test:entityType:custom:v1");
     });
 });
 
@@ -108,23 +122,23 @@ describe("RESOLVERS.version", () => {
     });
 
     it("derives version from ordId when no extension is set", () => {
-        expect(RESOLVERS.version(BASE_ENTITY)).toBe("1.0.0");
+        expect(RESOLVERS.version(BASE_ENTITY, BASE_APP_CONFIG)).toBe("1.0.0");
     });
 
     it("uses @ORD.Extensions.version when set", () => {
         const entity = { ...BASE_ENTITY, "@ORD.Extensions.version": "2.3.4" };
-        expect(RESOLVERS.version(entity)).toBe("2.3.4");
+        expect(RESOLVERS.version(entity, BASE_APP_CONFIG)).toBe("2.3.4");
     });
 
     it("warns and still returns the value when version is not a valid semver", () => {
         const entity = { ...BASE_ENTITY, "@ORD.Extensions.version": "not-a-version" };
-        expect(RESOLVERS.version(entity)).toBe("not-a-version");
+        expect(RESOLVERS.version(entity, BASE_APP_CONFIG)).toBe("not-a-version");
         expect(warnSpy).toHaveBeenCalled();
     });
 
     it("does not warn for valid semver strings", () => {
         const entity = { ...BASE_ENTITY, "@ORD.Extensions.version": "1.0.0" };
-        RESOLVERS.version(entity);
+        RESOLVERS.version(entity, BASE_APP_CONFIG);
         expect(warnSpy).not.toHaveBeenCalled();
     });
 });
@@ -166,6 +180,11 @@ describe("RESOLVERS.partOfPackage", () => {
 
     it("prefers @ORD.Extensions.partOfPackage when set", () => {
         const entity = { ...BASE_ENTITY, "@ORD.Extensions.partOfPackage": "sap.test:package:custom:v1" };
+        expect(RESOLVERS.partOfPackage(entity, BASE_APP_CONFIG)).toBe("sap.test:package:custom:v1");
+    });
+
+    it("correctly replaces placeholders in @ORD.Extensions.partOfPackage when set", () => {
+        const entity = { ...BASE_ENTITY, "@ORD.Extensions.partOfPackage": "{namespace}:{type}:custom:v1" };
         expect(RESOLVERS.partOfPackage(entity, BASE_APP_CONFIG)).toBe("sap.test:package:custom:v1");
     });
 });
@@ -338,12 +357,10 @@ describe("createEntityTypes", () => {
     });
 
     it("returns entity types for exposed entities", () => {
-        const appConfig = {
+        const result = createEntityTypes({
             ...BASE_CONFIG,
             csn: { definitions: { BusinessPartner: makeEntity() } },
-        };
-
-        const result = createEntityTypes(appConfig);
+        });
 
         expect(result).toHaveLength(1);
         expect(result[0].ordId).toBe("sap.test:entityType:BusinessPartner:v1");
@@ -390,7 +407,8 @@ describe("createEntityTypes", () => {
 
     it("deduplicates entities with the same ordId", () => {
         const entity = makeEntity();
-        const appConfig = {
+
+        const result = createEntityTypes({
             ...BASE_CONFIG,
             csn: {
                 definitions: {
@@ -398,16 +416,14 @@ describe("createEntityTypes", () => {
                     BPCopy2: { ...entity },
                 },
             },
-        };
-
-        const result = createEntityTypes(appConfig);
+        });
 
         expect(result).toHaveLength(1);
         expect(result[0].ordId).toBe("sap.test:entityType:BusinessPartner:v1");
     });
 
     it("returns multiple distinct entity types", () => {
-        const appConfig = {
+        const result = createEntityTypes({
             ...BASE_CONFIG,
             csn: {
                 definitions: {
@@ -418,14 +434,11 @@ describe("createEntityTypes", () => {
                     }),
                 },
             },
-        };
-
-        const result = createEntityTypes(appConfig);
+        });
 
         expect(result).toHaveLength(2);
-        const ordIds = result.map((r) => r.ordId);
-        expect(ordIds).toContain("sap.test:entityType:BusinessPartner:v1");
-        expect(ordIds).toContain("sap.test:entityType:SalesOrder:v1");
+        expect(result.map((r) => r.ordId)).toContain("sap.test:entityType:SalesOrder:v1");
+        expect(result.map((r) => r.ordId)).toContain("sap.test:entityType:BusinessPartner:v1");
     });
 
     it("excludes entities from services with @protocol: 'none'", () => {
@@ -433,11 +446,47 @@ describe("createEntityTypes", () => {
             ...BASE_CONFIG,
             csn: {
                 definitions: {
-                    HiddenEntity: makeEntity({ _service: { name: "HiddenService", "@protocol": "none" } }),
+                    HiddenEntity: makeEntity({ _service: { "name": "HiddenService", "@protocol": "none" } }),
                 },
             },
         };
 
         expect(createEntityTypes(appConfig)).toEqual([]);
+    });
+
+    it("correctly replaces placeholders in @ORD.Extensions.ordId", () => {
+        const result = createEntityTypes({
+            ...BASE_CONFIG,
+            csn: {
+                definitions: {
+                    SalesOrder: makeEntity({
+                        "name": "SalesOrder",
+                        [ENTITY_RELATIONSHIP_ANNOTATION]: "sap.test:SalesOrder:v1",
+                        "@ORD.Extensions.ordId": "{namespace}:{type}:custom:v1",
+                    }),
+                },
+            },
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].ordId).toBe("sap.test:entityType:custom:v1");
+    });
+
+    it("correctly replaces placeholders in @ORD.Extensions.partOfPackage", () => {
+        const result = createEntityTypes({
+            ...BASE_CONFIG,
+            csn: {
+                definitions: {
+                    SalesOrder: makeEntity({
+                        "name": "SalesOrder",
+                        [ENTITY_RELATIONSHIP_ANNOTATION]: "sap.test:SalesOrder:v1",
+                        "@ORD.Extensions.partOfPackage": "{namespace}:{type}:custom:v1",
+                    }),
+                },
+            },
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].partOfPackage).toBe("sap.test:package:custom:v1");
     });
 });

--- a/__tests__/unit/templates/event-resource.test.js
+++ b/__tests__/unit/templates/event-resource.test.js
@@ -137,7 +137,7 @@ describe("RESOLVERS.exposedEntityTypes", () => {
                 BPEntity: { [ENTITY_RELATIONSHIP_ANNOTATION]: "sap.test:BusinessPartner:v1" },
             },
         };
-        expect(RESOLVERS.exposedEntityTypes(service)).toEqual([{ ordId: "sap.test:entityType:BusinessPartner:v1" }]);
+        expect(RESOLVERS.exposedEntityTypes(service, BASE_APP_CONFIG)).toEqual([{ ordId: "sap.test:entityType:BusinessPartner:v1" }]);
     });
 
     it("deduplicates ordIds across entities", () => {
@@ -146,7 +146,7 @@ describe("RESOLVERS.exposedEntityTypes", () => {
             ...BASE_SERVICE,
             entities: { E1: entity, E2: entity },
         };
-        expect(RESOLVERS.exposedEntityTypes(service)).toEqual([{ ordId: "sap.odm:entityType:BusinessPartner:v1" }]);
+        expect(RESOLVERS.exposedEntityTypes(service, BASE_APP_CONFIG)).toEqual([{ ordId: "sap.odm:entityType:BusinessPartner:v1" }]);
     });
 
     it("includes both ODM and entity relationship ordIds when both annotations are present", () => {
@@ -159,7 +159,7 @@ describe("RESOLVERS.exposedEntityTypes", () => {
                 },
             },
         };
-        const result = RESOLVERS.exposedEntityTypes(service);
+        const result = RESOLVERS.exposedEntityTypes(service, BASE_APP_CONFIG);
         expect(result).toEqual(
             expect.arrayContaining([
                 { ordId: "sap.odm:entityType:BusinessPartner:v1" },

--- a/__tests__/unit/templates/event-resource.test.js
+++ b/__tests__/unit/templates/event-resource.test.js
@@ -1,6 +1,10 @@
 const cds = require("@sap/cds");
 
-const { createEventResources, createEventResourceTemplate, RESOLVERS } = require("../../../lib/templates/event-resource");
+const {
+    createEventResources,
+    createEventResourceTemplate,
+    RESOLVERS,
+} = require("../../../lib/templates/event-resource");
 const {
     RESOURCE_VISIBILITY,
     ENTITY_RELATIONSHIP_ANNOTATION,
@@ -71,6 +75,11 @@ describe("RESOLVERS.ordId", () => {
 
     it("prefers @ORD.Extensions.ordId when set", () => {
         const service = { ...BASE_SERVICE, "@ORD.Extensions.ordId": "sap.test:eventResource:custom:v2" };
+        expect(RESOLVERS.ordId(service, BASE_APP_CONFIG)).toBe("sap.test:eventResource:custom:v2");
+    });
+
+    it("replaces placeholders when used in @ORD.Extensions.ordId", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.ordId": "{namespace}:{type}:custom:v2" };
         expect(RESOLVERS.ordId(service, BASE_APP_CONFIG)).toBe("sap.test:eventResource:custom:v2");
     });
 });
@@ -216,6 +225,11 @@ describe("RESOLVERS.partOfPackage", () => {
 
     it("prefers @ORD.Extensions.partOfPackage when set", () => {
         const service = { ...BASE_SERVICE, "@ORD.Extensions.partOfPackage": "sap.test:package:custom:v1" };
+        expect(RESOLVERS.partOfPackage(service, BASE_APP_CONFIG)).toBe("sap.test:package:custom:v1");
+    });
+
+    it("replaces placeholders in @ORD.Extensions.partOfPackage when set", () => {
+        const service = { ...BASE_SERVICE, "@ORD.Extensions.partOfPackage": "{namespace}:{type}:custom:v1" };
         expect(RESOLVERS.partOfPackage(service, BASE_APP_CONFIG)).toBe("sap.test:package:custom:v1");
     });
 });
@@ -569,9 +583,8 @@ describe("createEventResources", () => {
         const result = createEventResources(appConfig);
 
         expect(result).toHaveLength(2);
-        const ordIds = result.map((r) => r.ordId);
-        expect(ordIds).toContain("sap.test:eventResource:ServiceA:v1");
-        expect(ordIds).toContain("sap.test:eventResource:ServiceB:v1");
+        expect(result.map((r) => r.ordId)).toContain("sap.test:eventResource:ServiceA:v1");
+        expect(result.map((r) => r.ordId)).toContain("sap.test:eventResource:ServiceB:v1");
     });
 
     it("deduplicates: multiple events from the same service produce one event resource", () => {
@@ -614,7 +627,7 @@ describe("createEventResources", () => {
 
     it("excludes events whose service has @protocol: 'none'", () => {
         const visibleService = makeService("VisibleService");
-        const hiddenService = makeService("HiddenService", { "@protocol": "none", kind: "service" });
+        const hiddenService = makeService("HiddenService", { "@protocol": "none", "kind": "service" });
         const appConfig = {
             ...BASE_CONFIG,
             csn: {
@@ -638,8 +651,8 @@ describe("createEventResources", () => {
             csn: {
                 definitions: {
                     "MyService.OrderPlaced": makeEventDef(service),
-                    Books: { kind: "entity", name: "Books", _service: service },
-                    MyService: service,
+                    "Books": { kind: "entity", name: "Books", _service: service },
+                    "MyService": service,
                 },
             },
         };
@@ -664,5 +677,45 @@ describe("createEventResources", () => {
         expect(result).toHaveLength(1);
         expect(result[0].ordId).toContain("eventResource");
         expect(result[0].ordId).toContain("OrderService");
+    });
+
+    it("correctly replaces placeholders in @ORD.Extensions.ordId", () => {
+        const appConfig = {
+            ...BASE_CONFIG,
+            csn: {
+                definitions: {
+                    "PublicService.EventA": makeEventDef(
+                        makeService("PublicService", {
+                            "@ORD.Extensions.ordId": "{namespace}:{type}:PublicService:v1",
+                        }),
+                    ),
+                },
+            },
+        };
+
+        const result = createEventResources(appConfig);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].ordId).toBe("sap.test:eventResource:PublicService:v1");
+    });
+
+    it("correctly replaces placeholders in @ORD.Extensions.partOfPackage", () => {
+        const appConfig = {
+            ...BASE_CONFIG,
+            csn: {
+                definitions: {
+                    "PublicService.EventA": makeEventDef(
+                        makeService("PublicService", {
+                            "@ORD.Extensions.partOfPackage": "{namespace}:{type}:PublicServices:v1",
+                        }),
+                    ),
+                },
+            },
+        };
+
+        const result = createEventResources(appConfig);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].partOfPackage).toBe("sap.test:package:PublicServices:v1");
     });
 });

--- a/__tests__/unit/templates/integration-dependency.test.js
+++ b/__tests__/unit/templates/integration-dependency.test.js
@@ -1,7 +1,11 @@
 const cds = require("@sap/cds");
 
 const { RESOURCE_VISIBILITY } = require("../../../lib/constants");
-const { createIntegrationDependencies, createIntegrationDependency, RESOLVERS } = require("../../../lib/templates/integration-dependency");
+const {
+    createIntegrationDependencies,
+    createIntegrationDependency,
+    RESOLVERS,
+} = require("../../../lib/templates/integration-dependency");
 
 describe("RESOLVERS.version", () => {
     it("defaults to 1.0.0 when env has no integrationDependency config", () => {
@@ -38,6 +42,15 @@ describe("RESOLVERS.ordId", () => {
         });
 
         expect(result).toBe("sap.test:integrationDependency:externalDependencies:v3");
+    });
+
+    it("replaces placeholders in env.integrationDependency.ordId", () => {
+        const result = RESOLVERS.ordId({
+            ordNamespace: "sap.test",
+            env: { integrationDependency: { ordId: "{namespace}:{type}:test:v1" } },
+        });
+
+        expect(result).toBe("sap.test:integrationDependency:test:v1");
     });
 });
 
@@ -116,6 +129,18 @@ describe("RESOLVERS.partOfPackage", () => {
             packageName: "TestPackage",
             hasSAPPolicyLevel: true,
             env: { integrationDependency: { partOfPackage: "sap.test:package:custom:v1" } },
+        });
+
+        expect(result).toBe("sap.test:package:custom:v1");
+    });
+
+    it("replaces placeholders in env.integrationDependency.partOfPackage when set", () => {
+        const result = RESOLVERS.partOfPackage({
+            appName: "TestApp",
+            ordNamespace: "sap.test",
+            packageName: "TestPackage",
+            hasSAPPolicyLevel: true,
+            env: { integrationDependency: { partOfPackage: "{namespace}:{type}:custom:v1" } },
         });
 
         expect(result).toBe("sap.test:package:custom:v1");
@@ -406,6 +431,27 @@ describe("createIntegrationDependency", () => {
         expect(result.visibility).toBe(RESOURCE_VISIBILITY.internal);
         expect(result.description).toBe("Custom integration dependency description");
         expect(result.shortDescription).toBe("Custom short description");
+    });
+
+    it("should replace placeholders when ordId is overridden via cdsrc", () => {
+        const result = createIntegrationDependency({
+            appName: "testapp",
+            packageName: "TestPackage",
+            ordNamespace: "customer.testapp",
+            env: {
+                integrationDependency: {
+                    ordId: "{namespace}:{type}:test:v1",
+                },
+            },
+            csn: cds.linked(`
+                @cds.external
+                @data.product
+                @cds.dp.ordId: 'sap.ext:apiResource:Supplier:v1'
+                service sap.sai.Supplier.v1 {};
+            `),
+        });
+
+        expect(result.ordId).toBe("customer.testapp:integrationDependency:test:v1");
     });
 });
 

--- a/__tests__/unit/templates/package.test.js
+++ b/__tests__/unit/templates/package.test.js
@@ -165,7 +165,7 @@ describe("createPackage", () => {
             const result = createPackage(BASE_CONFIG, {
                 label: "General",
                 visibility: RESOURCE_VISIBILITY.public,
-                productOrdId: "sap:product:MyProduct:",
+                products: ["sap:product:MyProduct:"],
             });
             expect(result.partOfProducts).toEqual(["sap:product:MyProduct:"]);
         });

--- a/__tests__/unit/templates/package.test.js
+++ b/__tests__/unit/templates/package.test.js
@@ -209,5 +209,16 @@ describe("createPackage", () => {
             const result = createPackage(BASE_CONFIG, { label: "General", visibility: RESOURCE_VISIBILITY.public });
             expect(result.vendor).toBe("customer:vendor:Customer:");
         });
+
+        it("placeholders in overrides are replaced accordingly", () => {
+            const appConfig = {
+                ...BASE_CONFIG,
+                env: { packages: [{ ordId: "{namespace}:{type}:custom-override:v1" }] },
+            };
+            const result = createPackages(appConfig);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].ordId).toBe("sap.test:package:custom-override:v1");
+        });
     });
 });

--- a/__tests__/unit/templates/product.test.js
+++ b/__tests__/unit/templates/product.test.js
@@ -118,12 +118,19 @@ describe("createProducts", () => {
         const appConfig = {
             ...BASE_CONFIG,
             env: {
-                products: [
-                    { ordId: "customer:product:A:" },
-                    { ordId: "customer:product:B:" },
-                ],
+                products: [{ ordId: "customer:product:A:" }, { ordId: "customer:product:B:" }],
             },
         };
         expect(createProducts(appConfig)).toHaveLength(1);
+    });
+
+    it("correctly replaces placeholders for namespace and type in product ordId", () => {
+        const appConfig = {
+            ...BASE_CONFIG,
+            env: {
+                products: [{ ordId: "{namespace}:{type}:A:" }],
+            },
+        };
+        expect(createProducts(appConfig)).toMatchSnapshot();
     });
 });

--- a/lib/common/placeholders.js
+++ b/lib/common/placeholders.js
@@ -1,0 +1,6 @@
+module.exports = {
+    replace: (value, context) => {
+        return Object.entries(context) //
+            .reduce((result, [key, value]) => result?.replaceAll(`{${key}}`, value), value);
+    },
+};

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -19,10 +19,6 @@ const {
 
 const DEFAULT_ACCESS_STRATEGIES = Object.freeze([ORD_ACCESS_STRATEGY.Open]);
 
-function asArray(value) {
-    return Array.isArray(value) || [null, undefined].includes(value) ? value : [value];
-}
-
 function getRFC3339Date() {
     const now = new Date();
     const year = now.getUTCFullYear();
@@ -170,7 +166,6 @@ function resolveAccessStrategies(authConfig, options = {}) {
 }
 
 module.exports = {
-    asArray,
     isValidService,
     getRFC3339Date,
     readORDExtensions,

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -19,6 +19,10 @@ const {
 
 const DEFAULT_ACCESS_STRATEGIES = Object.freeze([ORD_ACCESS_STRATEGY.Open]);
 
+function asArray(value) {
+    return Array.isArray(value) || value === undefined ? value : [value];
+}
+
 function getRFC3339Date() {
     const now = new Date();
     const year = now.getUTCFullYear();
@@ -166,6 +170,7 @@ function resolveAccessStrategies(authConfig, options = {}) {
 }
 
 module.exports = {
+    asArray,
     isValidService,
     getRFC3339Date,
     readORDExtensions,

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -20,7 +20,7 @@ const {
 const DEFAULT_ACCESS_STRATEGIES = Object.freeze([ORD_ACCESS_STRATEGY.Open]);
 
 function asArray(value) {
-    return Array.isArray(value) || value === undefined ? value : [value];
+    return Array.isArray(value) || [null, undefined].includes(value) ? value : [value];
 }
 
 function getRFC3339Date() {

--- a/lib/templates/api-resource.js
+++ b/lib/templates/api-resource.js
@@ -79,10 +79,11 @@ function _getResourceDefinition(resourceType, mediaType, ordId, serviceName, fil
  * @returns {Array} An array of objects for the API Resources.
  */
 const createAPIResourceTemplate = (srvDefinition, appConfig) => {
+    const namespace = appConfig.ordNamespace;
     const ordExtensions = readORDExtensions(srvDefinition);
     const visibility = resolveVisibility(appConfig, srvDefinition);
     const packageIds = createPackages(appConfig)?.map((pkg) => pkg.ordId) || [];
-    const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.api, visibility);
+    const packageId = _getPackageID(namespace, packageIds, ORD_RESOURCE_TYPE.api, visibility);
     const protocolResults = resolveApiResourceProtocol(srvDefinition);
     const apiResources = [];
     const accessStrategies = appConfig.accessStrategies;
@@ -115,9 +116,9 @@ const createAPIResourceTemplate = (srvDefinition, appConfig) => {
         const { apiProtocol, entryPoints, hasResourceDefinitions } = protocolResult;
         const protocolExtensions = readORDExtensions(srvDefinition, `@protocol('${apiProtocol}').ORD.Extensions.`);
         const ordId =
-            protocolExtensions.ordId ||
-            ordExtensions.ordId ||
-            `${appConfig.ordNamespace}:apiResource:${cleanServiceName}${index === 0 ? "" : `-${apiProtocol}`}:${version}`;
+            protocolExtensions.ordId ??
+            ordExtensions.ordId ??
+            `${namespace}:apiResource:${cleanServiceName}${index === 0 ? "" : `-${apiProtocol}`}:${version}`;
 
         // Build resource definitions based on protocol
         let resourceDefinitions = [];
@@ -221,7 +222,7 @@ const createAPIResourceTemplate = (srvDefinition, appConfig) => {
             obj.direction = "outbound";
             if (extracted) {
                 // Overwrite partOfGroups
-                obj.partOfGroups = [`${defaults.groupTypeId}:${appConfig.ordNamespace}:${cleanServiceName}`];
+                obj.partOfGroups = [`${defaults.groupTypeId}:${namespace}:${cleanServiceName}`];
             }
         }
 
@@ -276,8 +277,8 @@ function createAPIResources(appConfig) {
         .flatMap((service) => createAPIResourceTemplate(service, appConfig))
         .map((ar) => ({
             ...ar,
-            ordId: ar.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
             partOfPackage: ar.partOfPackage.replace(/\{namespace}/g, appConfig.ordNamespace),
+            ordId: ar.ordId.replace(/\{type}/g, "apiResource").replace(/\{namespace}/g, appConfig.ordNamespace),
         }));
 }
 

--- a/lib/templates/api-resource.js
+++ b/lib/templates/api-resource.js
@@ -3,6 +3,7 @@ const _ = require("lodash");
 const Logger = require("../logger");
 const defaults = require("../defaults");
 const { createPackages } = require("./package");
+const placeholders = require("../common/placeholders");
 const { resolveApiResourceProtocol } = require("../protocol-resolver");
 const { resolveVisibility, resolveServiceName, flattenEntityGraph } = require("../common/utils");
 const {
@@ -118,8 +119,8 @@ const createAPIResourceTemplate = (srvDefinition, appConfig) => {
         const { apiProtocol, entryPoints, hasResourceDefinitions } = protocolResult;
         const protocolExtensions = readORDExtensions(srvDefinition, `@protocol('${apiProtocol}').ORD.Extensions.`);
         const ordId =
-            protocolExtensions.ordId?.replace(/\{type}/g, "apiResource")?.replace(/\{namespace}/g, namespace) ??
-            ordExtensions.ordId?.replace(/\{type}/g, "apiResource")?.replace(/\{namespace}/g, namespace) ??
+            placeholders.replace(protocolExtensions.ordId, { type: "apiResource", namespace: namespace }) ??
+            placeholders.replace(ordExtensions.ordId, { type: "apiResource", namespace: namespace }) ??
             `${namespace}:apiResource:${cleanServiceName}${index === 0 ? "" : `-${apiProtocol}`}:${version}`;
 
         // Build resource definitions based on protocol
@@ -279,8 +280,11 @@ function createAPIResources(appConfig) {
         .flatMap((service) => createAPIResourceTemplate(service, appConfig))
         .map((ar) => ({
             ...ar,
-            partOfPackage: ar.partOfPackage.replace(/\{namespace}/g, appConfig.ordNamespace),
-            ordId: ar.ordId.replace(/\{type}/g, "apiResource").replace(/\{namespace}/g, appConfig.ordNamespace),
+            ordId: placeholders.replace(ar.ordId, { type: "apiResource", namespace: appConfig.ordNamespace }),
+            partOfPackage: placeholders.replace(ar.partOfPackage, {
+                type: "package",
+                namespace: appConfig.ordNamespace,
+            }),
         }));
 }
 

--- a/lib/templates/api-resource.js
+++ b/lib/templates/api-resource.js
@@ -1,3 +1,5 @@
+const _ = require("lodash");
+
 const Logger = require("../logger");
 const defaults = require("../defaults");
 const { createPackages } = require("./package");
@@ -116,8 +118,8 @@ const createAPIResourceTemplate = (srvDefinition, appConfig) => {
         const { apiProtocol, entryPoints, hasResourceDefinitions } = protocolResult;
         const protocolExtensions = readORDExtensions(srvDefinition, `@protocol('${apiProtocol}').ORD.Extensions.`);
         const ordId =
-            protocolExtensions.ordId ??
-            ordExtensions.ordId ??
+            protocolExtensions.ordId?.replace(/\{type}/g, "apiResource")?.replace(/\{namespace}/g, namespace) ??
+            ordExtensions.ordId?.replace(/\{type}/g, "apiResource")?.replace(/\{namespace}/g, namespace) ??
             `${namespace}:apiResource:${cleanServiceName}${index === 0 ? "" : `-${apiProtocol}`}:${version}`;
 
         // Build resource definitions based on protocol
@@ -213,8 +215,8 @@ const createAPIResourceTemplate = (srvDefinition, appConfig) => {
                 supported: "no",
             },
             ...(exposedEntityTypes.length ? { exposedEntityTypes } : []),
-            ...ordExtensions,
-            ...protocolExtensions,
+            ..._.omit(ordExtensions, ["ordId"]),
+            ..._.omit(protocolExtensions, ["ordId"]),
         };
 
         // Special handling for data product services

--- a/lib/templates/api-resource.js
+++ b/lib/templates/api-resource.js
@@ -259,27 +259,26 @@ function _extractVersionFromServiceName(serviceName) {
 }
 
 function _getPackageID(namespace, packageIds, resourceType, visibility = RESOURCE_VISIBILITY.public) {
-    if (!packageIds) return;
-
-    if (resourceType) {
-        return (
-            packageIds.find((id) => {
-                if (visibility === RESOURCE_VISIBILITY.public) {
-                    return id.includes(resourceType) && !id.includes("-internal") && !id.includes("-private");
-                } else {
-                    return id.includes(`${resourceType}-${visibility}`);
-                }
-            }) || packageIds.find((id) => id.includes(namespace))
-        );
-    }
-
-    return packageIds.find((id) => id.includes(`-${resourceType}-`)) || packageIds.find((id) => id.includes(namespace));
+    return (
+        packageIds.find((id) => {
+            if (visibility === RESOURCE_VISIBILITY.public) {
+                return id.includes(resourceType) && !id.includes("-internal") && !id.includes("-private");
+            } else {
+                return id.includes(`${resourceType}-${visibility}`);
+            }
+        }) || packageIds.find((id) => id.includes(namespace))
+    );
 }
 
 function createAPIResources(appConfig) {
     return Object.values(appConfig.csn.definitions)
         .filter((definition) => isValidService(definition) && !isEventsOnlyService(definition))
-        .flatMap((service) => createAPIResourceTemplate(service, appConfig));
+        .flatMap((service) => createAPIResourceTemplate(service, appConfig))
+        .map((ar) => ({
+            ...ar,
+            ordId: ar.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
+            partOfPackage: ar.partOfPackage.replace(/\{namespace}/g, appConfig.ordNamespace),
+        }));
 }
 
 module.exports = {

--- a/lib/templates/entity-type.js
+++ b/lib/templates/entity-type.js
@@ -12,11 +12,11 @@ const {
 } = require("../constants");
 
 const RESOLVERS = Object.freeze({
-    ordId: (entity) => {
+    ordId: (entity, appConfig) => {
         const [namespace, name, version = "v1"] = entity[ENTITY_RELATIONSHIP_ANNOTATION].split(":");
 
         return (
-            entity["@ORD.Extensions.ordId"] ??
+            entity["@ORD.Extensions.ordId"]?.replace(/\{namespace}/g, appConfig.ordNamespace) ??
             `${namespace}:entityType:${name}:v${(entity["@ORD.Extensions.version"] ?? version.substring(1)).split(".")[0]}`
         );
     },
@@ -38,8 +38,8 @@ const RESOLVERS = Object.freeze({
     localId: (entity) => {
         return entity["@ORD.Extensions.localId"] ?? entity[ENTITY_RELATIONSHIP_ANNOTATION].split(":")[1];
     },
-    version: (entity) => {
-        const ordId = RESOLVERS.ordId(entity);
+    version: (entity, appConfig) => {
+        const ordId = RESOLVERS.ordId(entity, appConfig);
         const version = entity["@ORD.Extensions.version"] ?? ordId.split(":").pop().replace("v", "") + ".0.0";
 
         if (!SEM_VERSION_REGEX.test(version)) {
@@ -58,7 +58,7 @@ const RESOLVERS = Object.freeze({
         const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
 
         return (
-            entity["@ORD.Extensions.partOfPackage"] ??
+            entity["@ORD.Extensions.partOfPackage"]?.replace(/\{namespace}/g, appConfig.ordNamespace) ??
             [
                 `${appConfig.ordNamespace}:package:${name}-entityType${suffix}:v1`,
                 `${appConfig.ordNamespace}:package:${name}:v1`,
@@ -80,18 +80,18 @@ function createEntityTypeTemplate(appConfig, entity) {
         releaseStatus: "active",
         extensible: { supported: "no" },
         lastUpdate: appConfig.lastUpdate,
-
-        ordId: RESOLVERS.ordId(entity),
-        title: RESOLVERS.title(entity),
-        level: RESOLVERS.level(entity),
-        localId: RESOLVERS.localId(entity),
-        version: RESOLVERS.version(entity),
-        visibility: RESOLVERS.visibility(entity, appConfig),
-        partOfPackage: RESOLVERS.partOfPackage(entity, appConfig),
         description: `Description for ${RESOLVERS.localId(entity)}`,
         shortDescription: `Short description of ${RESOLVERS.localId(entity)}`,
 
         ...readORDExtensions(entity),
+
+        title: RESOLVERS.title(entity),
+        level: RESOLVERS.level(entity),
+        localId: RESOLVERS.localId(entity),
+        ordId: RESOLVERS.ordId(entity, appConfig),
+        version: RESOLVERS.version(entity, appConfig),
+        visibility: RESOLVERS.visibility(entity, appConfig),
+        partOfPackage: RESOLVERS.partOfPackage(entity, appConfig),
     };
 }
 
@@ -104,11 +104,7 @@ function createEntityTypes(appConfig) {
                   .map((entity) => createEntityTypeTemplate(appConfig, entity))
                   .filter((entity) => entity.visibility !== RESOURCE_VISIBILITY.private),
               CONTENT_MERGE_KEY,
-          ).map((e) => ({
-              ...e,
-              ordId: e.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
-              partOfPackage: e.partOfPackage.replace(/\{namespace}/g, appConfig.ordNamespace),
-          }));
+          );
 }
 
 module.exports = {

--- a/lib/templates/entity-type.js
+++ b/lib/templates/entity-type.js
@@ -104,7 +104,11 @@ function createEntityTypes(appConfig) {
                   .map((entity) => createEntityTypeTemplate(appConfig, entity))
                   .filter((entity) => entity.visibility !== RESOURCE_VISIBILITY.private),
               CONTENT_MERGE_KEY,
-          );
+          ).map((e) => ({
+              ...e,
+              ordId: e.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
+              partOfPackage: e.partOfPackage.replace(/\{namespace}/g, appConfig.ordNamespace),
+          }));
 }
 
 module.exports = {

--- a/lib/templates/entity-type.js
+++ b/lib/templates/entity-type.js
@@ -2,6 +2,7 @@ const _ = require("lodash");
 
 const Logger = require("../logger");
 const { createPackages } = require("./package");
+const placeholders = require("../common/placeholders");
 const { readORDExtensions, isExposedEntityType } = require("../common/utils");
 const {
     LEVEL,
@@ -16,9 +17,10 @@ const RESOLVERS = Object.freeze({
         const [namespace, name, version = "v1"] = entity[ENTITY_RELATIONSHIP_ANNOTATION].split(":");
 
         return (
-            entity["@ORD.Extensions.ordId"]
-                ?.replace(/\{type}/g, "entityType")
-                ?.replace(/\{namespace}/g, appConfig.ordNamespace) ??
+            placeholders.replace(entity["@ORD.Extensions.ordId"], {
+                type: "entityType",
+                namespace: appConfig.ordNamespace,
+            }) ??
             `${namespace}:entityType:${name}:v${(entity["@ORD.Extensions.version"] ?? version.substring(1)).split(".")[0]}`
         );
     },
@@ -54,17 +56,20 @@ const RESOLVERS = Object.freeze({
         return entity["@ORD.Extensions.visibility"] ?? appConfig.env?.defaultVisibility ?? RESOURCE_VISIBILITY.public;
     },
     partOfPackage: (entity, appConfig) => {
+        const namespace = appConfig.ordNamespace;
         const visibility = RESOLVERS.visibility(entity, appConfig);
         const name = appConfig.appName?.replace(/[^a-zA-Z0-9]/g, "");
         const packages = createPackages(appConfig).map((pkg) => pkg.ordId);
         const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
 
         return (
-            entity["@ORD.Extensions.partOfPackage"]?.replace(/\{namespace}/g, appConfig.ordNamespace) ??
-            [
-                `${appConfig.ordNamespace}:package:${name}-entityType${suffix}:v1`,
-                `${appConfig.ordNamespace}:package:${name}:v1`,
-            ].find((candidate) => packages.includes(candidate))
+            placeholders.replace(entity["@ORD.Extensions.partOfPackage"], {
+                type: "package",
+                namespace: namespace,
+            }) ??
+            [`${namespace}:package:${name}-entityType${suffix}:v1`, `${namespace}:package:${name}:v1`].find(
+                (candidate) => packages.includes(candidate),
+            )
         );
     },
 });
@@ -85,8 +90,6 @@ function createEntityTypeTemplate(appConfig, entity) {
         description: `Description for ${RESOLVERS.localId(entity)}`,
         shortDescription: `Short description of ${RESOLVERS.localId(entity)}`,
 
-        ...readORDExtensions(entity),
-
         title: RESOLVERS.title(entity),
         level: RESOLVERS.level(entity),
         localId: RESOLVERS.localId(entity),
@@ -94,6 +97,8 @@ function createEntityTypeTemplate(appConfig, entity) {
         version: RESOLVERS.version(entity, appConfig),
         visibility: RESOLVERS.visibility(entity, appConfig),
         partOfPackage: RESOLVERS.partOfPackage(entity, appConfig),
+
+        ..._.omit(readORDExtensions(entity), Object.keys(RESOLVERS)),
     };
 }
 

--- a/lib/templates/entity-type.js
+++ b/lib/templates/entity-type.js
@@ -16,7 +16,9 @@ const RESOLVERS = Object.freeze({
         const [namespace, name, version = "v1"] = entity[ENTITY_RELATIONSHIP_ANNOTATION].split(":");
 
         return (
-            entity["@ORD.Extensions.ordId"]?.replace(/\{namespace}/g, appConfig.ordNamespace) ??
+            entity["@ORD.Extensions.ordId"]
+                ?.replace(/\{type}/g, "entityType")
+                ?.replace(/\{namespace}/g, appConfig.ordNamespace) ??
             `${namespace}:entityType:${name}:v${(entity["@ORD.Extensions.version"] ?? version.substring(1)).split(".")[0]}`
         );
     },

--- a/lib/templates/event-resource.js
+++ b/lib/templates/event-resource.js
@@ -35,7 +35,7 @@ const RESOLVERS = Object.freeze({
         const version = `v${RESOLVERS.version(service).split(".")[0]}`;
 
         return (
-            service["@ORD.Extensions.ordId"]?.replace(/\{namespace}/g, namespace) ??
+            service["@ORD.Extensions.ordId"]?.replace(/\{type}/g, "eventResource")?.replace(/\{namespace}/g, namespace) ??
             `${namespace}:eventResource:${name}:${version}`
         );
     },

--- a/lib/templates/event-resource.js
+++ b/lib/templates/event-resource.js
@@ -34,7 +34,10 @@ const RESOLVERS = Object.freeze({
         const name = resolveServiceName(appConfig, service);
         const version = `v${RESOLVERS.version(service).split(".")[0]}`;
 
-        return service["@ORD.Extensions.ordId"] ?? `${namespace}:eventResource:${name}:${version}`;
+        return (
+            service["@ORD.Extensions.ordId"]?.replace(/\{namespace}/g, namespace) ??
+            `${namespace}:eventResource:${name}:${version}`
+        );
     },
     title: (service, appConfig) => {
         return (
@@ -45,7 +48,7 @@ const RESOLVERS = Object.freeze({
             `ODM ${appConfig.appName.replace(/[^a-zA-Z0-9]/g, "")} Events`
         );
     },
-    exposedEntityTypes: (service) => {
+    exposedEntityTypes: (service, appConfig) => {
         const ordIds = new Set(
             Object.values(service.entities ?? {})
                 .flatMap((entity) => flattenEntityGraph(entity))
@@ -56,12 +59,12 @@ const RESOLVERS = Object.freeze({
                             : [`sap.odm:entityType:${entity[ORD_ODM_ENTITY_NAME_ANNOTATION]}:v1`]),
                         ...(!entity[ENTITY_RELATIONSHIP_ANNOTATION]
                             ? []
-                            : [entityTypeTemplate.RESOLVERS.ordId(entity)]),
+                            : [entityTypeTemplate.RESOLVERS.ordId(entity, appConfig)]),
                     ];
                 }),
         );
 
-        return [...ordIds].map((ordId) => ({ ordId: ordId }));
+        return service["@ORD.Extensions.exposedEntityTypes"] ?? [...ordIds].map((ordId) => ({ ordId: ordId }));
     },
     visibility: (service, appConfig) => {
         return resolveVisibility(appConfig, service);
@@ -70,20 +73,19 @@ const RESOLVERS = Object.freeze({
         const namespace = appConfig.ordNamespace;
         const name = resolveServiceName(appConfig, service);
 
-        return [`${defaults.groupTypeId}:${namespace}:${name}`];
+        return service["@ORD.Extensions.partOfGroups"] ?? [`${defaults.groupTypeId}:${namespace}:${name}`];
     },
     partOfPackage: (service, appConfig) => {
+        const namespace = appConfig.ordNamespace;
         const visibility = RESOLVERS.visibility(service, appConfig);
         const name = appConfig.appName?.replace(/[^a-zA-Z0-9]/g, "");
         const packages = createPackages(appConfig).map((pkg) => pkg.ordId);
         const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
 
         return (
-            service["@ORD.Extensions.partOfPackage"] ??
-            [
-                `${appConfig.ordNamespace}:package:${name}-event${suffix}:v1`,
-                `${appConfig.ordNamespace}:package:${name}:v1`,
-            ].find((candidate) => packages.includes(candidate))
+            service["@ORD.Extensions.partOfPackage"]?.replace(/\{namespace}/g, namespace) ??
+            [`${namespace}:package:${name}-event${suffix}:v1`, `${namespace}:package:${name}:v1`] //
+                .find((candidate) => packages.includes(candidate))
         );
     },
     resourceDefinitions: (service, appConfig) => {
@@ -91,14 +93,16 @@ const RESOLVERS = Object.freeze({
         const ordId = RESOLVERS.ordId(service, appConfig);
         const accessStrategies = appConfig.accessStrategies;
 
-        return [
-            {
-                type: "asyncapi-v2",
-                mediaType: `application/json`,
-                url: `/ord/v1/${ordId}/${name}.asyncapi2.json`,
-                accessStrategies: accessStrategies,
-            },
-        ];
+        return (
+            service["@ORD.Extensions.resourceDefinitions"] ?? [
+                {
+                    type: "asyncapi-v2",
+                    mediaType: `application/json`,
+                    url: `/ord/v1/${ordId}/${name}.asyncapi2.json`,
+                    accessStrategies: accessStrategies,
+                },
+            ]
+        );
     },
 });
 
@@ -113,13 +117,15 @@ const RESOLVERS = Object.freeze({
  * @returns {object} An object representing the Event Resource.
  */
 function createEventResourceTemplate(service, appConfig) {
-    const exposedEntityTypes = RESOLVERS.exposedEntityTypes(service);
+    const exposedEntityTypes = RESOLVERS.exposedEntityTypes(service, appConfig);
 
     return {
         releaseStatus: "active",
         extensible: { supported: "no" },
         lastUpdate: appConfig.lastUpdate,
         shortDescription: `${service.name} event resource`,
+
+        ...readORDExtensions(service),
 
         version: RESOLVERS.version(service),
         ordId: RESOLVERS.ordId(service, appConfig),
@@ -131,8 +137,6 @@ function createEventResourceTemplate(service, appConfig) {
         resourceDefinitions: RESOLVERS.resourceDefinitions(service, appConfig),
 
         ...(exposedEntityTypes.length && { exposedEntityTypes }),
-
-        ...readORDExtensions(service),
     };
 }
 
@@ -147,12 +151,7 @@ function createEventResources(appConfig) {
 
     return services
         .map((service) => createEventResourceTemplate(service, appConfig))
-        .filter((resource) => resource.visibility !== RESOURCE_VISIBILITY.private)
-        .map((er) => ({
-            ...er,
-            ordId: er.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
-            partOfPackage: er.partOfPackage.replace(/\{namespace}/g, appConfig.ordNamespace),
-        }));
+        .filter((resource) => resource.visibility !== RESOURCE_VISIBILITY.private);
 }
 
 module.exports = {

--- a/lib/templates/event-resource.js
+++ b/lib/templates/event-resource.js
@@ -3,6 +3,7 @@ const _ = require("lodash");
 const defaults = require("../defaults");
 const { createPackages } = require("./package");
 const entityTypeTemplate = require("./entity-type");
+const placeholders = require("../common/placeholders");
 const {
     RESOURCE_VISIBILITY,
     ENTITY_RELATIONSHIP_ANNOTATION,
@@ -30,13 +31,14 @@ const RESOLVERS = Object.freeze({
         );
     },
     ordId: (service, appConfig) => {
-        const namespace = appConfig.ordNamespace;
         const name = resolveServiceName(appConfig, service);
         const version = `v${RESOLVERS.version(service).split(".")[0]}`;
 
         return (
-            service["@ORD.Extensions.ordId"]?.replace(/\{type}/g, "eventResource")?.replace(/\{namespace}/g, namespace) ??
-            `${namespace}:eventResource:${name}:${version}`
+            placeholders.replace(service["@ORD.Extensions.ordId"], {
+                type: "eventResource",
+                namespace: appConfig.ordNamespace,
+            }) ?? `${appConfig.ordNamespace}:eventResource:${name}:${version}`
         );
     },
     title: (service, appConfig) => {
@@ -83,7 +85,7 @@ const RESOLVERS = Object.freeze({
         const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
 
         return (
-            service["@ORD.Extensions.partOfPackage"]?.replace(/\{namespace}/g, namespace) ??
+            placeholders.replace(service["@ORD.Extensions.partOfPackage"], { type: "package", namespace: namespace }) ??
             [`${namespace}:package:${name}-event${suffix}:v1`, `${namespace}:package:${name}:v1`] //
                 .find((candidate) => packages.includes(candidate))
         );
@@ -125,8 +127,6 @@ function createEventResourceTemplate(service, appConfig) {
         lastUpdate: appConfig.lastUpdate,
         shortDescription: `${service.name} event resource`,
 
-        ...readORDExtensions(service),
-
         version: RESOLVERS.version(service),
         ordId: RESOLVERS.ordId(service, appConfig),
         title: RESOLVERS.title(service, appConfig),
@@ -137,6 +137,8 @@ function createEventResourceTemplate(service, appConfig) {
         resourceDefinitions: RESOLVERS.resourceDefinitions(service, appConfig),
 
         ...(exposedEntityTypes.length && { exposedEntityTypes }),
+
+        ..._.omit(readORDExtensions(service), Object.keys(RESOLVERS)),
     };
 }
 

--- a/lib/templates/event-resource.js
+++ b/lib/templates/event-resource.js
@@ -147,7 +147,12 @@ function createEventResources(appConfig) {
 
     return services
         .map((service) => createEventResourceTemplate(service, appConfig))
-        .filter((resource) => resource.visibility !== RESOURCE_VISIBILITY.private);
+        .filter((resource) => resource.visibility !== RESOURCE_VISIBILITY.private)
+        .map((er) => ({
+            ...er,
+            ordId: er.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
+            partOfPackage: er.partOfPackage.replace(/\{namespace}/g, appConfig.ordNamespace),
+        }));
 }
 
 module.exports = {

--- a/lib/templates/integration-dependency.js
+++ b/lib/templates/integration-dependency.js
@@ -1,17 +1,18 @@
 const { createPackages } = require("./package");
+const placeholders = require("../common/placeholders");
 const { readORDExtensions, isExternalDataProduct } = require("../common/utils");
 const { RESOURCE_VISIBILITY, EXTERNAL_DP_ORD_ID_ANNOTATION } = require("../constants");
+const _ = require("lodash");
 
 const RESOLVERS = Object.freeze({
     ordId: (appConfig) => {
-        const namespace = appConfig.ordNamespace;
         const major = RESOLVERS.version(appConfig).split(".")[0];
 
         return (
-            appConfig.env?.integrationDependency?.ordId
-                ?.replace(/\{namespace}/g, namespace)
-                ?.replace(/\{type}/g, "integrationDependency") ??
-            `${namespace}:integrationDependency:externalDependencies:v${major}`
+            placeholders.replace(appConfig.env?.integrationDependency?.ordId, {
+                type: "integrationDependency",
+                namespace: appConfig.ordNamespace,
+            }) ?? `${appConfig.ordNamespace}:integrationDependency:externalDependencies:v${major}`
         );
     },
     version: (appConfig) => {
@@ -51,7 +52,10 @@ const RESOLVERS = Object.freeze({
         const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
 
         return (
-            appConfig.env?.integrationDependency?.partOfPackage?.replace(/\{namespace}/g, appConfig.ordNamespace) ??
+            placeholders.replace(appConfig.env?.integrationDependency?.partOfPackage, {
+                type: "package",
+                namespace: appConfig.ordNamespace,
+            }) ??
             [
                 `${appConfig.ordNamespace}:package:${name}-integrationDependency${suffix}:v1`,
                 `${appConfig.ordNamespace}:package:${name}:v1`,
@@ -71,13 +75,14 @@ function createIntegrationDependency(appConfig) {
         releaseStatus: "active",
         title: "External Dependencies",
 
-        ...(appConfig.env?.integrationDependency ?? {}), // Allow customization via cdsrc
-
         ordId: RESOLVERS.ordId(appConfig),
         version: RESOLVERS.version(appConfig),
         aspects: RESOLVERS.aspects(appConfig),
         visibility: RESOLVERS.visibility(appConfig),
         partOfPackage: RESOLVERS.partOfPackage(appConfig),
+
+        // Allow customization via cdsrc
+        ..._.omit(appConfig.env?.integrationDependency ?? {}, Object.keys(RESOLVERS)),
     };
 }
 

--- a/lib/templates/integration-dependency.js
+++ b/lib/templates/integration-dependency.js
@@ -7,31 +7,37 @@ const RESOLVERS = Object.freeze({
         const namespace = appConfig.ordNamespace;
         const major = RESOLVERS.version(appConfig).split(".")[0];
 
-        return `${namespace}:integrationDependency:externalDependencies:v${major}`;
+        return (
+            appConfig.env?.integrationDependency?.ordId?.replace(/\{namespace}/g, namespace) ??
+            `${namespace}:integrationDependency:externalDependencies:v${major}`
+        );
     },
     version: (appConfig) => {
         return appConfig.env?.integrationDependency?.version || "1.0.0";
     },
     aspects: (appConfig) => {
-        return Object.values(appConfig.csn.definitions)
-            .filter((definition) => isExternalDataProduct(definition))
-            .filter((service) => "apiResource" === service[EXTERNAL_DP_ORD_ID_ANNOTATION].split(":")[1])
-            .map((service) => {
-                const version = service[EXTERNAL_DP_ORD_ID_ANNOTATION].split(":")[3] ?? "v1";
+        return (
+            appConfig.env?.integrationDependency?.aspects ??
+            Object.values(appConfig.csn.definitions)
+                .filter((definition) => isExternalDataProduct(definition))
+                .filter((service) => "apiResource" === service[EXTERNAL_DP_ORD_ID_ANNOTATION].split(":")[1])
+                .map((service) => {
+                    const version = service[EXTERNAL_DP_ORD_ID_ANNOTATION].split(":")[3] ?? "v1";
 
-                return {
-                    title: service.name,
-                    mandatory: false,
-                    apiResources: [
-                        {
-                            ordId: service[EXTERNAL_DP_ORD_ID_ANNOTATION],
-                            minVersion: version.replace("v", "") + ".0.0",
-                        },
-                    ],
+                    return {
+                        title: service.name,
+                        mandatory: false,
+                        apiResources: [
+                            {
+                                ordId: service[EXTERNAL_DP_ORD_ID_ANNOTATION],
+                                minVersion: version.replace("v", "") + ".0.0",
+                            },
+                        ],
 
-                    ...readORDExtensions(service), // Allow customization via @ORD.Extensions on the service
-                };
-            });
+                        ...readORDExtensions(service), // Allow customization via @ORD.Extensions on the service
+                    };
+                })
+        );
     },
     visibility: (appConfig) => {
         return appConfig.env?.integrationDependency?.visibility || RESOURCE_VISIBILITY.public;
@@ -43,7 +49,7 @@ const RESOLVERS = Object.freeze({
         const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
 
         return (
-            appConfig.env?.integrationDependency?.partOfPackage ??
+            appConfig.env?.integrationDependency?.partOfPackage?.replace(/\{namespace}/g, appConfig.ordNamespace) ??
             [
                 `${appConfig.ordNamespace}:package:${name}-integrationDependency${suffix}:v1`,
                 `${appConfig.ordNamespace}:package:${name}:v1`,
@@ -63,24 +69,19 @@ function createIntegrationDependency(appConfig) {
         releaseStatus: "active",
         title: "External Dependencies",
 
+        ...(appConfig.env?.integrationDependency ?? {}), // Allow customization via cdsrc
+
         ordId: RESOLVERS.ordId(appConfig),
         version: RESOLVERS.version(appConfig),
         aspects: RESOLVERS.aspects(appConfig),
         visibility: RESOLVERS.visibility(appConfig),
         partOfPackage: RESOLVERS.partOfPackage(appConfig),
-
-        ...(appConfig.env?.integrationDependency ?? {}), // Allow customization via cdsrc
     };
 }
 
 function createIntegrationDependencies(appConfig) {
     return [createIntegrationDependency(appConfig)] //
-        .filter((dependency) => dependency.aspects?.length > 0)
-        .map((id) => ({
-            ...id,
-            ordId: id.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
-            partOfPackage: id.partOfPackage.replace(/\{namespace}/g, appConfig.ordNamespace),
-        }));
+        .filter((dependency) => dependency.aspects?.length > 0);
 }
 
 module.exports = {

--- a/lib/templates/integration-dependency.js
+++ b/lib/templates/integration-dependency.js
@@ -75,7 +75,12 @@ function createIntegrationDependency(appConfig) {
 
 function createIntegrationDependencies(appConfig) {
     return [createIntegrationDependency(appConfig)] //
-        .filter((dependency) => dependency.aspects?.length > 0);
+        .filter((dependency) => dependency.aspects?.length > 0)
+        .map((id) => ({
+            ...id,
+            ordId: id.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
+            partOfPackage: id.partOfPackage.replace(/\{namespace}/g, appConfig.ordNamespace),
+        }));
 }
 
 module.exports = {

--- a/lib/templates/integration-dependency.js
+++ b/lib/templates/integration-dependency.js
@@ -8,7 +8,9 @@ const RESOLVERS = Object.freeze({
         const major = RESOLVERS.version(appConfig).split(".")[0];
 
         return (
-            appConfig.env?.integrationDependency?.ordId?.replace(/\{namespace}/g, namespace) ??
+            appConfig.env?.integrationDependency?.ordId
+                ?.replace(/\{namespace}/g, namespace)
+                ?.replace(/\{type}/g, "integrationDependency") ??
             `${namespace}:integrationDependency:externalDependencies:v${major}`
         );
     },

--- a/lib/templates/package.js
+++ b/lib/templates/package.js
@@ -1,4 +1,3 @@
-const { asArray } = require("../common/utils");
 const { createProducts } = require("./product");
 const placeholders = require("../common/placeholders");
 const { ORD_RESOURCE_TYPE, RESOURCE_VISIBILITY } = require("../constants");

--- a/lib/templates/package.js
+++ b/lib/templates/package.js
@@ -49,7 +49,9 @@ function createPackages(appConfig) {
         )
         .map((p) => ({
             ...p,
-            ordId: p.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
+            ordId: p.ordId //
+                .replace(/\{type}/g, "package") //
+                .replace(/\{namespace}/g, appConfig.ordNamespace),
         }));
 }
 

--- a/lib/templates/package.js
+++ b/lib/templates/package.js
@@ -23,7 +23,9 @@ function createPackage(appConfig, { label, visibility, products, resourceType })
 }
 
 function createPackages(appConfig) {
-    const products = asArray(appConfig.existingProductORDId) ?? createProducts(appConfig)?.map((p) => p.ordId);
+    const products = appConfig.existingProductORDId
+        ? [appConfig.existingProductORDId]
+        : createProducts(appConfig)?.map((p) => p.ordId);
     const visibilities = !appConfig.hasSAPPolicyLevel
         ? [RESOURCE_VISIBILITY.public]
         : Object.values(RESOURCE_VISIBILITY);

--- a/lib/templates/package.js
+++ b/lib/templates/package.js
@@ -1,7 +1,8 @@
+const { asArray } = require("../common/utils");
 const { createProducts } = require("./product");
 const { ORD_RESOURCE_TYPE, RESOURCE_VISIBILITY } = require("../constants");
 
-function createPackage(appConfig, { label, visibility, productOrdId, resourceType }) {
+function createPackage(appConfig, { label, visibility, products, resourceType }) {
     const tag = !resourceType ? "" : `-${resourceType}`;
     const overrides = appConfig?.env?.packages?.[0] ?? {};
     const name = appConfig.appName.replace(/[^a-zA-Z0-9]/g, " ").trim();
@@ -15,13 +16,13 @@ function createPackage(appConfig, { label, visibility, productOrdId, resourceTyp
         shortDescription: `Package containing ${visibility} ${label}`,
         description: `This package contains ${visibility} ${label} for ${name}.`,
         ordId: `${appConfig.ordNamespace}:package:${technicalName}${tag}${suffix}:v1`,
-        ...(productOrdId && { partOfProducts: [productOrdId] }),
+        ...(products?.length > 0 && { partOfProducts: products }),
         ...overrides,
     };
 }
 
 function createPackages(appConfig) {
-    const productOrdId = appConfig.existingProductORDId || createProducts(appConfig)?.[0]?.ordId;
+    const products = asArray(appConfig.existingProductORDId) ?? createProducts(appConfig)?.map((p) => p.ordId);
     const visibilities = !appConfig.hasSAPPolicyLevel
         ? [RESOURCE_VISIBILITY.public]
         : Object.values(RESOURCE_VISIBILITY);
@@ -35,16 +36,21 @@ function createPackages(appConfig) {
               { label: "Integration Dependencies", resourceType: ORD_RESOURCE_TYPE.integrationDependency },
           ];
 
-    return packageTypes.flatMap(({ label, resourceType }) =>
-        visibilities.map((visibility) =>
-            createPackage(appConfig, {
-                label,
-                visibility,
-                productOrdId,
-                resourceType,
-            }),
-        ),
-    );
+    return packageTypes
+        .flatMap(({ label, resourceType }) =>
+            visibilities.map((visibility) =>
+                createPackage(appConfig, {
+                    label,
+                    visibility,
+                    products,
+                    resourceType,
+                }),
+            ),
+        )
+        .map((p) => ({
+            ...p,
+            ordId: p.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
+        }));
 }
 
 module.exports = {

--- a/lib/templates/package.js
+++ b/lib/templates/package.js
@@ -1,5 +1,6 @@
 const { asArray } = require("../common/utils");
 const { createProducts } = require("./product");
+const placeholders = require("../common/placeholders");
 const { ORD_RESOURCE_TYPE, RESOURCE_VISIBILITY } = require("../constants");
 
 function createPackage(appConfig, { label, visibility, products, resourceType }) {
@@ -49,9 +50,7 @@ function createPackages(appConfig) {
         )
         .map((p) => ({
             ...p,
-            ordId: p.ordId //
-                .replace(/\{type}/g, "package") //
-                .replace(/\{namespace}/g, appConfig.ordNamespace),
+            ordId: placeholders.replace(p.ordId, { type: "package", namespace: appConfig.ordNamespace }),
         }));
 }
 

--- a/lib/templates/product.js
+++ b/lib/templates/product.js
@@ -26,7 +26,9 @@ function createProducts(appConfig) {
         : [createProduct(appConfig)] //
               .map((p) => ({
                   ...p,
-                  ordId: p.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
+                  ordId: p.ordId //
+                      .replace(/\{type}/g, "product") //
+                      .replace(/\{namespace}/g, appConfig.ordNamespace),
               }));
 }
 

--- a/lib/templates/product.js
+++ b/lib/templates/product.js
@@ -21,7 +21,13 @@ function createProduct(appConfig) {
 }
 
 function createProducts(appConfig) {
-    return appConfig.existingProductORDId ? [] : [createProduct(appConfig)];
+    return appConfig.existingProductORDId
+        ? []
+        : [createProduct(appConfig)] //
+              .map((p) => ({
+                  ...p,
+                  ordId: p.ordId.replace(/\{namespace}/g, appConfig.ordNamespace),
+              }));
 }
 
 module.exports = {

--- a/lib/templates/product.js
+++ b/lib/templates/product.js
@@ -1,4 +1,5 @@
 const Logger = require("../logger");
+const placeholders = require("../common/placeholders");
 
 function createProduct(appConfig) {
     let overrides = appConfig?.env?.products?.[0] ?? {};
@@ -26,9 +27,7 @@ function createProducts(appConfig) {
         : [createProduct(appConfig)] //
               .map((p) => ({
                   ...p,
-                  ordId: p.ordId //
-                      .replace(/\{type}/g, "product") //
-                      .replace(/\{namespace}/g, appConfig.ordNamespace),
+                  ordId: placeholders.replace(p.ordId, { type: "product", namespace: appConfig.ordNamespace }),
               }));
 }
 


### PR DESCRIPTION
# Allow `{namespace}` Placeholder in `ordId` and `partOfPackage` Fields

### New Feature

✨ Introduced support for the `{namespace}` (and `{type}`) placeholder in `ordId` and `partOfPackage` fields across all ORD resource templates. After resource creation, placeholders are resolved by substituting them with the actual `appConfig.ordNamespace` and resource type values. This eliminates the need to hardcode namespace values in templates and configurations.

A dedicated `lib/common/placeholders.js` utility module handles all placeholder resolution using a simple `replace(value, context)` function.

### Changes

* `lib/common/placeholders.js`: **New file** — implements a generic `replace(value, context)` function that substitutes `{key}` placeholders in a string using the provided context object.
* `lib/templates/api-resource.js`: Applies `placeholders.replace()` to `ordId` and `partOfPackage` after resource construction. Simplified `_getPackageID` by removing the early return for missing `packageIds`. Spreads `ordExtensions` while omitting the `ordId` key to prevent double-application.
* `lib/templates/entity-type.js`: Updated `RESOLVERS.ordId` and `RESOLVERS.partOfPackage` to resolve placeholders via the new utility. Added `appConfig` parameter to `RESOLVERS.ordId` and `RESOLVERS.version`. Spreads ORD extensions while omitting already-resolved resolver keys.
* `lib/templates/event-resource.js`: Updated `RESOLVERS.ordId` and `RESOLVERS.partOfPackage` to use placeholder resolution. Added `@ORD.Extensions.exposedEntityTypes` and `@ORD.Extensions.partOfGroups` override support. Propagates `appConfig` to `exposedEntityTypes` resolver.
* `lib/templates/integration-dependency.js`: Updated `RESOLVERS.ordId` and `RESOLVERS.partOfPackage` to resolve placeholders. Added support for `appConfig.env.integrationDependency.aspects` override.
* `lib/templates/package.js`: Applies `placeholders.replace()` to `ordId` after package creation. Replaced `productOrdId` (single value) with `products` (array) to support multiple products in `partOfProducts`.
* `lib/templates/product.js`: Applies `placeholders.replace()` to `ordId` after product creation.
* `__tests__/unit/common/placeholders.test.js`: **New file** — comprehensive unit tests for the `placeholders.replace` utility covering single/multiple replacements, unknown placeholders, edge cases (`null`, `undefined`, empty string).
* `__tests__/unit/templates/api-resource.test.js`: Added tests for placeholder replacement in `@ORD.Extensions.ordId` and `partOfPackage`. Removed test case for `_getPackageID` returning `undefined` when no `packageIds` are provided.
* `__tests__/unit/templates/entity-type.test.js`: Added `appConfig` parameter to all `RESOLVERS` calls. Added tests for `@ORD.Extensions.ordId` and `partOfPackage` placeholder replacement.
* `__tests__/unit/templates/event-resource.test.js`: Added tests for `{namespace}:{type}` placeholder resolution in `ordId` and `partOfPackage`.
* `__tests__/unit/templates/integration-dependency.test.js`: Added tests for placeholder resolution in `ordId` and `partOfPackage` overrides.
* `__tests__/unit/templates/package.test.js`: Updated test to use renamed `products` array parameter. Added test for placeholder resolution in package `ordId` overrides.
* `__tests__/unit/templates/product.test.js`: Added snapshot test for `{namespace}:{type}` placeholder resolution in product `ordId`.
* `__tests__/bookshop/srv/admin-service.cds`: Added example usage of `{namespace}:{type}` placeholder in `@ORD.Extensions.ordId`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.4`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `79545727-bce8-437d-a092-fd6bf8011d69`
</details>
