### PR TITLE
draft: Further refactor template functions

### DIFF
--- a/__tests__/unit/templates.test.js
+++ b/__tests__/unit/templates.test.js
@@ -1,6 +1,6 @@
 const cds = require("@sap/cds");
 
-const { ORD_EXTENSIONS_PREFIX, RESOURCE_VISIBILITY } = require("../../lib/constants");
+const { RESOURCE_VISIBILITY } = require("../../lib/constants");
 const Configuration = require("../../lib/configuration");
 
 describe("templates", () => {
@@ -41,7 +41,7 @@ describe("templates", () => {
             `);
             const model = new Configuration(linkedModel).csn;
             const eventDefinition = model.definitions["MyService.ServiceEvent"];
-            expect(eventDefinition[ORD_EXTENSIONS_PREFIX + "visibility"]).toEqual(RESOURCE_VISIBILITY.private);
+            expect(eventDefinition["@ORD.Extensions.visibility"]).toEqual(RESOURCE_VISIBILITY.private);
         });
 
         it("should propagate visibility internal", () => {
@@ -68,7 +68,7 @@ describe("templates", () => {
             `);
             const model = new Configuration(linkedModel).csn;
             const eventDefinition = model.definitions["MyService.ServiceEvent"];
-            expect(eventDefinition[ORD_EXTENSIONS_PREFIX + "visibility"]).toEqual(RESOURCE_VISIBILITY.internal);
+            expect(eventDefinition["@ORD.Extensions.visibility"]).toEqual(RESOURCE_VISIBILITY.internal);
         });
 
         it("should not propagate if there is no visibility annotation", () => {
@@ -92,7 +92,7 @@ describe("templates", () => {
             `);
             const model = new Configuration(linkedModel).csn;
             const eventDefinition = model.definitions["MyService.ServiceEvent"];
-            expect(eventDefinition[ORD_EXTENSIONS_PREFIX + "visibility"]).toBeUndefined();
+            expect(eventDefinition["@ORD.Extensions.visibility"]).toBeUndefined();
         });
     });
 });

--- a/__tests__/unit/templates/api-resource.test.js
+++ b/__tests__/unit/templates/api-resource.test.js
@@ -10,7 +10,6 @@ const {
     DATA_PRODUCT_TYPE,
     ORD_ACCESS_STRATEGY,
     DATA_PRODUCT_ANNOTATION,
-    MCP_RESOURCE_DEFINITION_TYPE,
     DATA_PRODUCT_SIMPLE_ANNOTATION,
     ENTITY_RELATIONSHIP_ANNOTATION,
     ORD_ODM_ENTITY_NAME_ANNOTATION,
@@ -148,7 +147,7 @@ describe("createAPIResourceTemplate", () => {
         const mcpResource = apiResourceTemplate[0];
         expect(mcpResource.apiProtocol).toBe("mcp");
         expect(mcpResource.resourceDefinitions).toHaveLength(1);
-        expect(mcpResource.resourceDefinitions[0].type).toBe(MCP_RESOURCE_DEFINITION_TYPE);
+        expect(mcpResource.resourceDefinitions[0].type).toBe("sap:mcp-server-card:v0");
         expect(mcpResource.resourceDefinitions[0].mediaType).toBe("application/json");
         expect(mcpResource.resourceDefinitions[0].url).toContain(".mcp.json");
 

--- a/__tests__/unit/templates/package.test.js
+++ b/__tests__/unit/templates/package.test.js
@@ -165,7 +165,7 @@ describe("createPackage", () => {
             const result = createPackage(BASE_CONFIG, {
                 label: "General",
                 visibility: RESOURCE_VISIBILITY.public,
-                productOrdId: "sap:product:MyProduct:",
+                products: ["sap:product:MyProduct:"],
             });
             expect(result.partOfProducts).toEqual(["sap:product:MyProduct:"]);
         });
@@ -175,11 +175,11 @@ describe("createPackage", () => {
             expect(result).not.toHaveProperty("partOfProducts");
         });
 
-        it("omits partOfProducts when productOrdId is an empty string", () => {
+        it("omits partOfProducts when products is an empty array", () => {
             const result = createPackage(BASE_CONFIG, {
                 label: "General",
                 visibility: RESOURCE_VISIBILITY.public,
-                productOrdId: "",
+                products: [],
             });
             expect(result).not.toHaveProperty("partOfProducts");
         });

--- a/lib/auth/authentication.js
+++ b/lib/auth/authentication.js
@@ -23,7 +23,7 @@
  */
 
 const cds = require("@sap/cds");
-const { ORD_ACCESS_STRATEGY, BASIC_AUTH_HEADER_KEY, AUTH_STRINGS, CF_MTLS_HEADERS } = require("../constants");
+const { ORD_ACCESS_STRATEGY, AUTH_STRINGS, CF_MTLS_HEADERS } = require("../constants");
 const Logger = require("../logger");
 const bcrypt = require("bcryptjs");
 const { createCfMtlsConfig, handleCfMtlsAuthentication } = require("./cf-mtls");
@@ -178,7 +178,7 @@ function createAuthConfig() {
  * Authentication strategy handler for Basic authentication
  */
 async function basicAuthStrategy(req, res, authConfig) {
-    const authHeader = req.headers[BASIC_AUTH_HEADER_KEY];
+    const authHeader = req.headers["authorization"];
 
     if (!authHeader) {
         return { success: false, handled: false };

--- a/lib/auth/mtls-endpoint-service.js
+++ b/lib/auth/mtls-endpoint-service.js
@@ -7,8 +7,6 @@
 
 /* global AbortController */ // eslint-disable-line no-redeclare
 
-const { HTTP_CONFIG } = require("../constants");
-
 /**
  * Fetches mTLS certificate information from a single endpoint
  *
@@ -23,9 +21,9 @@ async function fetchMtlsCertInfo(endpoint, timeoutMs) {
 
     try {
         const response = await fetch(endpoint, {
-            method: HTTP_CONFIG.METHOD_GET,
-            headers: { Accept: HTTP_CONFIG.CONTENT_TYPE_JSON },
+            method: "GET",
             signal: controller.signal,
+            headers: { Accept: "application/json" },
         });
 
         clearTimeout(timeoutId);
@@ -62,7 +60,7 @@ async function fetchMtlsCertInfo(endpoint, timeoutMs) {
  * @param {number} [timeoutMs] - Timeout for each request in milliseconds
  * @returns {Promise<{certs: Array<{issuer: string, subject: string}>, rootCaDn: string[]}>}
  */
-async function fetchMtlsTrustedCertsFromEndpoints(endpoints, Logger, timeoutMs = HTTP_CONFIG.MTLS_TIMEOUT_MS) {
+async function fetchMtlsTrustedCertsFromEndpoints(endpoints, Logger, timeoutMs = 10_000) {
     if (!endpoints || endpoints.length === 0) {
         return { certs: [], rootCaDn: [] };
     }

--- a/lib/build.js
+++ b/lib/build.js
@@ -8,7 +8,7 @@ const cliProgress = require("cli-progress");
 const defaults = require("./defaults.js");
 const { ord } = require("./index");
 const registerCompileTargets = require("./common/register-compile-targets");
-const { BUILD_DEFAULT_PATH, ORD_DOCUMENT_FILE_NAME, DOCUMENT_PERSPECTIVES } = require("./constants");
+const { BUILD_DEFAULT_PATH, DOCUMENT_PERSPECTIVES } = require("./constants");
 
 module.exports = class OrdBuildPlugin extends cds.build.Plugin {
     static taskDefaults = { src: cds.env.folders.srv };
@@ -24,7 +24,7 @@ module.exports = class OrdBuildPlugin extends cds.build.Plugin {
             .then((model) => ({ model, document: ord(model) }))
             .then(({ model, document }) =>
                 Promise.all([
-                    this.write(this._postProcess(document)).to(ORD_DOCUMENT_FILE_NAME),
+                    this.write(this._postProcess(document)).to("ord-document.json"),
                     this._generateResourcesFiles(model, [
                         ...(document.apiResources || []),
                         ...(document.eventResources || []),

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -19,6 +19,14 @@ const {
 
 const DEFAULT_ACCESS_STRATEGIES = Object.freeze([ORD_ACCESS_STRATEGY.Open]);
 
+function prune(object) {
+    return Object.fromEntries(
+        Object.entries(object) // remove unused packages
+            .filter(([, value]) => value !== null && value !== undefined) // remove empty fields
+            .filter(([, value]) => typeof value !== "object" || Object.keys(value).length > 0), // remove empty arrays/objects
+    );
+}
+
 function getRFC3339Date() {
     const now = new Date();
     const year = now.getUTCFullYear();
@@ -166,6 +174,7 @@ function resolveAccessStrategies(authConfig, options = {}) {
 }
 
 module.exports = {
+    prune,
     isValidService,
     getRFC3339Date,
     readORDExtensions,

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -7,11 +7,8 @@ const {
     DATA_PRODUCT_ANNOTATION,
     DATA_PRODUCT_TYPE,
     DATA_PRODUCT_SIMPLE_ANNOTATION,
-    ORD_EXTENSIONS_PREFIX,
     RESOURCE_VISIBILITY,
-    ALLOWED_VISIBILITY,
     SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS,
-    EXTERNAL_SERVICE_ANNOTATION,
     EXTERNAL_DP_ORD_ID_ANNOTATION,
     CDS_ELEMENT_KIND,
     ORD_ACCESS_STRATEGY,
@@ -49,7 +46,7 @@ function resolveVisibility(appConfig, service) {
     let defaultVisibility = appConfig.env?.defaultVisibility ?? RESOURCE_VISIBILITY.public;
 
     //check for supported custom visibility value in defaultVisibility variable
-    if (!ALLOWED_VISIBILITY.includes(defaultVisibility)) {
+    if (!Object.values(RESOURCE_VISIBILITY).includes(defaultVisibility)) {
         Logger.warn(
             `Default visibility ${defaultVisibility} is not supported. Using ${RESOURCE_VISIBILITY.public} as fallback`,
         );
@@ -95,7 +92,7 @@ function flattenEntityGraph(current, processed = []) {
     ];
 }
 
-function readORDExtensions(model, prefix = ORD_EXTENSIONS_PREFIX) {
+function readORDExtensions(model, prefix = "@ORD.Extensions.") {
     return Object.entries(model) //
         .filter(([key]) => key.startsWith(prefix))
         .map(([key, value]) => [key.substring(prefix.length), value])
@@ -105,7 +102,7 @@ function readORDExtensions(model, prefix = ORD_EXTENSIONS_PREFIX) {
 function isExternalDataProduct(definition) {
     return !!(
         definition.kind === "service" &&
-        definition[EXTERNAL_SERVICE_ANNOTATION] &&
+        definition["@cds.external"] &&
         definition[DATA_PRODUCT_SIMPLE_ANNOTATION] &&
         definition[EXTERNAL_DP_ORD_ID_ANNOTATION]
     );

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,5 +1,3 @@
-const BASIC_AUTH_HEADER_KEY = "authorization";
-
 const BUILD_DEFAULT_PATH = "gen/ord";
 
 const ORD_ACCESS_STRATEGY = Object.freeze({
@@ -31,8 +29,6 @@ const CDS_ELEMENT_KIND = Object.freeze({
     type: "type",
 });
 
-const CONTENT_MERGE_KEY = "ordId";
-
 const DATA_PRODUCT_ANNOTATION = "@DataIntegration.dataProduct.type";
 
 const DATA_PRODUCT_SIMPLE_ANNOTATION = "@data.product";
@@ -40,8 +36,6 @@ const DATA_PRODUCT_SIMPLE_ANNOTATION = "@data.product";
 const DATA_PRODUCT_TYPE = Object.freeze({
     primary: "primary",
 });
-
-const DESCRIPTION_PREFIX = "Description for ";
 
 const ENTITY_RELATIONSHIP_ANNOTATION = "@EntityRelationship.entityType";
 
@@ -51,13 +45,7 @@ const LEVEL = Object.freeze({
     subEntity: "sub-entity",
 });
 
-const OPENAPI_SERVERS_ANNOTATION = "@OpenAPI.servers";
-
-const ORD_EXTENSIONS_PREFIX = "@ORD.Extensions.";
-
 const ORD_ODM_ENTITY_NAME_ANNOTATION = "@ODM.entityName";
-
-const ORD_EXISTING_PRODUCT_PROPERTY = "existingProductORDId";
 
 const ORD_RESOURCE_TYPE = Object.freeze({
     api: "api",
@@ -67,34 +55,18 @@ const ORD_RESOURCE_TYPE = Object.freeze({
     integrationDependency: "integrationDependency",
 });
 
-const ORD_SERVICE_NAME = "OpenResourceDiscoveryService";
-
-const ORD_DOCUMENT_FILE_NAME = "ord-document.json";
-
 const RESOURCE_VISIBILITY = Object.freeze({
     public: "public",
     internal: "internal",
     private: "private",
 });
 
-const ALLOWED_VISIBILITY = Object.values(RESOURCE_VISIBILITY);
-
-const IMPLEMENTATIONSTANDARD_VERSIONS = Object.freeze({
-    v1: "sap:ord-document-api:v1",
-});
-
-const SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS = Object.values(IMPLEMENTATIONSTANDARD_VERSIONS);
-
-const SHORT_DESCRIPTION_PREFIX = "Short description of ";
+const SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS = Object.freeze(["sap:ord-document-api:v1"]);
 
 const SEM_VERSION_REGEX =
     /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 
-const MCP_RESOURCE_DEFINITION_TYPE = "sap:mcp-server-card:v0";
-
 const EXTERNAL_DP_ORD_ID_ANNOTATION = "@cds.dp.ordId";
-
-const EXTERNAL_SERVICE_ANNOTATION = "@cds.external";
 
 // ORD apiProtocol values
 const ORD_API_PROTOCOL = Object.freeze({
@@ -137,13 +109,6 @@ const CF_MTLS_ERROR_REASON = Object.freeze({
     ROOT_CA_MISMATCH: "ROOT_CA_MISMATCH",
 });
 
-// HTTP Configuration Constants
-const HTTP_CONFIG = Object.freeze({
-    METHOD_GET: "GET",
-    CONTENT_TYPE_JSON: "application/json",
-    MTLS_TIMEOUT_MS: 10000,
-});
-
 // Authentication String Constants
 const AUTH_STRINGS = Object.freeze({
     BASIC_PREFIX: "Basic ",
@@ -158,39 +123,25 @@ const DOCUMENT_PERSPECTIVES = Object.freeze({
 const LOCAL_TENANT_ID_HEADER_KEY = "local-tenant-id";
 
 module.exports = {
-    BASIC_AUTH_HEADER_KEY,
     BUILD_DEFAULT_PATH,
     CAP_TO_ORD_PROTOCOL_MAP,
     CDS_ELEMENT_KIND,
     CF_MTLS_HEADERS,
-    CONTENT_MERGE_KEY,
     DATA_PRODUCT_ANNOTATION,
     DATA_PRODUCT_SIMPLE_ANNOTATION,
     DATA_PRODUCT_TYPE,
-    DESCRIPTION_PREFIX,
     ENTITY_RELATIONSHIP_ANNOTATION,
     EXTERNAL_DP_ORD_ID_ANNOTATION,
-    EXTERNAL_SERVICE_ANNOTATION,
     LEVEL,
-    MCP_RESOURCE_DEFINITION_TYPE,
-    OPENAPI_SERVERS_ANNOTATION,
     ORD_ACCESS_STRATEGY,
     ORD_API_PROTOCOL,
-    ORD_DOCUMENT_FILE_NAME,
-    ORD_EXTENSIONS_PREFIX,
     ORD_ODM_ENTITY_NAME_ANNOTATION,
-    ORD_EXISTING_PRODUCT_PROPERTY,
     ORD_ONLY_PROTOCOLS,
     ORD_RESOURCE_TYPE,
-    ORD_SERVICE_NAME,
     RESOURCE_VISIBILITY,
-    ALLOWED_VISIBILITY,
-    IMPLEMENTATIONSTANDARD_VERSIONS,
     SUPPORTED_IMPLEMENTATIONSTANDARD_VERSIONS,
-    SHORT_DESCRIPTION_PREFIX,
     SEM_VERSION_REGEX,
     CF_MTLS_ERROR_REASON,
-    HTTP_CONFIG,
     AUTH_STRINGS,
     DOCUMENT_PERSPECTIVES,
     LOCAL_TENANT_ID_HEADER_KEY,

--- a/lib/meta-data.js
+++ b/lib/meta-data.js
@@ -7,7 +7,6 @@ const { compile: asyncapi } = require("@cap-js/asyncapi");
 
 const Logger = require("./logger");
 const { interopCSN } = require("./interop-csn.js");
-const { OPENAPI_SERVERS_ANNOTATION } = require("./constants");
 
 const COMPILERS = Object.freeze({
     csn: function (csn, options) {
@@ -26,7 +25,7 @@ const COMPILERS = Object.freeze({
     },
     oas3: function (csn, options) {
         // Check for service-level @OpenAPI.servers annotation
-        const servers = csn?.definitions?.[options.service]?.[OPENAPI_SERVERS_ANNOTATION];
+        const servers = csn?.definitions?.[options.service]?.["@OpenAPI.servers"];
         const openapiOptions = { ...options, ...(cds.env?.ord?.compileOptions?.openapi || {}) };
 
         // Service-level annotation takes precedence over global config

--- a/lib/templates/api-resource.js
+++ b/lib/templates/api-resource.js
@@ -10,13 +10,9 @@ const {
     isEventsOnlyService,
 } = require("../common/utils");
 const {
-    DESCRIPTION_PREFIX,
     ORD_RESOURCE_TYPE,
     RESOURCE_VISIBILITY,
-    SHORT_DESCRIPTION_PREFIX,
     ORD_API_PROTOCOL,
-    MCP_RESOURCE_DEFINITION_TYPE,
-    ORD_EXTENSIONS_PREFIX,
     ORD_ODM_ENTITY_NAME_ANNOTATION,
     ENTITY_RELATIONSHIP_ANNOTATION,
 } = require("../constants");
@@ -31,7 +27,7 @@ function _getExposedEntityTypes(service) {
             .flatMap((entity) => flattenEntityGraph(entity))
             .flatMap((entity) => {
                 const [namespace, name, version = "v1"] = entity[ENTITY_RELATIONSHIP_ANNOTATION]?.split(":") || [];
-                const major = (entity[`${ORD_EXTENSIONS_PREFIX}version`] ?? version.substring(1)).split(".")[0];
+                const major = (entity["@ORD.Extensions.version"] ?? version.substring(1)).split(".")[0];
 
                 return [
                     ...(!entity[ORD_ODM_ENTITY_NAME_ANNOTATION]
@@ -149,7 +145,7 @@ const createAPIResourceTemplate = (srvDefinition, appConfig) => {
             } else if (apiProtocol === ORD_API_PROTOCOL.MCP) {
                 resourceDefinitions = [
                     _getResourceDefinition(
-                        MCP_RESOURCE_DEFINITION_TYPE,
+                        "sap:mcp-server-card:v0",
                         "json",
                         ordId,
                         srvDefinition.name,
@@ -197,8 +193,8 @@ const createAPIResourceTemplate = (srvDefinition, appConfig) => {
                 srvDefinition["@Common.Label"] ??
                 srvDefinition["@EndUserText.label"] ??
                 srvDefinition.name,
-            shortDescription: SHORT_DESCRIPTION_PREFIX + srvDefinition.name,
-            description: srvDefinition["@Core.Description"] ?? DESCRIPTION_PREFIX + srvDefinition.name,
+            shortDescription: `Short description of ${srvDefinition.name}`,
+            description: srvDefinition["@Core.Description"] ?? `Description for ${srvDefinition.name}`,
             version: semanticVersion,
             lastUpdate: appConfig.lastUpdate,
             visibility,

--- a/lib/templates/entity-type.js
+++ b/lib/templates/entity-type.js
@@ -3,13 +3,7 @@ const _ = require("lodash");
 const Logger = require("../logger");
 const { createPackages } = require("./package");
 const { prune, readORDExtensions, isExposedEntityType } = require("../common/utils");
-const {
-    LEVEL,
-    SEM_VERSION_REGEX,
-    RESOURCE_VISIBILITY,
-    ENTITY_RELATIONSHIP_ANNOTATION,
-    CONTENT_MERGE_KEY,
-} = require("../constants");
+const { LEVEL, SEM_VERSION_REGEX, RESOURCE_VISIBILITY, ENTITY_RELATIONSHIP_ANNOTATION } = require("../constants");
 
 const RESOLVERS = Object.freeze({
     ordId: (entity) => {
@@ -117,7 +111,7 @@ function createEntityTypes(appConfig) {
                   .filter((definition) => isExposedEntityType(definition))
                   .map((entity) => createEntityTypeTemplate(appConfig, entity))
                   .filter((entity) => entity.visibility !== RESOURCE_VISIBILITY.private),
-              CONTENT_MERGE_KEY,
+              "ordId",
           );
 }
 

--- a/lib/templates/entity-type.js
+++ b/lib/templates/entity-type.js
@@ -2,7 +2,7 @@ const _ = require("lodash");
 
 const Logger = require("../logger");
 const { createPackages } = require("./package");
-const { readORDExtensions, isExposedEntityType } = require("../common/utils");
+const { prune, readORDExtensions, isExposedEntityType } = require("../common/utils");
 const {
     LEVEL,
     SEM_VERSION_REGEX,
@@ -48,6 +48,21 @@ const RESOLVERS = Object.freeze({
 
         return version;
     },
+    extensible: (entity) => {
+        return readORDExtensions(entity, "@ORD.Extensions.extensible")?.[""] ?? { supported: "no" };
+    },
+    description: (entity) => {
+        return entity["@ORD.Extensions.description"] ?? `Description for ${RESOLVERS.localId(entity)}`;
+    },
+    releaseStatus: (entity) => {
+        return entity["@ORD.Extensions.releaseStatus"] ?? "active";
+    },
+    shortDescription: (entity) => {
+        return entity["@ORD.Extensions.shortDescription"] ?? `Short description of ${RESOLVERS.localId(entity)}`;
+    },
+    lastUpdate: (entity, appConfig) => {
+        return entity["@ORD.Extensions.lastUpdate"] ?? appConfig.lastUpdate;
+    },
     visibility: (entity, appConfig) => {
         return entity["@ORD.Extensions.visibility"] ?? appConfig.env?.defaultVisibility ?? RESOURCE_VISIBILITY.public;
     },
@@ -76,23 +91,22 @@ const RESOLVERS = Object.freeze({
  * @returns { object } An object for the EntityType (see: https://pages.github.tools.sap/CentralEngineering/open-resource-discovery-specification/spec-v1/interfaces/Document#entity-type).
  */
 function createEntityTypeTemplate(appConfig, entity) {
-    return {
-        releaseStatus: "active",
-        extensible: { supported: "no" },
-        lastUpdate: appConfig.lastUpdate,
-
+    return prune({
         ordId: RESOLVERS.ordId(entity),
         title: RESOLVERS.title(entity),
         level: RESOLVERS.level(entity),
         localId: RESOLVERS.localId(entity),
         version: RESOLVERS.version(entity),
+        extensible: RESOLVERS.extensible(entity),
+        description: RESOLVERS.description(entity),
+        releaseStatus: RESOLVERS.releaseStatus(entity),
+        lastUpdate: RESOLVERS.lastUpdate(entity, appConfig),
         visibility: RESOLVERS.visibility(entity, appConfig),
+        shortDescription: RESOLVERS.shortDescription(entity),
         partOfPackage: RESOLVERS.partOfPackage(entity, appConfig),
-        description: `Description for ${RESOLVERS.localId(entity)}`,
-        shortDescription: `Short description of ${RESOLVERS.localId(entity)}`,
 
-        ...readORDExtensions(entity),
-    };
+        ..._.omit(readORDExtensions(entity), Object.keys(RESOLVERS)),
+    });
 }
 
 function createEntityTypes(appConfig) {

--- a/lib/templates/event-resource.js
+++ b/lib/templates/event-resource.js
@@ -10,6 +10,7 @@ const {
     CDS_ELEMENT_KIND,
 } = require("../constants");
 const {
+    prune,
     readORDExtensions,
     resolveVisibility,
     flattenEntityGraph,
@@ -21,6 +22,9 @@ const RESOLVERS = Object.freeze({
     version: (service) => {
         return service["@ORD.Extensions.version"] ?? "1.0.0";
     },
+    extensible: (service) => {
+        return readORDExtensions(service, "@ORD.Extensions.extensible")?.[""] ?? { supported: "no" };
+    },
     description: (service) => {
         return (
             service["@ORD.Extensions.description"] ??
@@ -28,6 +32,9 @@ const RESOLVERS = Object.freeze({
             service["@Core.Description"] ??
             "CAP Event resource describing events / messages."
         );
+    },
+    releaseStatus: (service) => {
+        return service["@ORD.Extensions.releaseStatus"] ?? "active";
     },
     ordId: (service, appConfig) => {
         const namespace = appConfig.ordNamespace;
@@ -45,6 +52,9 @@ const RESOLVERS = Object.freeze({
             `ODM ${appConfig.appName.replace(/[^a-zA-Z0-9]/g, "")} Events`
         );
     },
+    shortDescription: (service) => {
+        return service["@ORD.Extensions.shortDescription"] ?? `${service.name} event resource`;
+    },
     exposedEntityTypes: (service) => {
         const ordIds = new Set(
             Object.values(service.entities ?? {})
@@ -61,7 +71,10 @@ const RESOLVERS = Object.freeze({
                 }),
         );
 
-        return [...ordIds].map((ordId) => ({ ordId: ordId }));
+        return service["@ORD.Extensions.exposedEntityTypes"] ?? [...ordIds].map((ordId) => ({ ordId: ordId }));
+    },
+    lastUpdate: (service, appConfig) => {
+        return service["@ORD.Extensions.lastUpdate"] ?? appConfig.lastUpdate;
     },
     visibility: (service, appConfig) => {
         return resolveVisibility(appConfig, service);
@@ -70,7 +83,7 @@ const RESOLVERS = Object.freeze({
         const namespace = appConfig.ordNamespace;
         const name = resolveServiceName(appConfig, service);
 
-        return [`${defaults.groupTypeId}:${namespace}:${name}`];
+        return service["@ORD.Extensions.partOfGroups"] ?? [`${defaults.groupTypeId}:${namespace}:${name}`];
     },
     partOfPackage: (service, appConfig) => {
         const visibility = RESOLVERS.visibility(service, appConfig);
@@ -91,14 +104,16 @@ const RESOLVERS = Object.freeze({
         const ordId = RESOLVERS.ordId(service, appConfig);
         const accessStrategies = appConfig.accessStrategies;
 
-        return [
-            {
-                type: "asyncapi-v2",
-                mediaType: `application/json`,
-                url: `/ord/v1/${ordId}/${name}.asyncapi2.json`,
-                accessStrategies: accessStrategies,
-            },
-        ];
+        return (
+            service["@ORD.Extensions.resourceDefinitions"] ?? [
+                {
+                    type: "asyncapi-v2",
+                    mediaType: `application/json`,
+                    url: `/ord/v1/${ordId}/${name}.asyncapi2.json`,
+                    accessStrategies: accessStrategies,
+                },
+            ]
+        );
     },
 });
 
@@ -113,27 +128,23 @@ const RESOLVERS = Object.freeze({
  * @returns {object} An object representing the Event Resource.
  */
 function createEventResourceTemplate(service, appConfig) {
-    const exposedEntityTypes = RESOLVERS.exposedEntityTypes(service);
-
-    return {
-        releaseStatus: "active",
-        extensible: { supported: "no" },
-        lastUpdate: appConfig.lastUpdate,
-        shortDescription: `${service.name} event resource`,
-
+    return prune({
         version: RESOLVERS.version(service),
+        extensible: RESOLVERS.extensible(service),
         ordId: RESOLVERS.ordId(service, appConfig),
         title: RESOLVERS.title(service, appConfig),
         description: RESOLVERS.description(service),
+        releaseStatus: RESOLVERS.releaseStatus(service),
+        lastUpdate: RESOLVERS.lastUpdate(service, appConfig),
         visibility: RESOLVERS.visibility(service, appConfig),
+        shortDescription: RESOLVERS.shortDescription(service),
         partOfGroups: RESOLVERS.partOfGroups(service, appConfig),
+        exposedEntityTypes: RESOLVERS.exposedEntityTypes(service),
         partOfPackage: RESOLVERS.partOfPackage(service, appConfig),
         resourceDefinitions: RESOLVERS.resourceDefinitions(service, appConfig),
 
-        ...(exposedEntityTypes.length && { exposedEntityTypes }),
-
-        ...readORDExtensions(service),
-    };
+        ..._.omit(readORDExtensions(service), Object.keys(RESOLVERS)),
+    });
 }
 
 function createEventResources(appConfig) {

--- a/lib/templates/group.js
+++ b/lib/templates/group.js
@@ -1,8 +1,11 @@
 const defaults = require("../defaults");
 const { RESOURCE_VISIBILITY } = require("../constants");
-const { resolveServiceName, isValidService, resolveVisibility } = require("../common/utils");
+const { prune, resolveServiceName, isValidService, resolveVisibility } = require("../common/utils");
 
 const RESOLVERS = Object.freeze({
+    groupTypeId: () => {
+        return defaults.groupTypeId;
+    },
     title: (service) => {
         return (
             service["@ORD.Extensions.title"] ??
@@ -16,7 +19,7 @@ const RESOLVERS = Object.freeze({
         const namespace = appConfig.ordNamespace;
         const name = resolveServiceName(appConfig, service);
 
-        return `${defaults.groupTypeId}:${namespace}:${name}`;
+        return `${RESOLVERS.groupTypeId()}:${namespace}:${name}`;
     },
 });
 
@@ -28,12 +31,11 @@ const RESOLVERS = Object.freeze({
  * @returns {Object} A group object.
  */
 function createGroupsTemplateForService(service, appConfig) {
-    return {
-        groupTypeId: defaults.groupTypeId,
-
+    return prune({
         title: RESOLVERS.title(service),
+        groupTypeId: RESOLVERS.groupTypeId(),
         groupId: RESOLVERS.groupId(service, appConfig),
-    };
+    });
 }
 
 function createGroups(appConfig) {

--- a/lib/templates/integration-dependency.js
+++ b/lib/templates/integration-dependency.js
@@ -1,5 +1,7 @@
+const _ = require("lodash");
+
 const { createPackages } = require("./package");
-const { readORDExtensions, isExternalDataProduct } = require("../common/utils");
+const { prune, readORDExtensions, isExternalDataProduct } = require("../common/utils");
 const { RESOURCE_VISIBILITY, EXTERNAL_DP_ORD_ID_ANNOTATION } = require("../constants");
 
 const RESOLVERS = Object.freeze({
@@ -7,34 +9,46 @@ const RESOLVERS = Object.freeze({
         const namespace = appConfig.ordNamespace;
         const major = RESOLVERS.version(appConfig).split(".")[0];
 
-        return `${namespace}:integrationDependency:externalDependencies:v${major}`;
+        return (
+            appConfig.env?.integrationDependency?.ordId ??
+            `${namespace}:integrationDependency:externalDependencies:v${major}`
+        );
+    },
+    title: (appConfig) => {
+        return appConfig.env?.integrationDependency?.title ?? "External Dependencies";
     },
     version: (appConfig) => {
-        return appConfig.env?.integrationDependency?.version || "1.0.0";
+        return appConfig.env?.integrationDependency?.version ?? "1.0.0";
     },
     aspects: (appConfig) => {
-        return Object.values(appConfig.csn.definitions)
-            .filter((definition) => isExternalDataProduct(definition))
-            .filter((service) => "apiResource" === service[EXTERNAL_DP_ORD_ID_ANNOTATION].split(":")[1])
-            .map((service) => {
-                const version = service[EXTERNAL_DP_ORD_ID_ANNOTATION].split(":")[3] ?? "v1";
+        return (
+            appConfig.env?.integrationDependency?.aspects ??
+            Object.values(appConfig.csn.definitions)
+                .filter((definition) => isExternalDataProduct(definition))
+                .filter((service) => "apiResource" === service[EXTERNAL_DP_ORD_ID_ANNOTATION].split(":")[1])
+                .map((service) => {
+                    const version = service[EXTERNAL_DP_ORD_ID_ANNOTATION].split(":")[3] ?? "v1";
 
-                return {
-                    title: service.name,
-                    mandatory: false,
-                    apiResources: [
-                        {
-                            ordId: service[EXTERNAL_DP_ORD_ID_ANNOTATION],
-                            minVersion: version.replace("v", "") + ".0.0",
-                        },
-                    ],
+                    return {
+                        title: service.name,
+                        mandatory: false,
+                        apiResources: [
+                            {
+                                ordId: service[EXTERNAL_DP_ORD_ID_ANNOTATION],
+                                minVersion: version.replace("v", "") + ".0.0",
+                            },
+                        ],
 
-                    ...readORDExtensions(service), // Allow customization via @ORD.Extensions on the service
-                };
-            });
+                        ...readORDExtensions(service), // Allow customization via @ORD.Extensions on the service
+                    };
+                })
+        );
+    },
+    mandatory: (appConfig) => {
+        return appConfig.env?.integrationDependency?.mandatory ?? false;
     },
     visibility: (appConfig) => {
-        return appConfig.env?.integrationDependency?.visibility || RESOURCE_VISIBILITY.public;
+        return appConfig.env?.integrationDependency?.visibility ?? RESOURCE_VISIBILITY.public;
     },
     partOfPackage: (appConfig) => {
         const visibility = RESOLVERS.visibility(appConfig);
@@ -50,6 +64,9 @@ const RESOLVERS = Object.freeze({
             ].find((candidate) => packages.includes(candidate))
         );
     },
+    releaseStatus: (appConfig) => {
+        return appConfig.env?.integrationDependency?.releaseStatus ?? "active";
+    },
 });
 
 /**
@@ -58,19 +75,18 @@ const RESOLVERS = Object.freeze({
  * @returns {Object} IntegrationDependency object
  */
 function createIntegrationDependency(appConfig) {
-    return {
-        mandatory: false,
-        releaseStatus: "active",
-        title: "External Dependencies",
-
+    return prune({
+        title: RESOLVERS.title(appConfig),
         ordId: RESOLVERS.ordId(appConfig),
         version: RESOLVERS.version(appConfig),
         aspects: RESOLVERS.aspects(appConfig),
+        mandatory: RESOLVERS.mandatory(appConfig),
         visibility: RESOLVERS.visibility(appConfig),
         partOfPackage: RESOLVERS.partOfPackage(appConfig),
+        releaseStatus: RESOLVERS.releaseStatus(appConfig),
 
-        ...(appConfig.env?.integrationDependency ?? {}), // Allow customization via cdsrc
-    };
+        ..._.omit(appConfig.env?.integrationDependency, Object.keys(RESOLVERS)), // Allow customization via .cdsrc.json
+    });
 }
 
 function createIntegrationDependencies(appConfig) {

--- a/lib/templates/package.js
+++ b/lib/templates/package.js
@@ -1,27 +1,61 @@
+const _ = require("lodash");
+
+const { prune } = require("../common/utils");
 const { createProducts } = require("./product");
 const { ORD_RESOURCE_TYPE, RESOURCE_VISIBILITY } = require("../constants");
 
-function createPackage(appConfig, { label, visibility, productOrdId, resourceType }) {
-    const tag = !resourceType ? "" : `-${resourceType}`;
-    const overrides = appConfig?.env?.packages?.[0] ?? {};
-    const name = appConfig.appName.replace(/[^a-zA-Z0-9]/g, " ").trim();
-    const technicalName = appConfig.appName.replace(/[^a-zA-Z0-9]/g, "");
-    const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
+const RESOLVERS = Object.freeze({
+    title: (appConfig) => {
+        return appConfig?.env?.packages?.[0]?.title ?? appConfig.appName.replace(/[^a-zA-Z0-9]/g, " ").trim();
+    },
+    vendor: (appConfig) => {
+        return appConfig?.env?.packages?.[0]?.vendor ?? "customer:vendor:Customer:";
+    },
+    version: (appConfig) => {
+        return appConfig?.env?.packages?.[0]?.version ?? "1.0.0";
+    },
+    partOfProducts: (appConfig, products) => {
+        return appConfig?.env?.packages?.[0]?.partOfProducts ?? products;
+    },
+    description: (appConfig, label, visibility) => {
+        return (
+            appConfig?.env?.packages?.[0]?.description ??
+            `This package contains ${visibility} ${label} for ${RESOLVERS.title(appConfig)}.`
+        );
+    },
+    shortDescription: (appConfig, label, visibility) => {
+        return appConfig?.env?.packages?.[0]?.shortDescription ?? `Package containing ${visibility} ${label}`;
+    },
+    ordId: (appConfig, label, visibility, resourceType) => {
+        const tag = !resourceType ? "" : `-${resourceType}`;
+        const technicalName = appConfig.appName.replace(/[^a-zA-Z0-9]/g, "");
+        const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
 
-    return {
-        title: name,
-        version: "1.0.0",
-        vendor: "customer:vendor:Customer:",
-        shortDescription: `Package containing ${visibility} ${label}`,
-        description: `This package contains ${visibility} ${label} for ${name}.`,
-        ordId: `${appConfig.ordNamespace}:package:${technicalName}${tag}${suffix}:v1`,
-        ...(productOrdId && { partOfProducts: [productOrdId] }),
-        ...overrides,
-    };
+        return (
+            appConfig?.env?.packages?.[0]?.ordId ??
+            `${appConfig.ordNamespace}:package:${technicalName}${tag}${suffix}:v1`
+        );
+    },
+});
+
+function createPackage(appConfig, { label, visibility, products, resourceType }) {
+    return prune({
+        title: RESOLVERS.title(appConfig),
+        vendor: RESOLVERS.vendor(appConfig),
+        version: RESOLVERS.version(appConfig),
+        partOfProducts: RESOLVERS.partOfProducts(appConfig, products),
+        description: RESOLVERS.description(appConfig, label, visibility),
+        ordId: RESOLVERS.ordId(appConfig, label, visibility, resourceType),
+        shortDescription: RESOLVERS.shortDescription(appConfig, label, visibility),
+
+        ..._.omit(appConfig?.env?.packages?.[0], Object.keys(RESOLVERS)),
+    });
 }
 
 function createPackages(appConfig) {
-    const productOrdId = appConfig.existingProductORDId || createProducts(appConfig)?.[0]?.ordId;
+    const products = appConfig.existingProductORDId
+        ? [appConfig.existingProductORDId]
+        : createProducts(appConfig).map((p) => p.ordId);
     const visibilities = !appConfig.hasSAPPolicyLevel
         ? [RESOURCE_VISIBILITY.public]
         : Object.values(RESOURCE_VISIBILITY);
@@ -40,7 +74,7 @@ function createPackages(appConfig) {
             createPackage(appConfig, {
                 label,
                 visibility,
-                productOrdId,
+                products,
                 resourceType,
             }),
         ),
@@ -50,4 +84,5 @@ function createPackages(appConfig) {
 module.exports = {
     createPackages,
     createPackage,
+    RESOLVERS,
 };

--- a/lib/templates/product.js
+++ b/lib/templates/product.js
@@ -1,23 +1,51 @@
+const _ = require("lodash");
+
 const Logger = require("../logger");
+const { prune } = require("../common/utils");
 
-function createProduct(appConfig) {
-    let overrides = appConfig?.env?.products?.[0] ?? {};
-    const name = appConfig.packageName.replace(/[^a-zA-Z0-9]/g, " ").trim();
+const RESOLVERS = Object.freeze({
+    ordId: (appConfig, overrides) => {
+        const name = appConfig.packageName
+            .split(/[^a-zA-Z0-9]/)
+            .filter(Boolean)
+            .join(".");
 
-    if (overrides?.ordId?.toLowerCase().startsWith("sap")) {
-        overrides = {}; // disable overrides, misconfiguration detected
+        return overrides?.ordId ?? `customer:product:${name}:`;
+    },
+    title: (appConfig, overrides) => {
+        return overrides?.title ?? appConfig.packageName.replace(/[^a-zA-Z0-9]/g, " ").trim();
+    },
+    vendor: (appConfig, overrides) => {
+        return overrides?.vendor ?? "customer:vendor:Customer:";
+    },
+    shortDescription: (appConfig, overrides) => {
+        return overrides?.shortDescription ?? `Short description of ${RESOLVERS.title(appConfig, overrides)}`;
+    },
+});
+
+function extractOverrides(appConfig) {
+    if (appConfig?.env?.products?.[0]?.ordId?.toLowerCase().startsWith("sap")) {
         Logger.error(
             "Detected sap product ordId, which should not be defined for custom products, use default value instead. Please check ORD global registry.",
         );
+
+        return {}; // disable overrides, misconfiguration detected
     }
 
-    return {
-        title: name,
-        vendor: "customer:vendor:Customer:",
-        shortDescription: `Short description of ${name}`,
-        ordId: `customer:product:${name.split(" ").join(".")}:`,
-        ...overrides,
-    };
+    return appConfig?.env?.products?.[0] ?? {};
+}
+
+function createProduct(appConfig) {
+    const overrides = extractOverrides(appConfig);
+
+    return prune({
+        ordId: RESOLVERS.ordId(appConfig, overrides),
+        title: RESOLVERS.title(appConfig, overrides),
+        vendor: RESOLVERS.vendor(appConfig, overrides),
+        shortDescription: RESOLVERS.shortDescription(appConfig, overrides),
+
+        ..._.omit(overrides, Object.keys(RESOLVERS)),
+    });
 }
 
 function createProducts(appConfig) {
@@ -27,4 +55,5 @@ function createProducts(appConfig) {
 module.exports = {
     createProducts,
     createProduct,
+    RESOLVERS,
 };


### PR DESCRIPTION
# Refactor Template Functions with RESOLVERS Pattern and `prune` Utility

♻️ **Refactor**: Standardizes all ORD template modules to use a consistent `RESOLVERS` pattern and a new `prune` utility, improving extensibility and reducing hardcoded defaults.

### Changes

* `lib/common/utils.js`: Introduced a `prune` helper function that strips `null`, `undefined`, and empty object/array fields from objects. Exported for use across template modules.

* `lib/templates/package.js`: Replaced the inline `createPackage` function with a structured `RESOLVERS` object for all fields (`title`, `vendor`, `version`, `ordId`, `description`, `shortDescription`, `partOfProducts`). Switched `productOrdId` (single value) to `products` (array). Uses `prune` and `_.omit` to prevent RESOLVER keys from being double-applied via env overrides. Exports `RESOLVERS`.

* `lib/templates/product.js`: Extracted a `RESOLVERS` object and an `extractOverrides` helper. Replaced inline object construction with `prune` + `_.omit` pattern. Exports `RESOLVERS`.

* `lib/templates/entity-type.js`: Added new resolvers (`extensible`, `description`, `releaseStatus`, `shortDescription`, `lastUpdate`) to `RESOLVERS`. Template now uses `prune({...})` and `_.omit(readORDExtensions(...), Object.keys(RESOLVERS))` to avoid override conflicts.

* `lib/templates/event-resource.js`: Added resolvers for `extensible`, `releaseStatus`, `shortDescription`, `lastUpdate`, `exposedEntityTypes`, `partOfGroups`, and `resourceDefinitions`. Template switched to `prune` and `_.omit` pattern. `exposedEntityTypes` and `partOfGroups` now support `@ORD.Extensions` overrides.

* `lib/templates/group.js`: Added `groupTypeId` to `RESOLVERS`. Template converted to use `prune`.

* `lib/templates/integration-dependency.js`: Added `title`, `mandatory`, `releaseStatus` resolvers; `aspects`, `ordId`, and `visibility` now support env-based overrides with `??` (replacing `||`). Template uses `prune` and `_.omit`. Added `lodash` import.

* `__tests__/unit/templates/package.test.js`: Updated tests to use `products` array instead of `productOrdId` string, and updated test description to reflect the change.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.4`

- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `89200bf7-1b59-4ac8-83fc-a3fc13796825`
- Event Trigger: `pull_request.opened`
</details>
