### PR TITLE
fix: Allow overriding document version for interop CSN

### DIFF
--- a/__tests__/unit/__snapshots__/interop-csn.test.js.snap
+++ b/__tests__/unit/__snapshots__/interop-csn.test.js.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`interop-csn should correctly handle version override 1`] = `
+{
+  "csnInteropEffective": "1.0",
+  "definitions": {
+    "com.example.MyService": {
+      "@EndUserText.label": "{i18n>service.title}",
+      "@ORD.Extensions.version": "1.3.8",
+      "kind": "service",
+    },
+  },
+  "i18n": {
+    "en": {
+      "service.title": "My Service",
+    },
+  },
+  "meta": {
+    "__name": "MyService",
+    "__namespace": "com.example",
+    "document": {
+      "version": "1.3.8",
+    },
+    "flavor": "effective",
+  },
+}
+`;
+
 exports[`interop-csn should extract service metadata 1`] = `
 {
   "csnInteropEffective": "1.0",

--- a/__tests__/unit/interop-csn.test.js
+++ b/__tests__/unit/interop-csn.test.js
@@ -53,14 +53,14 @@ describe("interop-csn", () => {
                 "customer.namespace.MyService.v2": { kind: "service" },
             },
             meta: {
-              creator: "shouldVanish",
-              compilerCsnFlavor: "shouldVanish",
-              unknownProp: "shouldVanish",
-              __privateProperty: "shouldStay",
-              features: {
-                "complete": true
-              },
-            }
+                creator: "shouldVanish",
+                compilerCsnFlavor: "shouldVanish",
+                unknownProp: "shouldVanish",
+                __privateProperty: "shouldStay",
+                features: {
+                    complete: true,
+                },
+            },
         };
         expect(interopCSN(csn)).toMatchSnapshot();
     });
@@ -122,5 +122,23 @@ describe("interop-csn", () => {
         expect(interopCSN(123)).toBe(123);
         expect(interopCSN(null)).toBe(null);
         expect(interopCSN(undefined)).toBe(undefined);
+    });
+
+    it("should correctly handle version override", () => {
+        localize.bundles4.mockReturnValue([["en", { "service.title": "My Service", "unused.key": "Unused" }]]);
+
+        const result = interopCSN({
+            definitions: {
+                "com.example.MyService": {
+                    "kind": "service",
+                    "@title": "{i18n>service.title}",
+                    "@cds.autoexpose": true,
+                    "@ORD.Extensions.version": "1.3.8",
+                },
+            },
+        });
+
+        expect(result).toMatchSnapshot();
+        expect(result.meta.document.version).toBe("1.3.8");
     });
 });

--- a/__tests__/unit/interop-csn.test.js
+++ b/__tests__/unit/interop-csn.test.js
@@ -1,3 +1,5 @@
+const assert = require("node:assert");
+
 const { interopCSN } = require("../../lib/interop-csn.js");
 
 jest.mock("@sap/cds/lib/i18n/localize", () => ({
@@ -140,5 +142,27 @@ describe("interop-csn", () => {
 
         expect(result).toMatchSnapshot();
         expect(result.meta.document.version).toBe("1.3.8");
+    });
+
+    it("should fail on major version mismatch when overriding version", () => {
+        localize.bundles4.mockReturnValue([["en", { "service.title": "My Service", "unused.key": "Unused" }]]);
+
+        expect(() =>
+            interopCSN({
+                definitions: {
+                    "com.example.MyService.v1": {
+                        "kind": "service",
+                        "@title": "{i18n>service.title}",
+                        "@cds.autoexpose": true,
+                        "@ORD.Extensions.version": "2.3.8",
+                    },
+                },
+            }),
+        ).toThrow(
+            new assert.AssertionError({
+                message:
+                    "Major version in service name (1) does not match major version in @ORD.Extensions.version (2.3.8)",
+            }),
+        );
     });
 });

--- a/lib/interop-csn.js
+++ b/lib/interop-csn.js
@@ -20,7 +20,7 @@ function add_i18n_texts(csn) {
     // get all texts of the app
     const i18n = [...(localize.bundles4(csn) || [])]
         .filter(([locale]) => !!locale)
-        .map(([locale, value]) => [locale.replaceAll('_', '-'), value])  // CSN interop uses '-' as separator
+        .map(([locale, value]) => [locale.replaceAll("_", "-"), value]) // CSN interop uses '-' as separator
         .reduce((all, [locale, value]) => ({ ...all, [locale]: value }), {});
 
     // get all i18n keys referenced in the csn
@@ -119,9 +119,9 @@ function map_annotations(csn) {
         }
 
         // delete all @assert.unique annotations
-        let assertUniqueAnnos = Object.keys(o).filter(x => x.startsWith('@assert.unique'))
+        let assertUniqueAnnos = Object.keys(o).filter((x) => x.startsWith("@assert.unique"));
         for (let a of assertUniqueAnnos) {
-            delete o[a]
+            delete o[a];
         }
     }
 }
@@ -132,7 +132,7 @@ function map_annotations(csn) {
 function add_meta_info(csn) {
     if (typeof csn != "object") return csn; // needed to make tests pass
     csn["csnInteropEffective"] = "1.0";
-    csn.meta ??= {};  // ensure there is a meta section
+    csn.meta ??= {}; // ensure there is a meta section
 
     // Keep only the properties of csn.meta that are relevant for interop:
     //   "flavor", "document", "features", and private extension names (starting with "__")
@@ -143,27 +143,33 @@ function add_meta_info(csn) {
             delete csn.meta[k];
         }
     }
+
     csn.meta.flavor = "effective";
 
-    let services = Object.entries(csn.definitions).filter(([, def]) => def.kind === "service");
+    const services = Object.entries(csn.definitions).filter(([, def]) => def.kind === "service");
     if (services.length === 1) {
+        const [name, definition] = services[0];
         // assumption: "short" service name contains no dots
-        let segments = services[0][0].split(".");
+        const segments = name.split(".");
+
         let v = "1";
         let srv = segments.pop();
-        let m = srv.match(/^v(\d+)$/);
+        const m = srv.match(/^v(\d+)$/);
         if (m) {
             srv = segments.pop();
             v = m[1];
         }
-        csn.meta.document = { version: `${v}.0.0` };
-        csn.meta.__name = srv;
-        if (segments.length > 0) csn.meta.__namespace = segments.join(".");
+
+        Object.assign(csn.meta, {
+            __name: srv,
+            document: { version: definition["@ORD.Extensions.version"] ?? `${v}.0.0` },
+            ...(segments.length > 0 && { __namespace: segments.join(".") }),
+        });
     }
 
     return csn;
 }
 
 module.exports = {
-    interopCSN
+    interopCSN,
 };

--- a/lib/interop-csn.js
+++ b/lib/interop-csn.js
@@ -1,3 +1,4 @@
+const assert = require("node:assert");
 const localize = require("@sap/cds/lib/i18n/localize");
 
 // turn effective CSN into interop CSN
@@ -159,6 +160,11 @@ function add_meta_info(csn) {
             srv = segments.pop();
             v = m[1];
         }
+
+        assert(
+            !definition["@ORD.Extensions.version"] || v === definition["@ORD.Extensions.version"].split(".").shift(),
+            `Major version in service name (${v}) does not match major version in @ORD.Extensions.version (${definition["@ORD.Extensions.version"]})`,
+        );
 
         Object.assign(csn.meta, {
             __name: srv,


### PR DESCRIPTION
# Allow Overriding Document Version for Interop CSN

### Bug Fix

🐛 Fixed the `add_meta_info` function in the interop CSN module to allow overriding the document version via the `@ORD.Extensions.version` annotation on a service definition, falling back to the version derived from the service name if not specified.

### Changes

* `lib/interop-csn.js`: Updated the `add_meta_info` function to read the `@ORD.Extensions.version` annotation from the service definition when setting `csn.meta.document.version`. If the annotation is not present, the version is derived from the service name as before (e.g., `v1` → `1.0.0`). The meta assignment was also refactored using `Object.assign` for cleaner structure. Additionally, several minor code style fixes were applied (consistent use of `const`, semicolons, and quote style).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.22.8`

- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Correlation ID: `2fe7e864-3ea6-4d67-966a-9e9aa4e3cb9a`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
