### PR TITLE
chore: Refactor 'lib/templates/product.js' to use resolvers

### DIFF
--- a/__tests__/unit/templates/product.test.js
+++ b/__tests__/unit/templates/product.test.js
@@ -1,10 +1,279 @@
 const Logger = require("../../../lib/logger");
-const { createProducts, createProduct } = require("../../../lib/templates/product");
+const { createProducts, createProduct, RESOLVERS } = require("../../../lib/templates/product");
 
-const BASE_CONFIG = {
-    packageName: "MyPackage",
-    ordNamespace: "sap.test",
-};
+describe("RESOLVERS", () => {
+    describe("ordId", () => {
+        it("returns default ordId derived from packageName when no override", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                {},
+            );
+
+            expect(result).toBe("customer:product:MyPackage:");
+        });
+
+        it("joins segments with dots, splitting on any non-alphanumeric character", () => {
+            const result = RESOLVERS.ordId({ ordNamespace: "sap.test", packageName: "my-app name" }, {});
+
+            expect(result).toBe("customer:product:my.app.name:");
+        });
+
+        it("drops leading/trailing separators from packageName", () => {
+            const result = RESOLVERS.ordId({ ordNamespace: "sap.test", packageName: "-MyPackage-" }, {});
+
+            expect(result).toBe("customer:product:MyPackage:");
+        });
+
+        it("uses override ordId verbatim when provided", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { ordId: "customer:product:Custom:" },
+            );
+
+            expect(result).toBe("customer:product:Custom:");
+        });
+
+        it("replaces {namespace} placeholder in override ordId", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { ordId: "{namespace}:product:A:" },
+            );
+
+            expect(result).toBe("sap.test:product:A:");
+        });
+
+        it("replaces {type} placeholder in override ordId", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { ordId: "customer:{type}:A:" },
+            );
+
+            expect(result).toBe("customer:product:A:");
+        });
+
+        it("replaces both {namespace} and {type} placeholders in override ordId", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { ordId: "{namespace}:{type}:A:" },
+            );
+
+            expect(result).toBe("sap.test:product:A:");
+        });
+
+        it("falls back to default when override ordId is undefined", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { ordId: undefined },
+            );
+
+            expect(result).toBe("customer:product:MyPackage:");
+        });
+
+        it("falls back to default when overrides is undefined", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                undefined,
+            );
+
+            expect(result).toBe("customer:product:MyPackage:");
+        });
+    });
+
+    describe("title", () => {
+        it("returns packageName with non-alphanumeric chars replaced by spaces", () => {
+            const result = RESOLVERS.title(
+                {
+                    packageName: "my-app.name",
+                    ordNamespace: "sap.test",
+                },
+                {},
+            );
+
+            expect(result).toBe("my app name");
+        });
+
+        it("trims leading/trailing spaces produced by replacement", () => {
+            const result = RESOLVERS.title(
+                {
+                    packageName: "-MyPackage-",
+                    ordNamespace: "sap.test",
+                },
+                {},
+            );
+
+            expect(result).toBe("MyPackage");
+        });
+
+        it("uses override title verbatim when provided", () => {
+            const result = RESOLVERS.title(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { title: "Custom Title" },
+            );
+
+            expect(result).toBe("Custom Title");
+        });
+
+        it("falls back to derived title when override title is undefined", () => {
+            const result = RESOLVERS.title(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { title: undefined },
+            );
+
+            expect(result).toBe("MyPackage");
+        });
+
+        it("falls back to derived title when overrides is undefined", () => {
+            const result = RESOLVERS.title(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                undefined,
+            );
+
+            expect(result).toBe("MyPackage");
+        });
+    });
+
+    describe("vendor", () => {
+        it("returns default vendor when no override", () => {
+            const result = RESOLVERS.vendor(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                {},
+            );
+
+            expect(result).toBe("customer:vendor:Customer:");
+        });
+
+        it("uses override vendor verbatim when provided", () => {
+            const result = RESOLVERS.vendor(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { vendor: "sap:vendor:SAP:" },
+            );
+
+            expect(result).toBe("sap:vendor:SAP:");
+        });
+
+        it("falls back to default when override vendor is undefined", () => {
+            const result = RESOLVERS.vendor(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { vendor: undefined },
+            );
+
+            expect(result).toBe("customer:vendor:Customer:");
+        });
+
+        it("falls back to default when overrides is undefined", () => {
+            const result = RESOLVERS.vendor(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                undefined,
+            );
+
+            expect(result).toBe("customer:vendor:Customer:");
+        });
+    });
+
+    describe("shortDescription", () => {
+        it("returns a sentence containing the resolved title when no override", () => {
+            const result = RESOLVERS.shortDescription(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                {},
+            );
+
+            expect(result).toBe("Short description of MyPackage");
+        });
+
+        it("incorporates the override title into the default short description", () => {
+            const result = RESOLVERS.shortDescription(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { title: "My App" },
+            );
+
+            expect(result).toBe("Short description of My App");
+        });
+
+        it("uses override shortDescription verbatim when provided", () => {
+            const result = RESOLVERS.shortDescription(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { shortDescription: "Custom desc" },
+            );
+
+            expect(result).toBe("Custom desc");
+        });
+
+        it("falls back to derived short description when override shortDescription is undefined", () => {
+            const result = RESOLVERS.shortDescription(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                { shortDescription: undefined },
+            );
+
+            expect(result).toBe("Short description of MyPackage");
+        });
+
+        it("falls back to derived short description when overrides is undefined", () => {
+            const result = RESOLVERS.shortDescription(
+                {
+                    packageName: "MyPackage",
+                    ordNamespace: "sap.test",
+                },
+                undefined,
+            );
+
+            expect(result).toBe("Short description of MyPackage");
+        });
+    });
+});
 
 describe("createProduct", () => {
     let errorSpy;
@@ -17,7 +286,8 @@ describe("createProduct", () => {
     });
 
     it("produces a complete product object with defaults", () => {
-        const result = createProduct(BASE_CONFIG);
+        const result = createProduct({ packageName: "MyPackage", ordNamespace: "sap.test" });
+
         expect(result).toEqual({
             title: "MyPackage",
             vendor: "customer:vendor:Customer:",
@@ -27,54 +297,70 @@ describe("createProduct", () => {
     });
 
     it("converts non-alphanumeric characters in packageName to spaces for title", () => {
-        const result = createProduct({ ...BASE_CONFIG, packageName: "my-package.name" });
+        const result = createProduct({
+            ordNamespace: "sap.test",
+            packageName: "my-package.name",
+        });
+
         expect(result.title).toBe("my package name");
     });
 
     it("joins title words with dots for the ordId", () => {
-        const result = createProduct({ ...BASE_CONFIG, packageName: "my-package name" });
+        const result = createProduct({
+            ordNamespace: "sap.test",
+            packageName: "my-package name",
+        });
+
         expect(result.ordId).toBe("customer:product:my.package.name:");
     });
 
     it("trims leading/trailing non-alphanumeric characters from the name", () => {
-        const result = createProduct({ ...BASE_CONFIG, packageName: "-MyPackage-" });
+        const result = createProduct({
+            ordNamespace: "sap.test",
+            packageName: "-MyPackage-",
+        });
+
         expect(result.title).toBe("MyPackage");
         expect(result.ordId).toBe("customer:product:MyPackage:");
     });
 
     describe("env.products overrides", () => {
         it("merges env.products[0] onto the result", () => {
-            const appConfig = {
-                ...BASE_CONFIG,
+            const result = createProduct({
+                packageName: "MyPackage",
+                ordNamespace: "sap.test",
                 env: { products: [{ vendor: "sap:vendor:SAP:", shortDescription: "Custom desc" }] },
-            };
-            const result = createProduct(appConfig);
+            });
+
             expect(result.vendor).toBe("sap:vendor:SAP:");
             expect(result.shortDescription).toBe("Custom desc");
         });
 
         it("override can replace the ordId", () => {
-            const appConfig = {
-                ...BASE_CONFIG,
+            const result = createProduct({
+                packageName: "MyPackage",
+                ordNamespace: "sap.test",
                 env: { products: [{ ordId: "customer:product:CustomProduct:" }] },
-            };
-            const result = createProduct(appConfig);
+            });
+
             expect(result.ordId).toBe("customer:product:CustomProduct:");
         });
 
         it("ignores overrides and logs an error when ordId starts with 'sap' (case-insensitive)", () => {
-            const appConfig = {
-                ...BASE_CONFIG,
+            const result = createProduct({
+                packageName: "MyPackage",
+                ordNamespace: "sap.test",
                 env: { products: [{ ordId: "SAP:product:SomeProduct:", vendor: "sap:vendor:SAP:" }] },
-            };
-            const result = createProduct(appConfig);
+            });
+
             expect(errorSpy).toHaveBeenCalledTimes(1);
             expect(result.ordId).toBe("customer:product:MyPackage:");
             expect(result.vendor).toBe("customer:vendor:Customer:");
         });
 
         it("does not apply overrides when env.products is absent", () => {
-            const result = createProduct(BASE_CONFIG);
+            const result = createProduct({ packageName: "MyPackage", ordNamespace: "sap.test" });
+
             expect(result.vendor).toBe("customer:vendor:Customer:");
         });
     });
@@ -91,46 +377,56 @@ describe("createProducts", () => {
     });
 
     it("returns an array with one product when existingProductORDId is not set", () => {
-        const result = createProducts(BASE_CONFIG);
+        const result = createProducts({ packageName: "MyPackage", ordNamespace: "sap.test" });
+
         expect(result).toHaveLength(1);
         expect(result[0].ordId).toBe("customer:product:MyPackage:");
     });
 
     it("returns an empty array when existingProductORDId is set", () => {
-        const appConfig = { ...BASE_CONFIG, existingProductORDId: "sap:product:SAPServiceCloudV2:" };
-        expect(createProducts(appConfig)).toEqual([]);
+        const result = createProducts({
+            packageName: "MyPackage",
+            ordNamespace: "sap.test",
+            existingProductORDId: "sap:product:SAPServiceCloudV2:",
+        });
+
+        expect(result).toEqual([]);
     });
 
     it("returns an empty array when existingProductORDId is an empty string (falsy)", () => {
-        const appConfig = { ...BASE_CONFIG, existingProductORDId: "" };
-        const result = createProducts(appConfig);
+        const result = createProducts({ packageName: "MyPackage", ordNamespace: "sap.test", existingProductORDId: "" });
+
         expect(result).toHaveLength(1);
     });
 
     it("the returned product reflects the packageName", () => {
-        const appConfig = { ...BASE_CONFIG, packageName: "my-app" };
-        const result = createProducts(appConfig);
+        const result = createProducts({ ordNamespace: "sap.test", packageName: "my-app" });
+
         expect(result[0].title).toBe("my app");
         expect(result[0].ordId).toBe("customer:product:my.app:");
     });
 
     it("never returns more than one product regardless of env.products length", () => {
-        const appConfig = {
-            ...BASE_CONFIG,
+        const result = createProducts({
+            packageName: "MyPackage",
+            ordNamespace: "sap.test",
             env: {
                 products: [{ ordId: "customer:product:A:" }, { ordId: "customer:product:B:" }],
             },
-        };
-        expect(createProducts(appConfig)).toHaveLength(1);
+        });
+
+        expect(result).toHaveLength(1);
     });
 
     it("correctly replaces placeholders for namespace and type in product ordId", () => {
-        const appConfig = {
-            ...BASE_CONFIG,
+        const result = createProducts({
+            packageName: "MyPackage",
+            ordNamespace: "sap.test",
             env: {
                 products: [{ ordId: "{namespace}:{type}:A:" }],
             },
-        };
-        expect(createProducts(appConfig)).toMatchSnapshot();
+        });
+
+        expect(result).toMatchSnapshot();
     });
 });

--- a/lib/templates/product.js
+++ b/lib/templates/product.js
@@ -1,9 +1,33 @@
+const _ = require("lodash");
+
 const Logger = require("../logger");
 const placeholders = require("../common/placeholders");
 
+const RESOLVERS = Object.freeze({
+    ordId: (appConfig, overrides) => {
+        const name = appConfig.packageName
+            .split(/[^a-zA-Z0-9]/)
+            .filter(Boolean)
+            .join(".");
+
+        return (
+            placeholders.replace(overrides?.ordId, { type: "product", namespace: appConfig.ordNamespace }) ??
+            `customer:product:${name}:`
+        );
+    },
+    title: (appConfig, overrides) => {
+        return overrides?.title ?? appConfig.packageName.replace(/[^a-zA-Z0-9]/g, " ").trim();
+    },
+    vendor: (appConfig, overrides) => {
+        return overrides?.vendor ?? "customer:vendor:Customer:";
+    },
+    shortDescription: (appConfig, overrides) => {
+        return overrides?.shortDescription ?? `Short description of ${RESOLVERS.title(appConfig, overrides)}`;
+    },
+});
+
 function createProduct(appConfig) {
     let overrides = appConfig?.env?.products?.[0] ?? {};
-    const name = appConfig.packageName.replace(/[^a-zA-Z0-9]/g, " ").trim();
 
     if (overrides?.ordId?.toLowerCase().startsWith("sap")) {
         overrides = {}; // disable overrides, misconfiguration detected
@@ -13,25 +37,21 @@ function createProduct(appConfig) {
     }
 
     return {
-        title: name,
-        vendor: "customer:vendor:Customer:",
-        shortDescription: `Short description of ${name}`,
-        ordId: `customer:product:${name.split(" ").join(".")}:`,
-        ...overrides,
+        title: RESOLVERS.title(appConfig, overrides),
+        ordId: RESOLVERS.ordId(appConfig, overrides),
+        vendor: RESOLVERS.vendor(appConfig, overrides),
+        shortDescription: RESOLVERS.shortDescription(appConfig, overrides),
+
+        ..._.omit(overrides, Object.keys(RESOLVERS)),
     };
 }
 
 function createProducts(appConfig) {
-    return appConfig.existingProductORDId
-        ? []
-        : [createProduct(appConfig)] //
-              .map((p) => ({
-                  ...p,
-                  ordId: placeholders.replace(p.ordId, { type: "product", namespace: appConfig.ordNamespace }),
-              }));
+    return appConfig.existingProductORDId ? [] : [createProduct(appConfig)];
 }
 
 module.exports = {
     createProducts,
     createProduct,
+    RESOLVERS,
 };


### PR DESCRIPTION
# Refactor `lib/templates/product.js` to Use Resolvers

### Refactor

♻️ Extracted the product field computation logic in `lib/templates/product.js` into a dedicated, exported `RESOLVERS` map. Each resolver (`ordId`, `title`, `vendor`, `shortDescription`) is now a pure function accepting `appConfig` and `overrides`, making the logic independently testable and easier to reason about.

Additionally, placeholder replacement for `ordId` is now handled directly inside the `RESOLVERS.ordId` function instead of in a post-processing `.map()` step in `createProducts`. The spread of raw overrides in `createProduct` is replaced with `_.omit(overrides, Object.keys(RESOLVERS))` to prevent resolver-managed keys from being double-applied.

### Changes

* `lib/templates/product.js`:
  - Added `lodash` dependency.
  - Introduced a frozen `RESOLVERS` object with pure functions for `ordId`, `title`, `vendor`, and `shortDescription`.
  - Refactored `createProduct` to delegate field computation to `RESOLVERS` and use `_.omit` to safely spread remaining overrides.
  - Simplified `createProducts` by removing the post-processing `.map()` for placeholder replacement (now handled in `RESOLVERS.ordId`).
  - Exported `RESOLVERS` from the module.

* `__tests__/unit/templates/product.test.js`:
  - Imported and added a dedicated `describe("RESOLVERS", ...)` block with granular unit tests for each resolver function, covering default values, overrides, placeholder substitution, and edge cases.
  - Removed the shared `BASE_CONFIG` constant; test cases now inline their config objects directly for clarity.
  - Cleaned up test cases in `createProduct` and `createProducts` describe blocks to match the new inline style.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.22.5`

- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `13d804be-a8f5-4ab3-9742-ca5f453f0fca`
</details>
