### PR TITLE
chore: Release 1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.9.2 (2026-07-16)
+
+## What's Changed
+
+- fix(protocol-resolver): map CAP 'mcp' protocol to ORD apiProtocol by @zongqichen in https://github.com/cap-js/ord/pull/519
+
+**Full Changelog**: https://github.com/cap-js/ord/compare/v1.9.1...v1.9.2
+
 ## 1.9.1 (2026-06-26)
 
 ## What's Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cap-js/ord",
-    "version": "1.9.1",
+    "version": "1.9.2",
     "description": "CAP Plugin for generating ORD document.",
     "repository": "cap-js/ord",
     "author": "SAP SE (https://www.sap.com)",


### PR DESCRIPTION
# Release v1.9.2

🔧 **Chore:** Bumps the package version to `1.9.2` and updates the changelog with the corresponding release notes.

### Changes

* `package.json`: Version bumped from `1.9.1` to `1.9.2`.
* `CHANGELOG.md`: Added release entry for `1.9.2` (2026-07-16), documenting the fix for mapping CAP `mcp` protocol to ORD `apiProtocol` in the protocol resolver.

**Full Changelog**: https://github.com/cap-js/ord/compare/v1.9.1...v1.9.2

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.6`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `9c1fbf40-8102-11f1-8289-f152b241bd69`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
</details>
