### PR TITLE
feat: Allow for specifying the "package name" via .cdsrc.json

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -13,7 +13,7 @@ module.exports = class Configuration {
     constructor(csn) {
         const env = cds.env["ord"];
         const authConfig = createAuthConfig();
-        const packageName = this._loadNameFromPackageJson();
+        const packageName = env?.packageName ?? this._loadNameFromPackageJson();
         const eventApplicationNamespace = cds.env?.export?.asyncapi?.applicationNamespace;
         const ordNamespace = env?.namespace || `customer.${packageName.replace(/[^a-zA-Z0-9]/g, "")}`;
 


### PR DESCRIPTION
# Allow Specifying Package Name via `.cdsrc.json`

### New Feature

✨ Added support for overriding the package name through the ORD configuration in `.cdsrc.json`. Previously, the package name was always derived from `package.json`. Now, users can specify a custom `packageName` directly in the `ord` section of their CDS environment configuration, which takes precedence over the automatically loaded value.

### Changes

* `lib/configuration.js`: Updated the `packageName` resolution logic to first check for `env?.packageName` (from the `ord` section in `.cdsrc.json`) before falling back to `_loadNameFromPackageJson()` using the nullish coalescing operator (`??`).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.4`

- Correlation ID: `ceac1168-dfb8-47f3-9be6-e35dbcedfbef`
- Event Trigger: `issue_comment.edited`
</details>
