### PR TITLE
chore: Extract resource definitions generation logic to a dispatch table

### DIFF
--- a/__tests__/unit/templates/api-resource.test.js
+++ b/__tests__/unit/templates/api-resource.test.js
@@ -108,8 +108,7 @@ describe("createAPIResourceTemplate", () => {
                 };
             `);
 
-        const srvDefinition = model.definitions["customer.testNamespace.MyService"];
-        expect(createAPIResourceTemplate(srvDefinition, appConfig)).toEqual([]);
+        expect(createAPIResources({ ...appConfig, csn: model })).toEqual([]);
     });
 
     it("should create correct resource definition for MCP protocol", () => {
@@ -179,9 +178,7 @@ describe("createAPIResourceTemplate", () => {
                     }
                 };
             `);
-        const srvDefinition = linkedModel.definitions["MyService"];
-        appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
-        const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig);
+        const apiResourceTemplate = createAPIResources({ ...appConfig, csn: linkedModel });
 
         expect(apiResourceTemplate).toBeInstanceOf(Array);
         expect(apiResourceTemplate).toMatchSnapshot();
@@ -210,7 +207,6 @@ describe("createAPIResourceTemplate", () => {
                 };
             `);
         const srvDefinition = linkedModel.definitions["MyService"];
-        appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
         const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig);
 
         expect(apiResourceTemplate).toBeInstanceOf(Array);
@@ -240,9 +236,7 @@ describe("createAPIResourceTemplate", () => {
                     }
                 };
             `);
-        const srvDefinition = linkedModel.definitions["MyService"];
-        appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
-        const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig);
+        const apiResourceTemplate = createAPIResources({ ...appConfig, csn: linkedModel });
 
         expect(apiResourceTemplate).toBeInstanceOf(Array);
         expect(apiResourceTemplate).toMatchSnapshot();
@@ -282,7 +276,6 @@ describe("createAPIResourceTemplate", () => {
                 };
             `);
         const srvDefinition = linkedModel.definitions["MyService"];
-        appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
         const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig);
 
         expect(apiResourceTemplate).toMatchSnapshot();
@@ -321,7 +314,6 @@ describe("createAPIResourceTemplate", () => {
                 };
             `);
         const srvDefinition = linkedModel.definitions["MyService"];
-        appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
         const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig);
 
         expect(apiResourceTemplate).toMatchSnapshot();
@@ -360,7 +352,6 @@ describe("createAPIResourceTemplate", () => {
                 };
             `);
         const srvDefinition = linkedModel.definitions["MyService"];
-        appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
         const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig);
 
         expect(apiResourceTemplate).toMatchSnapshot();
@@ -407,7 +398,6 @@ describe("createAPIResourceTemplate", () => {
                 };
             `);
         const srvDefinition = linkedModel.definitions["MyService"];
-        appConfig["entityTypeTargets"] = [{ ordId: "sap.odm:entityType:test:v1" }];
         const apiResourceTemplate = createAPIResourceTemplate(srvDefinition, appConfig);
 
         expect(apiResourceTemplate).toMatchSnapshot();

--- a/lib/templates/api-resource.js
+++ b/lib/templates/api-resource.js
@@ -67,7 +67,7 @@ const RESOURCE_DEFINITION_PROVIDERS = Object.freeze({
         ];
     },
     [ORD_API_PROTOCOL.ODATA_V4]: (service, ordId, accessStrategies) => {
-        // openapi-v3 is not supported for OData V2, only EDMX
+        // OData V4 supports both openapi-v3 and EDMX
         return [
             {
                 type: "openapi-v3",

--- a/lib/templates/api-resource.js
+++ b/lib/templates/api-resource.js
@@ -123,6 +123,49 @@ function _getExposedEntityTypes(service) {
 }
 
 /**
+ * Extracts version suffix from service name for data product services.
+ * Only accepts pattern: .v<number> (e.g., .v0, .v1, .v2, .v10)
+ * Rejects patterns like: .v1.1, .v1.0, .version1, .beta
+ *
+ * @param {string} serviceName The full service name
+ * @returns {Object|null} Object with cleanName, version, and semanticVersion, or null if invalid pattern
+ */
+function _extractVersionFromServiceName(serviceName) {
+    // Only match pattern: .v<number> (where number is 1 or more digits)
+    const versionPattern = /\.v(\d+)$/;
+    const match = serviceName.match(versionPattern);
+
+    if (!match) {
+        return null; // No valid version suffix found
+    }
+
+    const versionNumber = parseInt(match[1], 10);
+
+    return {
+        cleanName: serviceName.replace(versionPattern, ""),
+        semanticVersion: `${versionNumber}.0.0`,
+    };
+}
+
+function _getPackageID(namespace, packageIds, resourceType, visibility = RESOURCE_VISIBILITY.public) {
+    if (!packageIds) return;
+
+    if (resourceType) {
+        return (
+            packageIds.find((id) => {
+                if (visibility === RESOURCE_VISIBILITY.public) {
+                    return id.includes(resourceType) && !id.includes("-internal") && !id.includes("-private");
+                } else {
+                    return id.includes(`${resourceType}-${visibility}`);
+                }
+            }) || packageIds.find((id) => id.includes(namespace))
+        );
+    }
+
+    return packageIds.find((id) => id.includes(`-${resourceType}-`)) || packageIds.find((id) => id.includes(namespace));
+}
+
+/**
  * This is a template function to create API Resource object for API Resource Array.
  * Properties of an API resource can be overwritten by the ORD extensions. Example: visibility.
  * Ensures proper visibility compliance by checking associated EntityTypes.
@@ -218,49 +261,6 @@ const createAPIResourceTemplate = (srvDefinition, appConfig) => {
 
     return apiResources;
 };
-
-/**
- * Extracts version suffix from service name for data product services.
- * Only accepts pattern: .v<number> (e.g., .v0, .v1, .v2, .v10)
- * Rejects patterns like: .v1.1, .v1.0, .version1, .beta
- *
- * @param {string} serviceName The full service name
- * @returns {Object|null} Object with cleanName, version, and semanticVersion, or null if invalid pattern
- */
-function _extractVersionFromServiceName(serviceName) {
-    // Only match pattern: .v<number> (where number is 1 or more digits)
-    const versionPattern = /\.v(\d+)$/;
-    const match = serviceName.match(versionPattern);
-
-    if (!match) {
-        return null; // No valid version suffix found
-    }
-
-    const versionNumber = parseInt(match[1], 10);
-
-    return {
-        cleanName: serviceName.replace(versionPattern, ""),
-        semanticVersion: `${versionNumber}.0.0`,
-    };
-}
-
-function _getPackageID(namespace, packageIds, resourceType, visibility = RESOURCE_VISIBILITY.public) {
-    if (!packageIds) return;
-
-    if (resourceType) {
-        return (
-            packageIds.find((id) => {
-                if (visibility === RESOURCE_VISIBILITY.public) {
-                    return id.includes(resourceType) && !id.includes("-internal") && !id.includes("-private");
-                } else {
-                    return id.includes(`${resourceType}-${visibility}`);
-                }
-            }) || packageIds.find((id) => id.includes(namespace))
-        );
-    }
-
-    return packageIds.find((id) => id.includes(`-${resourceType}-`)) || packageIds.find((id) => id.includes(namespace));
-}
 
 function createAPIResources(appConfig) {
     return Object.values(appConfig.csn.definitions)

--- a/lib/templates/api-resource.js
+++ b/lib/templates/api-resource.js
@@ -4,10 +4,10 @@ const { createPackages } = require("./package");
 const { resolveApiResourceProtocol } = require("../protocol-resolver");
 const { resolveVisibility, resolveServiceName, flattenEntityGraph } = require("../common/utils");
 const {
-    readORDExtensions,
-    isPrimaryDataProductService,
     isValidService,
+    readORDExtensions,
     isEventsOnlyService,
+    isPrimaryDataProductService,
 } = require("../common/utils");
 const {
     DESCRIPTION_PREFIX,
@@ -20,6 +20,81 @@ const {
     ORD_ODM_ENTITY_NAME_ANNOTATION,
     ENTITY_RELATIONSHIP_ANNOTATION,
 } = require("../constants");
+
+const RESOURCE_DEFINITION_PROVIDERS = Object.freeze({
+    [ORD_API_PROTOCOL.SAP_INA]: () => [],
+    [ORD_API_PROTOCOL.MCP]: (service, ordId, accessStrategies) => {
+        return [
+            {
+                mediaType: `application/json`,
+                type: MCP_RESOURCE_DEFINITION_TYPE,
+                accessStrategies: accessStrategies,
+                url: `/ord/v1/${ordId}/${service.name}.mcp.json`,
+            },
+        ];
+    },
+    [ORD_API_PROTOCOL.REST]: (service, ordId, accessStrategies) => {
+        // REST only has OpenAPI, no EDMX
+        return [
+            {
+                type: "openapi-v3",
+                mediaType: `application/json`,
+                accessStrategies: accessStrategies,
+                url: `/ord/v1/${ordId}/${service.name}.oas3.json`,
+            },
+        ];
+    },
+    [ORD_API_PROTOCOL.GRAPHQL]: (service, ordId, accessStrategies) => {
+        // GraphQL only has GraphQL SDL
+        return [
+            {
+                type: "graphql-sdl",
+                mediaType: "text/plain",
+                accessStrategies: accessStrategies,
+                url: `/ord/v1/${ordId}/${service.name}.graphql`,
+            },
+        ];
+    },
+    [ORD_API_PROTOCOL.ODATA_V2]: (service, ordId, accessStrategies) => {
+        // openapi-v3 is not supported for OData V2, only EDMX
+        return [
+            {
+                type: "edmx",
+                mediaType: "application/xml",
+                accessStrategies: accessStrategies,
+                url: `/ord/v1/${ordId}/${service.name}.edmx`,
+            },
+        ];
+    },
+    [ORD_API_PROTOCOL.ODATA_V4]: (service, ordId, accessStrategies) => {
+        // openapi-v3 is not supported for OData V2, only EDMX
+        return [
+            {
+                type: "openapi-v3",
+                mediaType: "application/json",
+                accessStrategies: accessStrategies,
+                url: `/ord/v1/${ordId}/${service.name}.oas3.json`,
+            },
+            {
+                type: "edmx",
+                mediaType: "application/xml",
+                accessStrategies: accessStrategies,
+                url: `/ord/v1/${ordId}/${service.name}.edmx`,
+            },
+        ];
+    },
+    [ORD_API_PROTOCOL.SAP_DATA_SUBSCRIPTION]: (service, ordId, accessStrategies) => {
+        // Data product services use CSN
+        return [
+            {
+                mediaType: `application/json`,
+                accessStrategies: accessStrategies,
+                type: "sap-csn-interop-effective-v1",
+                url: `/ord/v1/${ordId}/${service.name}.csn.json`,
+            },
+        ];
+    },
+});
 
 function _getGroupID(appConfig, srvDefinition) {
     return `${defaults.groupTypeId}:${appConfig.ordNamespace}:${resolveServiceName(appConfig, srvDefinition)}`;
@@ -48,29 +123,6 @@ function _getExposedEntityTypes(service) {
 }
 
 /**
- * Pure template function for creating ORD resource definitions.
- * This function does not make assumptions about access strategies - they must be provided explicitly.
- * Access strategies are validated and will fallback to 'open' in non-strict mode if missing.
- *
- * @param {string} resourceType The type of the resource.
- * @param {string} mediaType The media type of the resource.
- * @param {string} ordId The ordId of the resource.
- * @param {string} serviceName The name of the service.
- * @param {string} fileExtension The file extension of the resource.
- * @param {Array<{type: string}>} accessStrategies The array of accessStrategies objects (required, no default)
- * @returns {Object} A resource definition object.
- * @private
- */
-function _getResourceDefinition(resourceType, mediaType, ordId, serviceName, fileExtension, accessStrategies) {
-    return {
-        type: resourceType,
-        mediaType: `application/${mediaType}`,
-        url: `/ord/v1/${ordId}/${serviceName}.${fileExtension}`,
-        accessStrategies: accessStrategies,
-    };
-}
-
-/**
  * This is a template function to create API Resource object for API Resource Array.
  * Properties of an API resource can be overwritten by the ORD extensions. Example: visibility.
  * Ensures proper visibility compliance by checking associated EntityTypes.
@@ -79,13 +131,13 @@ function _getResourceDefinition(resourceType, mediaType, ordId, serviceName, fil
  * @returns {Array} An array of objects for the API Resources.
  */
 const createAPIResourceTemplate = (srvDefinition, appConfig) => {
+    const apiResources = [];
+    const accessStrategies = appConfig.accessStrategies;
     const ordExtensions = readORDExtensions(srvDefinition);
     const visibility = resolveVisibility(appConfig, srvDefinition);
     const packageIds = createPackages(appConfig)?.map((pkg) => pkg.ordId) || [];
     const packageId = _getPackageID(appConfig.ordNamespace, packageIds, ORD_RESOURCE_TYPE.api, visibility);
     const protocolResults = resolveApiResourceProtocol(srvDefinition);
-    const apiResources = [];
-    const accessStrategies = appConfig.accessStrategies;
 
     // If no protocols were generated, skip this service
     if (protocolResults.length === 0) {
@@ -120,73 +172,9 @@ const createAPIResourceTemplate = (srvDefinition, appConfig) => {
             `${appConfig.ordNamespace}:apiResource:${cleanServiceName}${index === 0 ? "" : `-${apiProtocol}`}:${version}`;
 
         // Build resource definitions based on protocol
-        let resourceDefinitions = [];
-        if (hasResourceDefinitions) {
-            if (apiProtocol === ORD_API_PROTOCOL.SAP_DATA_SUBSCRIPTION) {
-                // Data product services use CSN
-                resourceDefinitions = [
-                    _getResourceDefinition(
-                        "sap-csn-interop-effective-v1",
-                        "json",
-                        ordId,
-                        srvDefinition.name,
-                        "csn.json",
-                        accessStrategies,
-                    ),
-                ];
-            } else if (apiProtocol === ORD_API_PROTOCOL.REST) {
-                // REST only has OpenAPI, no EDMX
-                resourceDefinitions = [
-                    _getResourceDefinition(
-                        "openapi-v3",
-                        "json",
-                        ordId,
-                        srvDefinition.name,
-                        "oas3.json",
-                        accessStrategies,
-                    ),
-                ];
-            } else if (apiProtocol === ORD_API_PROTOCOL.MCP) {
-                resourceDefinitions = [
-                    _getResourceDefinition(
-                        MCP_RESOURCE_DEFINITION_TYPE,
-                        "json",
-                        ordId,
-                        srvDefinition.name,
-                        "mcp.json",
-                        accessStrategies,
-                    ),
-                ];
-            } else if (apiProtocol === ORD_API_PROTOCOL.GRAPHQL) {
-                // GraphQL only has GraphQL SDL
-                resourceDefinitions = [
-                    {
-                        type: "graphql-sdl",
-                        mediaType: "text/plain",
-                        url: `/ord/v1/${ordId}/${srvDefinition.name}.graphql`,
-                        accessStrategies: accessStrategies,
-                    },
-                ];
-            } else if (apiProtocol === ORD_API_PROTOCOL.ODATA_V2) {
-                // openapi-v3 is not supported for OData V2, only EDMX
-                resourceDefinitions = [
-                    _getResourceDefinition("edmx", "xml", ordId, srvDefinition.name, "edmx", accessStrategies),
-                ];
-            } else {
-                // odata-v4 and others have both OpenAPI and EDMX
-                resourceDefinitions = [
-                    _getResourceDefinition(
-                        "openapi-v3",
-                        "json",
-                        ordId,
-                        srvDefinition.name,
-                        "oas3.json",
-                        accessStrategies,
-                    ),
-                    _getResourceDefinition("edmx", "xml", ordId, srvDefinition.name, "edmx", accessStrategies),
-                ];
-            }
-        }
+        const resourceDefinitions = !hasResourceDefinitions
+            ? []
+            : RESOURCE_DEFINITION_PROVIDERS[apiProtocol](srvDefinition, ordId, accessStrategies);
 
         const exposedEntityTypes = _getExposedEntityTypes(srvDefinition);
 
@@ -225,9 +213,7 @@ const createAPIResourceTemplate = (srvDefinition, appConfig) => {
             }
         }
 
-        if (obj.visibility !== RESOURCE_VISIBILITY.private) {
-            apiResources.push(obj);
-        }
+        apiResources.push(obj);
     });
 
     return apiResources;
@@ -279,7 +265,8 @@ function _getPackageID(namespace, packageIds, resourceType, visibility = RESOURC
 function createAPIResources(appConfig) {
     return Object.values(appConfig.csn.definitions)
         .filter((definition) => isValidService(definition) && !isEventsOnlyService(definition))
-        .flatMap((service) => createAPIResourceTemplate(service, appConfig));
+        .flatMap((service) => createAPIResourceTemplate(service, appConfig))
+        .filter((ar) => ar.visibility !== RESOURCE_VISIBILITY.private);
 }
 
 module.exports = {


### PR DESCRIPTION
# Refactor: Extract Resource Definitions Generation Logic to a Dispatch Table

### Refactor

♻️ Replaced a long chain of `if/else` conditionals in the API resource template generation with a `RESOURCE_DEFINITION_PROVIDERS` dispatch table, making the code more maintainable and easier to extend with new protocols.

Additionally, the private visibility filter was moved from `createAPIResourceTemplate` to `createAPIResources`, centralizing the filtering logic at the aggregation level.

### Changes

* `lib/templates/api-resource.js`:
  - Introduced a frozen `RESOURCE_DEFINITION_PROVIDERS` dispatch table mapping each `ORD_API_PROTOCOL` to its corresponding resource definition builder function.
  - Replaced the `_getResourceDefinition` helper and the multi-branch `if/else` block with a single dispatch call: `RESOURCE_DEFINITION_PROVIDERS[apiProtocol](srvDefinition, ordId, accessStrategies)`.
  - Moved the `visibility !== private` filter from `createAPIResourceTemplate` to `createAPIResources`, so individual template creation no longer needs to be aware of visibility filtering.
  - Reordered `readORDExtensions` and `isPrimaryDataProductService` imports (cosmetic cleanup).

* `__tests__/unit/templates/api-resource.test.js`:
  - Updated several test cases to call `createAPIResources({ ...appConfig, csn: model })` instead of manually extracting `srvDefinition` and passing it to `createAPIResourceTemplate`, aligning with the updated filtering behavior.
  - Removed inline `appConfig["entityTypeTargets"]` overrides from several tests where they were no longer needed.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.22.0`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `dd0fa9b1-74a6-4ca9-848e-1bcd3599aa62`
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
