### PR TITLE
chore: Refactor 'lib/templates/package.js' to use resolvers

### DIFF
--- a/__tests__/unit/common/utils.test.js
+++ b/__tests__/unit/common/utils.test.js
@@ -1,4 +1,5 @@
 const {
+    prune,
     getRFC3339Date,
     resolveVisibility,
     resolveServiceName,
@@ -13,6 +14,74 @@ const Logger = require("../../../lib/logger");
 const cds = require("@sap/cds");
 
 const RFC3339_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+describe("prune", () => {
+    it("keeps entries with string values", () => {
+        const result = prune({ a: "hello" });
+
+        expect(result).toEqual({ a: "hello" });
+    });
+
+    it("keeps entries with number values", () => {
+        const result = prune({ n: 0 });
+
+        expect(result).toEqual({ n: 0 });
+    });
+
+    it("keeps entries with boolean false", () => {
+        const result = prune({ flag: false });
+
+        expect(result).toEqual({ flag: false });
+    });
+
+    it("removes entries with null values", () => {
+        const result = prune({ a: "keep", b: null });
+
+        expect(result).toEqual({ a: "keep" });
+    });
+
+    it("removes entries with undefined values", () => {
+        const result = prune({ a: "keep", b: undefined });
+
+        expect(result).toEqual({ a: "keep" });
+    });
+
+    it("removes entries with empty arrays", () => {
+        const result = prune({ a: "keep", b: [] });
+
+        expect(result).toEqual({ a: "keep" });
+    });
+
+    it("removes entries with empty objects", () => {
+        const result = prune({ a: "keep", b: {} });
+
+        expect(result).toEqual({ a: "keep" });
+    });
+
+    it("keeps entries with non-empty arrays", () => {
+        const result = prune({ a: [1, 2, 3] });
+
+        expect(result).toEqual({ a: [1, 2, 3] });
+    });
+
+    it("keeps entries with non-empty objects", () => {
+        const result = prune({ a: { x: 1 } });
+
+        expect(result).toEqual({ a: { x: 1 } });
+    });
+
+    it("returns an empty object when all entries are prunable", () => {
+        const result = prune({ a: null, b: undefined, c: [], d: {} });
+
+        expect(result).toEqual({});
+    });
+
+    it("returns an empty object when given an empty object", () => {
+        const result = prune({});
+
+        expect(result).toEqual({});
+    });
+});
 
 describe("isPrimaryDataProductService", () => {
     it("returns true for @DataIntegration.dataProduct.type: 'primary'", () => {

--- a/__tests__/unit/templates/package.test.js
+++ b/__tests__/unit/templates/package.test.js
@@ -1,5 +1,395 @@
-const { createPackages, createPackage } = require("../../../lib/templates/package");
+const { createPackages, createPackage, RESOLVERS } = require("../../../lib/templates/package");
 const { ORD_RESOURCE_TYPE, RESOURCE_VISIBILITY } = require("../../../lib/constants");
+
+describe("RESOLVERS", () => {
+    describe("title", () => {
+        it("returns default title derived from appName when no env override", () => {
+            const result = RESOLVERS.title({
+                appName: "MyApp",
+                ordNamespace: "sap.test",
+            });
+
+            expect(result).toBe("MyApp");
+        });
+
+        it("replaces non-alphanumeric characters in appName with spaces and trims", () => {
+            const result = RESOLVERS.title({
+                appName: "-my-app.name-",
+                ordNamespace: "sap.test",
+            });
+
+            expect(result).toBe("my app name");
+        });
+
+        it("uses env.packages[0].title when provided", () => {
+            const result = RESOLVERS.title({
+                appName: "MyApp",
+                ordNamespace: "sap.test",
+                env: { packages: [{ title: "Custom Title" }] },
+            });
+
+            expect(result).toBe("Custom Title");
+        });
+
+        it("falls back to default when env.packages[0].title is undefined", () => {
+            const result = RESOLVERS.title({
+                appName: "MyApp",
+                ordNamespace: "sap.test",
+                env: { packages: [{ title: undefined }] },
+            });
+
+            expect(result).toBe("MyApp");
+        });
+    });
+
+    describe("vendor", () => {
+        it("returns default vendor when no env override", () => {
+            const result = RESOLVERS.vendor({
+                appName: "MyApp",
+                ordNamespace: "sap.test",
+            });
+
+            expect(result).toBe("customer:vendor:Customer:");
+        });
+
+        it("uses env.packages[0].vendor when provided", () => {
+            const result = RESOLVERS.vendor({
+                appName: "MyApp",
+                ordNamespace: "sap.test",
+                env: { packages: [{ vendor: "sap:vendor:SAP:" }] },
+            });
+
+            expect(result).toBe("sap:vendor:SAP:");
+        });
+
+        it("falls back to default when env.packages[0].vendor is undefined", () => {
+            const result = RESOLVERS.vendor({
+                appName: "MyApp",
+                ordNamespace: "sap.test",
+                env: { packages: [{ vendor: undefined }] },
+            });
+
+            expect(result).toBe("customer:vendor:Customer:");
+        });
+    });
+
+    describe("version", () => {
+        it("returns default version when no env override", () => {
+            const result = RESOLVERS.version({
+                appName: "MyApp",
+                ordNamespace: "sap.test",
+            });
+
+            expect(result).toBe("1.0.0");
+        });
+
+        it("uses env.packages[0].version when provided", () => {
+            const result = RESOLVERS.version({
+                appName: "MyApp",
+                ordNamespace: "sap.test",
+                env: { packages: [{ version: "2.3.4" }] },
+            });
+
+            expect(result).toBe("2.3.4");
+        });
+
+        it("falls back to default when env.packages[0].version is undefined", () => {
+            const result = RESOLVERS.version({
+                appName: "MyApp",
+                ordNamespace: "sap.test",
+                env: { packages: [{ version: undefined }] },
+            });
+
+            expect(result).toBe("1.0.0");
+        });
+    });
+
+    describe("partOfProducts", () => {
+        it("returns the supplied products array when no env override", () => {
+            const result = RESOLVERS.partOfProducts(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                },
+                ["customer:product:MyApp:"],
+            );
+
+            expect(result).toEqual(["customer:product:MyApp:"]);
+        });
+
+        it("uses env.packages[0].partOfProducts when provided", () => {
+            const result = RESOLVERS.partOfProducts(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ partOfProducts: ["sap:product:SomeProduct:"] }] },
+                },
+                ["customer:product:MyApp:"],
+            );
+
+            expect(result).toEqual(["sap:product:SomeProduct:"]);
+        });
+
+        it("falls back to supplied products when env.packages[0].partOfProducts is undefined", () => {
+            const result = RESOLVERS.partOfProducts(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ partOfProducts: undefined }] },
+                },
+                ["customer:product:MyApp:"],
+            );
+
+            expect(result).toEqual(["customer:product:MyApp:"]);
+        });
+    });
+
+    describe("description", () => {
+        it("returns a default description containing visibility, label, and resolved title", () => {
+            const result = RESOLVERS.description(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+            );
+
+            expect(result).toBe("This package contains public General for MyApp.");
+        });
+
+        it("incorporates the resolved title into the default description", () => {
+            const result = RESOLVERS.description(
+                {
+                    appName: "my-app",
+                    ordNamespace: "sap.test",
+                },
+                "APIs",
+                RESOURCE_VISIBILITY.internal,
+            );
+
+            expect(result).toBe("This package contains internal APIs for my app.");
+        });
+
+        it("uses env.packages[0].description when provided", () => {
+            const result = RESOLVERS.description(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ description: "Custom description" }] },
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+            );
+
+            expect(result).toBe("Custom description");
+        });
+
+        it("falls back to default when env.packages[0].description is undefined", () => {
+            const result = RESOLVERS.description(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ description: undefined }] },
+                },
+                "APIs",
+                RESOURCE_VISIBILITY.private,
+            );
+
+            expect(result).toBe("This package contains private APIs for MyApp.");
+        });
+    });
+
+    describe("shortDescription", () => {
+        it("returns default short description containing visibility and label", () => {
+            const result = RESOLVERS.shortDescription(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+            );
+
+            expect(result).toBe("Package containing public General");
+        });
+
+        it("uses env.packages[0].shortDescription when provided", () => {
+            const result = RESOLVERS.shortDescription(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ shortDescription: "Custom short desc" }] },
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+            );
+
+            expect(result).toBe("Custom short desc");
+        });
+
+        it("falls back to default when env.packages[0].shortDescription is undefined", () => {
+            const result = RESOLVERS.shortDescription(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ shortDescription: undefined }] },
+                },
+                "APIs",
+                RESOURCE_VISIBILITY.internal,
+            );
+
+            expect(result).toBe("Package containing internal APIs");
+        });
+    });
+
+    describe("ordId", () => {
+        it("returns default ordId with no resourceType tag and no visibility suffix for public", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+                undefined,
+            );
+
+            expect(result).toBe("sap.test:package:MyApp:v1");
+        });
+
+        it("appends resourceType tag when resourceType is provided", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                },
+                "APIs",
+                RESOURCE_VISIBILITY.public,
+                "api",
+            );
+
+            expect(result).toBe("sap.test:package:MyApp-api:v1");
+        });
+
+        it("appends visibility suffix for non-public visibility", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                },
+                "APIs",
+                RESOURCE_VISIBILITY.internal,
+                undefined,
+            );
+
+            expect(result).toBe("sap.test:package:MyApp-internal:v1");
+        });
+
+        it("appends both resourceType tag and visibility suffix together", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                },
+                "APIs",
+                RESOURCE_VISIBILITY.private,
+                "api",
+            );
+
+            expect(result).toBe("sap.test:package:MyApp-api-private:v1");
+        });
+
+        it("strips non-alphanumeric characters from appName", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    appName: "my-app.name",
+                    ordNamespace: "sap.test",
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+                undefined,
+            );
+
+            expect(result).toBe("sap.test:package:myappname:v1");
+        });
+
+        it("uses env.packages[0].ordId verbatim when provided", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ ordId: "sap.test:package:Custom:v1" }] },
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+                undefined,
+            );
+
+            expect(result).toBe("sap.test:package:Custom:v1");
+        });
+
+        it("replaces {namespace} placeholder in env.packages[0].ordId", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ ordId: "{namespace}:package:MyApp:v1" }] },
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+                undefined,
+            );
+
+            expect(result).toBe("sap.test:package:MyApp:v1");
+        });
+
+        it("replaces {type} placeholder in env.packages[0].ordId", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ ordId: "sap.test:{type}:MyApp:v1" }] },
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+                undefined,
+            );
+
+            expect(result).toBe("sap.test:package:MyApp:v1");
+        });
+
+        it("replaces both {namespace} and {type} placeholders in env.packages[0].ordId", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ ordId: "{namespace}:{type}:MyApp:v1" }] },
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+                undefined,
+            );
+
+            expect(result).toBe("sap.test:package:MyApp:v1");
+        });
+
+        it("falls back to default when env.packages[0].ordId is undefined", () => {
+            const result = RESOLVERS.ordId(
+                {
+                    appName: "MyApp",
+                    ordNamespace: "sap.test",
+                    env: { packages: [{ ordId: undefined }] },
+                },
+                "General",
+                RESOURCE_VISIBILITY.public,
+                undefined,
+            );
+
+            expect(result).toBe("sap.test:package:MyApp:v1");
+        });
+    });
+});
 
 describe("packages", () => {
     it("should return default value if policyLevels contains sap", () => {

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -19,6 +19,14 @@ const {
 
 const DEFAULT_ACCESS_STRATEGIES = Object.freeze([ORD_ACCESS_STRATEGY.Open]);
 
+function prune(object) {
+    return Object.fromEntries(
+        Object.entries(object)
+            .filter(([, value]) => value !== null && value !== undefined) // remove empty fields
+            .filter(([, value]) => typeof value !== "object" || Object.keys(value).length > 0), // remove empty arrays/objects
+    );
+}
+
 function getRFC3339Date() {
     const now = new Date();
     const year = now.getUTCFullYear();
@@ -166,6 +174,7 @@ function resolveAccessStrategies(authConfig, options = {}) {
 }
 
 module.exports = {
+    prune,
     isValidService,
     getRFC3339Date,
     readORDExtensions,

--- a/lib/ord.js
+++ b/lib/ord.js
@@ -1,4 +1,5 @@
 const defaults = require("./defaults");
+const utils = require("./common/utils");
 const Configuration = require("./configuration");
 const { createGroups } = require("./templates/group");
 const { createPackages } = require("./templates/package");
@@ -24,12 +25,12 @@ function prune(document) {
                   ...(document.integrationDependencies?.map((id) => id.partOfPackage) ?? []),
               ],
     );
-    const packages = document.packages?.filter((pkg) => usedPackageIds.has(pkg.ordId));
 
-    return Object.fromEntries(
-        Object.entries(Object.assign(document, { packages })) // remove unused packages
-            .filter(([, value]) => value !== null && value !== undefined) // remove empty fields
-            .filter(([, value]) => typeof value !== "object" || Object.keys(value).length > 0), // remove empty arrays
+    return utils.prune(
+        Object.assign(document, {
+            // remove unused packages
+            packages: document.packages?.filter((pkg) => usedPackageIds.has(pkg.ordId)),
+        }),
     );
 }
 

--- a/lib/templates/event-resource.js
+++ b/lib/templates/event-resource.js
@@ -1,6 +1,7 @@
 const _ = require("lodash");
 
 const defaults = require("../defaults");
+const { prune } = require("../common/utils");
 const { createPackages } = require("./package");
 const entityTypeTemplate = require("./entity-type");
 const placeholders = require("../common/placeholders");
@@ -119,9 +120,7 @@ const RESOLVERS = Object.freeze({
  * @returns {object} An object representing the Event Resource.
  */
 function createEventResourceTemplate(service, appConfig) {
-    const exposedEntityTypes = RESOLVERS.exposedEntityTypes(service, appConfig);
-
-    return {
+    return prune({
         releaseStatus: "active",
         extensible: { supported: "no" },
         lastUpdate: appConfig.lastUpdate,
@@ -134,12 +133,11 @@ function createEventResourceTemplate(service, appConfig) {
         visibility: RESOLVERS.visibility(service, appConfig),
         partOfGroups: RESOLVERS.partOfGroups(service, appConfig),
         partOfPackage: RESOLVERS.partOfPackage(service, appConfig),
+        exposedEntityTypes: RESOLVERS.exposedEntityTypes(service, appConfig),
         resourceDefinitions: RESOLVERS.resourceDefinitions(service, appConfig),
 
-        ...(exposedEntityTypes.length && { exposedEntityTypes }),
-
         ..._.omit(readORDExtensions(service), Object.keys(RESOLVERS)),
-    };
+    });
 }
 
 function createEventResources(appConfig) {

--- a/lib/templates/package.js
+++ b/lib/templates/package.js
@@ -1,24 +1,58 @@
+const _ = require("lodash");
+
+const { prune } = require("../common/utils");
 const { createProducts } = require("./product");
 const placeholders = require("../common/placeholders");
 const { ORD_RESOURCE_TYPE, RESOURCE_VISIBILITY } = require("../constants");
 
-function createPackage(appConfig, { label, visibility, products, resourceType }) {
-    const tag = !resourceType ? "" : `-${resourceType}`;
-    const overrides = appConfig?.env?.packages?.[0] ?? {};
-    const name = appConfig.appName.replace(/[^a-zA-Z0-9]/g, " ").trim();
-    const technicalName = appConfig.appName.replace(/[^a-zA-Z0-9]/g, "");
-    const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
+const RESOLVERS = Object.freeze({
+    title: (appConfig) => {
+        return appConfig?.env?.packages?.[0]?.title ?? appConfig.appName.replace(/[^a-zA-Z0-9]/g, " ").trim();
+    },
+    vendor: (appConfig) => {
+        return appConfig?.env?.packages?.[0]?.vendor ?? "customer:vendor:Customer:";
+    },
+    version: (appConfig) => {
+        return appConfig?.env?.packages?.[0]?.version ?? "1.0.0";
+    },
+    partOfProducts: (appConfig, products) => {
+        return appConfig?.env?.packages?.[0]?.partOfProducts ?? products;
+    },
+    description: (appConfig, label, visibility) => {
+        return (
+            appConfig?.env?.packages?.[0]?.description ??
+            `This package contains ${visibility} ${label} for ${RESOLVERS.title(appConfig)}.`
+        );
+    },
+    shortDescription: (appConfig, label, visibility) => {
+        return appConfig?.env?.packages?.[0]?.shortDescription ?? `Package containing ${visibility} ${label}`;
+    },
+    ordId: (appConfig, label, visibility, resourceType) => {
+        const tag = !resourceType ? "" : `-${resourceType}`;
+        const technicalName = appConfig.appName.replace(/[^a-zA-Z0-9]/g, "");
+        const suffix = visibility === RESOURCE_VISIBILITY.public ? "" : `-${visibility}`;
 
-    return {
-        title: name,
-        version: "1.0.0",
-        vendor: "customer:vendor:Customer:",
-        shortDescription: `Package containing ${visibility} ${label}`,
-        description: `This package contains ${visibility} ${label} for ${name}.`,
-        ordId: `${appConfig.ordNamespace}:package:${technicalName}${tag}${suffix}:v1`,
-        ...(products?.length > 0 && { partOfProducts: products }),
-        ...overrides,
-    };
+        return (
+            placeholders.replace(appConfig?.env?.packages?.[0]?.ordId, {
+                type: "package",
+                namespace: appConfig.ordNamespace,
+            }) ?? `${appConfig.ordNamespace}:package:${technicalName}${tag}${suffix}:v1`
+        );
+    },
+});
+
+function createPackage(appConfig, { label, visibility, products, resourceType }) {
+    return prune({
+        title: RESOLVERS.title(appConfig),
+        vendor: RESOLVERS.vendor(appConfig),
+        version: RESOLVERS.version(appConfig),
+        partOfProducts: RESOLVERS.partOfProducts(appConfig, products),
+        description: RESOLVERS.description(appConfig, label, visibility),
+        ordId: RESOLVERS.ordId(appConfig, label, visibility, resourceType),
+        shortDescription: RESOLVERS.shortDescription(appConfig, label, visibility),
+
+        ..._.omit(appConfig?.env?.packages?.[0], Object.keys(RESOLVERS)),
+    });
 }
 
 function createPackages(appConfig) {
@@ -38,24 +72,20 @@ function createPackages(appConfig) {
               { label: "Integration Dependencies", resourceType: ORD_RESOURCE_TYPE.integrationDependency },
           ];
 
-    return packageTypes
-        .flatMap(({ label, resourceType }) =>
-            visibilities.map((visibility) =>
-                createPackage(appConfig, {
-                    label,
-                    visibility,
-                    products,
-                    resourceType,
-                }),
-            ),
-        )
-        .map((p) => ({
-            ...p,
-            ordId: placeholders.replace(p.ordId, { type: "package", namespace: appConfig.ordNamespace }),
-        }));
+    return packageTypes.flatMap(({ label, resourceType }) =>
+        visibilities.map((visibility) =>
+            createPackage(appConfig, {
+                label,
+                visibility,
+                products,
+                resourceType,
+            }),
+        ),
+    );
 }
 
 module.exports = {
     createPackages,
     createPackage,
+    RESOLVERS,
 };


### PR DESCRIPTION
# Refactor `lib/templates/package.js` to Use Resolvers Pattern

### Refactor

♻️ Refactors `lib/templates/package.js` to use an explicit `RESOLVERS` map for all field-level logic, consistent with how other templates in the project handle configuration resolution. Also extracts a shared `prune` utility into `lib/common/utils.js` and updates dependent files accordingly.

### Changes

* `lib/templates/package.js`: Introduces a frozen `RESOLVERS` object covering `title`, `vendor`, `version`, `partOfProducts`, `description`, `shortDescription`, and `ordId`. Replaces inline property construction and spread-override pattern in `createPackage` with resolver calls and `prune`. Removes the redundant second-pass `placeholders.replace` in `createPackages`. Exports `RESOLVERS` for external use and testing.

* `lib/common/utils.js`: Adds a generic `prune` utility function that removes `null`, `undefined`, empty arrays, and empty objects from a plain object. Exports it alongside existing utilities.

* `lib/ord.js`: Replaces the inline `prune` implementation (previously duplicated in this file) with the shared `utils.prune`, keeping the domain-specific unused-package filtering logic intact.

* `lib/templates/event-resource.js`: Imports and uses the shared `prune` utility. Moves the `exposedEntityTypes` field directly into the returned object (relying on `prune` to drop it when empty), removing the previous conditional spread.

* `__tests__/unit/common/utils.test.js`: Adds a full `describe("prune", ...)` suite covering strings, numbers, booleans, `null`, `undefined`, empty/non-empty arrays, and empty/non-empty objects.

* `__tests__/unit/templates/package.test.js`: Adds a comprehensive `describe("RESOLVERS", ...)` suite testing each resolver individually, including env overrides, fallback behaviour, placeholder substitution (`{namespace}`, `{type}`), and edge cases.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.22.5`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `9ae14635-df64-42ad-a941-b8491c32e137`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
</details>
