### PR TITLE
chore: Update to ORD 1.16

### DIFF
--- a/__tests__/integration/__snapshots__/basic-auth.test.js.snap
+++ b/__tests__/integration/__snapshots__/basic-auth.test.js.snap
@@ -243,7 +243,6 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
     },
   ],
   "openResourceDiscovery": "1.16",
-
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",

--- a/__tests__/integration/__snapshots__/basic-auth.test.js.snap
+++ b/__tests__/integration/__snapshots__/basic-auth.test.js.snap
@@ -242,7 +242,7 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -477,7 +477,7 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -709,7 +709,7 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -944,7 +944,7 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Endpoint Test
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -1176,7 +1176,7 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Structure Val
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -1411,7 +1411,7 @@ exports[`ORD Integration Tests - Basic Authentication ORD Document Structure Val
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",

--- a/__tests__/integration/__snapshots__/cds-build.test.js.snap
+++ b/__tests__/integration/__snapshots__/cds-build.test.js.snap
@@ -207,7 +207,7 @@ exports[`ORD Build Integration Tests IntegrationDependency with cdsrc customizat
       "visibility": "internal",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -443,7 +443,7 @@ exports[`ORD Build Integration Tests IntegrationDependency with custom.ord.json 
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -678,7 +678,7 @@ exports[`ORD Build Integration Tests Successful Build should generate ord-docume
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",

--- a/__tests__/integration/__snapshots__/mtls-auth-dev.test.js.snap
+++ b/__tests__/integration/__snapshots__/mtls-auth-dev.test.js.snap
@@ -206,7 +206,7 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -441,7 +441,7 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -676,7 +676,7 @@ exports[`ORD Integration Tests - mTLS Development Mode (cfMtls object with confi
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",

--- a/__tests__/integration/__snapshots__/mtls-auth-prod.test.js.snap
+++ b/__tests__/integration/__snapshots__/mtls-auth-prod.test.js.snap
@@ -221,7 +221,7 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) ORD Documen
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -474,7 +474,7 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) ORD Documen
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -727,7 +727,7 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) Production 
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",
@@ -980,7 +980,7 @@ exports[`ORD Integration Tests - mTLS Production Mode (cfMtls: true) mTLS Authen
       "visibility": "public",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire ord integration test.",

--- a/__tests__/unit/__snapshots__/defaults.test.js.snap
+++ b/__tests__/unit/__snapshots__/defaults.test.js.snap
@@ -210,7 +210,7 @@ exports[`defaults description should return default value 1`] = `"this is an app
 
 exports[`defaults groupTypeId should return default value 1`] = `"sap.cds:service"`;
 
-exports[`defaults openResourceDiscovery should return default value 1`] = `"1.14"`;
+exports[`defaults openResourceDiscovery should return default value 1`] = `"1.16"`;
 
 exports[`defaults policyLevels should return default value 1`] = `
 [

--- a/__tests__/unit/__snapshots__/mocked-csn.test.js.snap
+++ b/__tests__/unit/__snapshots__/mocked-csn.test.js.snap
@@ -251,7 +251,7 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
       "title": "This is test Cinema Service title",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -366,7 +366,7 @@ exports[`Tests for ORD document generated out of mocked csn files Tests for ORD 
       "title": "EbMtEmitter Service",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",

--- a/__tests__/unit/__snapshots__/ord.e2e.test.js.snap
+++ b/__tests__/unit/__snapshots__/ord.e2e.test.js.snap
@@ -971,7 +971,7 @@ exports[`Tests for Data Product definition Check interop CSN annotation mapping 
       "title": "Test Service",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for cap js ord.",
@@ -2220,7 +2220,7 @@ exports[`Tests for Data Product definition Check interop CSN service name parsin
       "title": "Simple Service",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for cap js ord.",
@@ -2335,7 +2335,7 @@ exports[`Tests for eventResource and apiResource should block MTXServices when m
       "title": "My Service",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -2450,7 +2450,7 @@ exports[`Tests for eventResource and apiResource should block OpenResourceDiscov
       "title": "My Service",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -2565,7 +2565,7 @@ exports[`Tests for eventResource and apiResource should exclude external service
       "title": "My Service",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -2680,7 +2680,7 @@ exports[`Tests for eventResource and apiResource should exclude service when it 
       "title": "My Service",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -2964,7 +2964,7 @@ exports[`Tests for products and packages should not contain products property if
       "title": "v1 Service",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -3240,7 +3240,7 @@ exports[`Tests for products and packages should raise error log when custom prod
       "title": "v1 Service",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",
@@ -3524,7 +3524,7 @@ exports[`Tests for products and packages should use valid custom products ordId 
       "title": "v1 Service",
     },
   ],
-  "openResourceDiscovery": "1.14",
+  "openResourceDiscovery": "1.16",
   "packages": [
     {
       "description": "This package contains public General for capire bookshop ord sample.",

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -14,7 +14,7 @@ const sizeLimit = 2000000; // 2mb
  */
 module.exports = {
     $schema: "https://open-resource-discovery.github.io/specification/spec-v1/interfaces/Document.schema.json",
-    openResourceDiscovery: "1.14",
+    openResourceDiscovery: "1.16",
     policyLevels: ["none"],
     groupTypeId: "sap.cds:service",
     description: "this is an application description",

--- a/lib/extend-ord-with-custom.js
+++ b/lib/extend-ord-with-custom.js
@@ -9,12 +9,13 @@ const SCALAR_TYPES = Object.freeze(["number", "string", "boolean"]);
 const MERGE_STRATEGIES = Object.freeze({
     // Directly replace scalar values and scalar value arrays
     $schema: (current, custom) => custom,
+    baseUrl: (current, custom) => custom,
     description: (current, custom) => custom,
     perspective: (current, custom) => custom,
-    openResourceDiscovery: (current, custom) => custom,
     policyLevel: (current, custom) => custom,
     customPolicyLevel: (current, custom) => custom,
     policyLevels: (current, custom) => prune(custom),
+    openResourceDiscovery: (current, custom) => custom,
 
     // Perform simple merge for objects
     describedSystemType: (current, custom) => prune(_.assign(current, custom)),

--- a/lib/extend-ord-with-custom.js
+++ b/lib/extend-ord-with-custom.js
@@ -25,6 +25,7 @@ const MERGE_STRATEGIES = Object.freeze({
     // Perform smart merge for arrays of objects
     agents: (current, custom) => merge(current, custom, ["ordId"]),
     vendors: (current, custom) => merge(current, custom, ["ordId"]),
+    overlays: (current, custom) => merge(current, custom, ["ordId"]),
     products: (current, custom) => merge(current, custom, ["ordId"]),
     packages: (current, custom) => merge(current, custom, ["ordId"]),
     groups: (current, custom) => merge(current, custom, ["groupId"]),

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -48,7 +48,7 @@ module.exports = (csn, extensions) => {
             [...(extensions || []), getCustomORDContent(appConfig)].filter(Boolean), //
             {
                 $schema: defaults.$schema,
-                baseUrl: appConfig.env.baseUrl,
+                baseUrl: appConfig?.env?.baseUrl,
                 groups: createGroups(appConfig),
                 products: createProducts(appConfig),
                 packages: createPackages(appConfig),

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -48,6 +48,7 @@ module.exports = (csn, extensions) => {
             [...(extensions || []), getCustomORDContent(appConfig)].filter(Boolean), //
             {
                 $schema: defaults.$schema,
+                baseUrl: appConfig.env.baseUrl,
                 groups: createGroups(appConfig),
                 products: createProducts(appConfig),
                 packages: createPackages(appConfig),

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -48,8 +48,8 @@ module.exports = (csn, extensions) => {
             [...(extensions || []), getCustomORDContent(appConfig)].filter(Boolean), //
             {
                 $schema: defaults.$schema,
-                baseUrl: appConfig?.env?.baseUrl,
                 groups: createGroups(appConfig),
+                baseUrl: appConfig?.env?.baseUrl,
                 products: createProducts(appConfig),
                 packages: createPackages(appConfig),
                 policyLevels: appConfig.policyLevels,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@cap-js/cds-test": "0.4.1",
         "@cap-js/graphql": "^0.14.0",
         "@cap-js/sqlite": "^2",
-        "@open-resource-discovery/specification": "1.16.0",
+        "@open-resource-discovery/specification": "1.16.1",
         "@sap/cds-dk": ">=8.9.5",
         "eslint": "^10.0.0",
         "express": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@cap-js/cds-test": "0.4.1",
         "@cap-js/graphql": "^0.14.0",
         "@cap-js/sqlite": "^2",
-        "@open-resource-discovery/specification": "1.14.5",
+        "@open-resource-discovery/specification": "1.16.0",
         "@sap/cds-dk": ">=8.9.5",
         "eslint": "^10.0.0",
         "express": "^5.0.0",


### PR DESCRIPTION
# Update ORD Specification Version to 1.16

### Chore

🔧 Bumped the Open Resource Discovery (ORD) specification version from `1.15` to `1.16` across the codebase, and added `baseUrl` support to the generated ORD document structure.

### Changes

* `lib/defaults.js`: Updated the `openResourceDiscovery` default value from `"1.15"` to `"1.16"`.
* `lib/ord.js`: Added `baseUrl` from `appConfig.env.baseUrl` to the generated ORD document structure.
* `lib/extend-ord-with-custom.js`: Added `baseUrl` as a scalar merge strategy so it can be overridden via custom ORD content.
* `package.json`: Updated the `@open-resource-discovery/specification` dev dependency from `1.15.0` to `1.16.0`.
* `__tests__/unit/__snapshots__/defaults.test.js.snap`: Updated snapshot to reflect the new ORD version `"1.16"`.
* `__tests__/unit/__snapshots__/mocked-csn.test.js.snap`: Updated `openResourceDiscovery` snapshots to `"1.16"`.
* `__tests__/unit/__snapshots__/ord.e2e.test.js.snap`: Updated all relevant `openResourceDiscovery` snapshot entries to `"1.16"`.
* `__tests__/integration/__snapshots__/basic-auth.test.js.snap`: Updated integration test snapshots to `"1.16"`.
* `__tests__/integration/__snapshots__/cds-build.test.js.snap`: Updated integration test snapshots to `"1.16"`.
* `__tests__/integration/__snapshots__/mtls-auth-dev.test.js.snap`: Updated integration test snapshots to `"1.16"`.
* `__tests__/integration/__snapshots__/mtls-auth-prod.test.js.snap`: Updated integration test snapshots to `"1.16"`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.22.4`

- Correlation ID: `8f7e36f0-62f5-4c09-ae05-2d571af97812`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.edited`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
